### PR TITLE
Use nearest filtering for procedural textures

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -163,7 +163,7 @@ function createProceduralTexture({
   texture.colorSpace = THREE.SRGBColorSpace;
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.magFilter = THREE.NearestFilter;
-  texture.minFilter = THREE.NearestMipmapLinearFilter;
+  texture.minFilter = THREE.NearestFilter;
   return texture;
 }
 


### PR DESCRIPTION
## Summary
- switch the procedural texture minification filter to THREE.NearestFilter to ensure crisp texels when rendering blocks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d04eee75ac832a9b76bc76d41806b6