### PR TITLE
Improve startup flow and pointer lock handling

### DIFF
--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -134,7 +134,7 @@
   </head>
   <body>
     <div id="app">
-      <div id="overlay">
+      <div id="overlay" class="hidden" aria-hidden="true">
         <div id="instructions">
           <h1>Procedural Block World</h1>
           <p>


### PR DESCRIPTION
## Summary
- auto-hide the start overlay so the world renders right away and let the canvas pointer events trigger pointer lock attempts
- surface HUD guidance and fallback messaging when pointer lock support is missing or blocked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0cae78688832abbcfe203d5d5847c