### PR TITLE
Add block combat interactions and enhanced jump

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -150,6 +150,8 @@ try {
     terrainHeight,
     solidBlocks: chunkManager.solidBlocks,
     waterColumns: chunkManager.waterColumns,
+    chunkManager,
+    damageMaterials: blockMaterials.damageStages,
     onStateChange: updateHud,
   })
 


### PR DESCRIPTION
## Summary
- extend world chunk metadata so instanced blocks can be located and removed when attacked
- add a player-side mining/attack loop with stronger jumps, raycast targeting, and damage overlay handling
- generate algorithmic damage textures and pass their materials into the player controls for rendering feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d157c1ff00832aa9274142e0d7e3d2