### PR TITLE
Implement chunk streaming and survival interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Procedural Block World
+
+This project hosts a browser-based sandbox inspired by classic block-building games. It ships with a static HTML bootstrap (`index.html`) for lightweight deployment and a Vite workspace (`three-demo/`) that provides a modern development loop while reusing the shared `src/` modules.
+
+## Features
+- Deterministic, procedurally generated textures for every block type.
+- Streaming chunk manager that expands the world as you explore.
+- Water buoyancy, oxygen tracking, and fall damage to ground the traversal loop.
+- Enhanced lighting pass with ACES filmic tone mapping, soft shadows, and a fill light for richer visuals.
+- Responsive HUD overlay that surfaces health, oxygen, and contextual status messaging.
+
+## Development Workflow
+The Vite demo is the recommended way to iterate on the experience:
+
+1. Install dependencies once:
+   ```bash
+   cd three-demo
+   npm install
+   ```
+2. Start the development server with hot module replacement:
+   ```bash
+   npm run dev
+   ```
+3. Open the provided local URL in a modern browser. The Vite entry point reuses the root `src/` modules, so all changes in `src/` are reflected instantly.
+
+For quick previews without tooling, you can still open `index.html` directly in a browser or serve the root directory with any static file server (for example, `npx serve .`).
+
+## Controls
+- `WASD` / arrow keys – movement
+- `Space` – jump (or swim upwards when underwater)
+- `Shift` – sprint on land, dive while swimming
+- Mouse – look around
+- Keep an eye on the lower-left HUD for health, oxygen, and contextual status alerts.
+
+## Building for Production
+To create an optimized build via Vite:
+
+```bash
+cd three-demo
+npm run build
+```
+
+The output is written to `three-demo/dist/` and can be hosted on any static web server.

--- a/index.html
+++ b/index.html
@@ -42,6 +42,74 @@
         line-height: 1.6;
       }
 
+      #hud {
+        position: absolute;
+        left: 24px;
+        bottom: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        pointer-events: none;
+        min-width: 220px;
+        font-size: 14px;
+      }
+
+      .hud-bar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .hud-label {
+        text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        color: rgba(255, 255, 255, 0.8);
+      }
+
+      .hud-track {
+        flex: 1;
+        height: 6px;
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .hud-fill {
+        height: 100%;
+        width: 100%;
+        background: linear-gradient(90deg, #6bff8f, #2ec4a0);
+        transition: width 0.2s ease;
+      }
+
+      #hud-oxygen-fill {
+        background: linear-gradient(90deg, #7ecbff, #3a8dff);
+      }
+
+      .hud-value {
+        font-variant-numeric: tabular-nums;
+        font-size: 12px;
+        color: rgba(255, 255, 255, 0.9);
+        min-width: 32px;
+        text-align: right;
+      }
+
+      #hud-status {
+        min-height: 18px;
+        font-size: 13px;
+        color: #ffe28a;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+
+      #hud-status.visible {
+        opacity: 1;
+      }
+
+      #hud.in-water .hud-fill {
+        background: linear-gradient(90deg, #45d0ff, #1b7bff);
+      }
+
       canvas {
         display: block;
       }
@@ -52,8 +120,9 @@
       <div id="instructions">
         <h1>Procedural Block World</h1>
         <p>
-          Click anywhere to lock the pointer, then use WASD to move and Space to
-          hop up ledges. Move the mouse to look around.
+          Click anywhere to lock the pointer, then use WASD to move, Space to
+          jump, and Shift to sprint (or dive while swimming). Keep an eye on
+          your health and oxygen in the HUD.
         </p>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
 
 import { createBlockMaterials } from './rendering/textures.js';
-import { generateWorld, terrainHeight, worldConfig } from './world/generation.js';
+import { terrainHeight, worldConfig } from './world/generation.js';
+import { createChunkManager } from './world/chunk-manager.js';
 import { createPlayerControls } from './player/controls.js';
 
 const overlay = document.getElementById('overlay');
@@ -22,13 +23,62 @@ const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.1;
 document.body.appendChild(renderer.domElement);
 
 const clock = new THREE.Clock();
 
 const blockMaterials = createBlockMaterials();
-const { meshes, solidBlocks, waterColumns } = generateWorld(blockMaterials);
-meshes.forEach((mesh) => scene.add(mesh));
+
+const chunkManager = createChunkManager({
+  scene,
+  blockMaterials,
+  viewDistance: 2,
+});
+
+const hud = document.createElement('div');
+hud.id = 'hud';
+hud.innerHTML = `
+  <div class="hud-bar">
+    <span class="hud-label">Health</span>
+    <div class="hud-track" aria-hidden="true">
+      <div class="hud-fill" id="hud-health-fill"></div>
+    </div>
+    <span class="hud-value" id="hud-health-value">100</span>
+  </div>
+  <div class="hud-bar">
+    <span class="hud-label">Oxygen</span>
+    <div class="hud-track" aria-hidden="true">
+      <div class="hud-fill" id="hud-oxygen-fill"></div>
+    </div>
+    <span class="hud-value" id="hud-oxygen-value">12</span>
+  </div>
+  <div id="hud-status" role="status" aria-live="polite"></div>
+`;
+document.body.appendChild(hud);
+
+const healthFill = hud.querySelector('#hud-health-fill');
+const healthValue = hud.querySelector('#hud-health-value');
+const oxygenFill = hud.querySelector('#hud-oxygen-fill');
+const oxygenValue = hud.querySelector('#hud-oxygen-value');
+const statusElement = hud.querySelector('#hud-status');
+
+function updateHud(state) {
+  const healthPercent = THREE.MathUtils.clamp(state.health / 100, 0, 1);
+  healthFill.style.width = `${healthPercent * 100}%`;
+  healthValue.textContent = `${Math.round(state.health)}`;
+
+  const oxygenPercent = THREE.MathUtils.clamp(state.oxygen / state.maxOxygen, 0, 1);
+  oxygenFill.style.width = `${oxygenPercent * 100}%`;
+  oxygenValue.textContent = `${state.oxygen.toFixed(1)}`;
+
+  statusElement.textContent = state.statusMessage ?? '';
+  statusElement.classList.toggle('visible', Boolean(state.statusMessage));
+  hud.classList.toggle('in-water', state.isInWater);
+}
 
 const playerControls = createPlayerControls({
   scene,
@@ -37,17 +87,26 @@ const playerControls = createPlayerControls({
   overlay,
   worldConfig,
   terrainHeight,
-  solidBlocks,
-  waterColumns,
+  solidBlocks: chunkManager.solidBlocks,
+  waterColumns: chunkManager.waterColumns,
+  onStateChange: updateHud,
 });
+
+chunkManager.update(playerControls.getPosition());
+updateHud(playerControls.getState());
 
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
 scene.add(ambientLight);
+
+const hemiLight = new THREE.HemisphereLight(0xbcdfff, 0x5a4833, 0.45);
+scene.add(hemiLight);
 
 const sun = new THREE.DirectionalLight(0xffffff, 1.1);
 sun.position.set(20, 50, 20);
 sun.castShadow = true;
 sun.shadow.mapSize.set(2048, 2048);
+sun.shadow.camera.near = 0.5;
+sun.shadow.camera.far = 200;
 scene.add(sun);
 
 const waterMaterial = blockMaterials.water;
@@ -58,6 +117,7 @@ function animate() {
   requestAnimationFrame(animate);
   const delta = Math.min(clock.getDelta(), 0.05);
 
+  chunkManager.update(playerControls.getPosition());
   playerControls.update(delta);
 
   waveTime += delta;
@@ -68,3 +128,8 @@ function animate() {
 }
 
 animate();
+
+window.addEventListener('beforeunload', () => {
+  playerControls.dispose();
+  chunkManager.dispose();
+});

--- a/src/world/chunk-manager.js
+++ b/src/world/chunk-manager.js
@@ -1,0 +1,88 @@
+import { generateChunk, worldConfig } from './generation.js';
+
+function chunkKey(x, z) {
+  return `${x}|${z}`;
+}
+
+function worldToChunk(value) {
+  const halfSize = worldConfig.chunkSize / 2;
+  return Math.floor((value + halfSize) / worldConfig.chunkSize);
+}
+
+export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) {
+  const loadedChunks = new Map();
+  const solidBlocks = new Set();
+  const waterColumns = new Set();
+  let lastCenterKey = null;
+
+  function ensureChunk(chunkX, chunkZ) {
+    const key = chunkKey(chunkX, chunkZ);
+    if (loadedChunks.has(key)) {
+      return;
+    }
+    const chunk = generateChunk(blockMaterials, chunkX, chunkZ);
+    scene.add(chunk.group);
+    chunk.solidBlockKeys.forEach((block) => solidBlocks.add(block));
+    chunk.waterColumnKeys.forEach((column) => waterColumns.add(column));
+    loadedChunks.set(key, chunk);
+  }
+
+  function disposeChunk(key) {
+    const chunk = loadedChunks.get(key);
+    if (!chunk) {
+      return;
+    }
+
+    scene.remove(chunk.group);
+    chunk.solidBlockKeys.forEach((block) => solidBlocks.delete(block));
+    chunk.waterColumnKeys.forEach((column) => waterColumns.delete(column));
+    loadedChunks.delete(key);
+  }
+
+  function update(position) {
+    const centerChunkX = worldToChunk(position.x);
+    const centerChunkZ = worldToChunk(position.z);
+    const centerKey = chunkKey(centerChunkX, centerChunkZ);
+
+    if (centerKey === lastCenterKey && loadedChunks.size > 0) {
+      return;
+    }
+
+    const needed = new Set();
+    for (let dx = -viewDistance; dx <= viewDistance; dx++) {
+      for (let dz = -viewDistance; dz <= viewDistance; dz++) {
+        const chunkX = centerChunkX + dx;
+        const chunkZ = centerChunkZ + dz;
+        const key = chunkKey(chunkX, chunkZ);
+        needed.add(key);
+        ensureChunk(chunkX, chunkZ);
+      }
+    }
+
+    Array.from(loadedChunks.keys()).forEach((key) => {
+      if (!needed.has(key)) {
+        disposeChunk(key);
+      }
+    });
+
+    lastCenterKey = centerKey;
+  }
+
+  function dispose() {
+    Array.from(loadedChunks.keys()).forEach((key) => disposeChunk(key));
+  }
+
+  return {
+    update,
+    dispose,
+    solidBlocks,
+    waterColumns,
+  };
+}
+
+export function chunkIndexFromWorld(x, z) {
+  return {
+    x: worldToChunk(x),
+    z: worldToChunk(z),
+  };
+}

--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -42,6 +42,74 @@
         line-height: 1.6;
       }
 
+      #hud {
+        position: absolute;
+        left: 24px;
+        bottom: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        pointer-events: none;
+        min-width: 220px;
+        font-size: 14px;
+      }
+
+      .hud-bar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .hud-label {
+        text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        color: rgba(255, 255, 255, 0.8);
+      }
+
+      .hud-track {
+        flex: 1;
+        height: 6px;
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .hud-fill {
+        height: 100%;
+        width: 100%;
+        background: linear-gradient(90deg, #6bff8f, #2ec4a0);
+        transition: width 0.2s ease;
+      }
+
+      #hud-oxygen-fill {
+        background: linear-gradient(90deg, #7ecbff, #3a8dff);
+      }
+
+      .hud-value {
+        font-variant-numeric: tabular-nums;
+        font-size: 12px;
+        color: rgba(255, 255, 255, 0.9);
+        min-width: 32px;
+        text-align: right;
+      }
+
+      #hud-status {
+        min-height: 18px;
+        font-size: 13px;
+        color: #ffe28a;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+
+      #hud-status.visible {
+        opacity: 1;
+      }
+
+      #hud.in-water .hud-fill {
+        background: linear-gradient(90deg, #45d0ff, #1b7bff);
+      }
+
       canvas {
         display: block;
       }
@@ -53,8 +121,9 @@
         <div id="instructions">
           <h1>Procedural Block World</h1>
           <p>
-            Click anywhere to lock the pointer, then use WASD to move and Space
-            to hop up ledges. Move the mouse to look around.
+            Click anywhere to lock the pointer, then use WASD to move, Space to
+            jump, and Shift to sprint (or dive while swimming). Keep an eye on
+            your health and oxygen in the HUD.
           </p>
         </div>
       </div>

--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -1,7 +1,8 @@
 import * as THREE from 'three'
 
 import { createBlockMaterials } from '../../src/rendering/textures.js'
-import { generateWorld, terrainHeight, worldConfig } from '../../src/world/generation.js'
+import { terrainHeight, worldConfig } from '../../src/world/generation.js'
+import { createChunkManager } from '../../src/world/chunk-manager.js'
 import { createPlayerControls } from '../../src/player/controls.js'
 
 const overlay = document.getElementById('overlay')
@@ -22,13 +23,62 @@ const renderer = new THREE.WebGLRenderer({ antialias: true })
 renderer.setPixelRatio(window.devicePixelRatio)
 renderer.setSize(window.innerWidth, window.innerHeight)
 renderer.outputColorSpace = THREE.SRGBColorSpace
+renderer.shadowMap.enabled = true
+renderer.shadowMap.type = THREE.PCFSoftShadowMap
+renderer.toneMapping = THREE.ACESFilmicToneMapping
+renderer.toneMappingExposure = 1.1
 document.body.appendChild(renderer.domElement)
 
 const clock = new THREE.Clock()
 
 const blockMaterials = createBlockMaterials()
-const { meshes, solidBlocks, waterColumns } = generateWorld(blockMaterials)
-meshes.forEach((mesh) => scene.add(mesh))
+
+const chunkManager = createChunkManager({
+  scene,
+  blockMaterials,
+  viewDistance: 2,
+})
+
+const hud = document.createElement('div')
+hud.id = 'hud'
+hud.innerHTML = `
+  <div class="hud-bar">
+    <span class="hud-label">Health</span>
+    <div class="hud-track" aria-hidden="true">
+      <div class="hud-fill" id="hud-health-fill"></div>
+    </div>
+    <span class="hud-value" id="hud-health-value">100</span>
+  </div>
+  <div class="hud-bar">
+    <span class="hud-label">Oxygen</span>
+    <div class="hud-track" aria-hidden="true">
+      <div class="hud-fill" id="hud-oxygen-fill"></div>
+    </div>
+    <span class="hud-value" id="hud-oxygen-value">12</span>
+  </div>
+  <div id="hud-status" role="status" aria-live="polite"></div>
+`
+document.body.appendChild(hud)
+
+const healthFill = hud.querySelector('#hud-health-fill')
+const healthValue = hud.querySelector('#hud-health-value')
+const oxygenFill = hud.querySelector('#hud-oxygen-fill')
+const oxygenValue = hud.querySelector('#hud-oxygen-value')
+const statusElement = hud.querySelector('#hud-status')
+
+function updateHud(state) {
+  const healthPercent = THREE.MathUtils.clamp(state.health / 100, 0, 1)
+  healthFill.style.width = `${healthPercent * 100}%`
+  healthValue.textContent = `${Math.round(state.health)}`
+
+  const oxygenPercent = THREE.MathUtils.clamp(state.oxygen / state.maxOxygen, 0, 1)
+  oxygenFill.style.width = `${oxygenPercent * 100}%`
+  oxygenValue.textContent = `${state.oxygen.toFixed(1)}`
+
+  statusElement.textContent = state.statusMessage ?? ''
+  statusElement.classList.toggle('visible', Boolean(state.statusMessage))
+  hud.classList.toggle('in-water', state.isInWater)
+}
 
 const playerControls = createPlayerControls({
   scene,
@@ -37,17 +87,26 @@ const playerControls = createPlayerControls({
   overlay,
   worldConfig,
   terrainHeight,
-  solidBlocks,
-  waterColumns,
+  solidBlocks: chunkManager.solidBlocks,
+  waterColumns: chunkManager.waterColumns,
+  onStateChange: updateHud,
 })
+
+chunkManager.update(playerControls.getPosition())
+updateHud(playerControls.getState())
 
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.5)
 scene.add(ambientLight)
+
+const hemiLight = new THREE.HemisphereLight(0xbcdfff, 0x5a4833, 0.45)
+scene.add(hemiLight)
 
 const sun = new THREE.DirectionalLight(0xffffff, 1.1)
 sun.position.set(20, 50, 20)
 sun.castShadow = true
 sun.shadow.mapSize.set(2048, 2048)
+sun.shadow.camera.near = 0.5
+sun.shadow.camera.far = 200
 scene.add(sun)
 
 const waterMaterial = blockMaterials.water
@@ -57,6 +116,7 @@ function animate() {
   requestAnimationFrame(animate)
   const delta = Math.min(clock.getDelta(), 0.05)
 
+  chunkManager.update(playerControls.getPosition())
   playerControls.update(delta)
 
   waveTime += delta
@@ -67,3 +127,8 @@ function animate() {
 }
 
 animate()
+
+window.addEventListener('beforeunload', () => {
+  playerControls.dispose()
+  chunkManager.dispose()
+})


### PR DESCRIPTION
## Summary
- introduce a chunk manager that streams instanced block meshes around the player and reuse it in both entry points
- add buoyancy, oxygen tracking, fall damage, and a HUD with health/oxygen readouts driven by player state callbacks
- polish lighting/tone mapping and document the standard Vite-based workflow for development and builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d08c5feab8832a9e04030aa8a9db96