### PR TITLE
Inject shared THREE dependencies

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,18 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js';
+import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/controls/PointerLockControls.js';
 
 import { createBlockMaterials } from './rendering/textures.js';
-import { terrainHeight, worldConfig } from './world/generation.js';
+import {
+  initializeWorldGeneration,
+  terrainHeight,
+  worldConfig,
+} from './world/generation.js';
 import { createChunkManager } from './world/chunk-manager.js';
 import { createPlayerControls } from './player/controls.js';
 
 const overlay = document.getElementById('overlay');
+
+initializeWorldGeneration({ THREE });
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0xa9d6ff);
@@ -31,7 +38,7 @@ document.body.appendChild(renderer.domElement);
 
 const clock = new THREE.Clock();
 
-const blockMaterials = createBlockMaterials();
+const blockMaterials = createBlockMaterials({ THREE });
 
 const chunkManager = createChunkManager({
   scene,
@@ -81,6 +88,8 @@ function updateHud(state) {
 }
 
 const playerControls = createPlayerControls({
+  THREE,
+  PointerLockControls,
   scene,
   camera,
   renderer,

--- a/src/player/controls.js
+++ b/src/player/controls.js
@@ -1,6 +1,3 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
-import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/PointerLockControls.js';
-
 function blockKey(x, y, z) {
   return `${x}|${y}|${z}`;
 }
@@ -41,6 +38,8 @@ function isPointerLockSupported(doc) {
 }
 
 export function createPlayerControls({
+  THREE,
+  PointerLockControls,
   scene,
   camera,
   renderer,
@@ -51,6 +50,12 @@ export function createPlayerControls({
   waterColumns,
   onStateChange = () => {},
 }) {
+  if (!THREE) {
+    throw new Error('createPlayerControls requires a THREE instance');
+  }
+  if (!PointerLockControls) {
+    throw new Error('createPlayerControls requires PointerLockControls');
+  }
   const controls = new PointerLockControls(camera, renderer.domElement);
   scene.add(controls.getObject());
 

--- a/src/rendering/texture-engine.js
+++ b/src/rendering/texture-engine.js
@@ -1,5 +1,3 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
-
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -57,7 +55,11 @@ const WHITE = { r: 1, g: 1, b: 1 };
 const BLACK = { r: 0, g: 0, b: 0 };
 
 export class TextureEngine {
-  constructor(seed = 1337) {
+  constructor({ THREE, seed = 1337 } = {}) {
+    if (!THREE) {
+      throw new Error('TextureEngine requires a THREE instance');
+    }
+    this.THREE = THREE;
     this.seed = seed >>> 0;
   }
 
@@ -249,7 +251,13 @@ export class TextureEngine {
     return Math.pow(normalized, sharpness);
   }
 
-  createTexture(label, { size = 64, generator, wrap = THREE.RepeatWrapping, filter = THREE.NearestFilter }) {
+  createTexture(
+    label,
+    { size = 64, generator, wrap = undefined, filter = undefined } = {}
+  ) {
+    const THREE = this.THREE;
+    const textureWrap = wrap ?? THREE.RepeatWrapping;
+    const textureFilter = filter ?? THREE.NearestFilter;
     const canvas = document.createElement('canvas');
     canvas.width = size;
     canvas.height = size;
@@ -291,9 +299,9 @@ export class TextureEngine {
     ctx.putImageData(imageData, 0, 0);
     const texture = new THREE.CanvasTexture(canvas);
     texture.colorSpace = THREE.SRGBColorSpace;
-    texture.wrapS = texture.wrapT = wrap;
-    texture.magFilter = filter;
-    texture.minFilter = filter;
+    texture.wrapS = texture.wrapT = textureWrap;
+    texture.magFilter = textureFilter;
+    texture.minFilter = textureFilter;
     return texture;
   }
 }

--- a/src/rendering/textures.js
+++ b/src/rendering/textures.js
@@ -1,8 +1,10 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
 import { TextureEngine } from './texture-engine.js';
 
-export function createBlockMaterials({ seed = 1337 } = {}) {
-  const engine = new TextureEngine(seed);
+export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
+  if (!THREE) {
+    throw new Error('createBlockMaterials requires a THREE instance');
+  }
+  const engine = new TextureEngine({ THREE, seed });
 
   const textures = {
     grass: engine.createTexture('grass', {

--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -1,11 +1,18 @@
 import * as THREE from 'three'
+import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js'
 
 import { createBlockMaterials } from '../../src/rendering/textures.js'
-import { terrainHeight, worldConfig } from '../../src/world/generation.js'
+import {
+  initializeWorldGeneration,
+  terrainHeight,
+  worldConfig,
+} from '../../src/world/generation.js'
 import { createChunkManager } from '../../src/world/chunk-manager.js'
 import { createPlayerControls } from '../../src/player/controls.js'
 
 const overlay = document.getElementById('overlay')
+
+initializeWorldGeneration({ THREE })
 
 const scene = new THREE.Scene()
 scene.background = new THREE.Color(0xa9d6ff)
@@ -31,7 +38,7 @@ document.body.appendChild(renderer.domElement)
 
 const clock = new THREE.Clock()
 
-const blockMaterials = createBlockMaterials()
+const blockMaterials = createBlockMaterials({ THREE })
 
 const chunkManager = createChunkManager({
   scene,
@@ -81,6 +88,8 @@ function updateHud(state) {
 }
 
 const playerControls = createPlayerControls({
+  THREE,
+  PointerLockControls,
   scene,
   camera,
   renderer,


### PR DESCRIPTION
## Summary
- update the browser entrypoint to reuse a single Three.js 0.180.0 import and pass PointerLockControls to player controls
- inject the shared THREE instance into player controls, texture generation, and world generation helpers instead of importing from a CDN internally
- wire the Vite sandbox to share its bundled three dependencies with the shared helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c5fa7cac832aac9c65afe4d5b098