### PR TITLE
Handle world initialization failures and guard water animation

### DIFF
--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -123,6 +123,10 @@
         opacity: 1;
       }
 
+      #hud-status.error {
+        color: #ffb4a2;
+      }
+
       #hud.in-water .hud-fill {
         background: linear-gradient(90deg, #45d0ff, #1b7bff);
       }


### PR DESCRIPTION
## Summary
- add overlay and HUD helpers so initialization failures surface a visible error message instead of crashing the render loop
- guard the water wave animation against missing textures and surface a HUD warning when the map is unavailable
- style HUD error state to distinguish failure notices

## Testing
- npm run build
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d0d3a210f8832a8076692aff84a7f1