### PR TITLE
Improve spawn safety and collision recovery

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -5,6 +5,7 @@ import { createBlockMaterials } from './rendering/textures.js'
 import {
   initializeWorldGeneration,
   worldConfig,
+  terrainHeight,
 } from './world/generation.js'
 import { createChunkManager } from './world/chunk-manager.js'
 import { createPlayerControls } from './player/controls.js'
@@ -146,6 +147,7 @@ try {
     renderer,
     overlay,
     worldConfig,
+    terrainHeight,
     solidBlocks: chunkManager.solidBlocks,
     waterColumns: chunkManager.waterColumns,
     chunkManager,


### PR DESCRIPTION
## Summary
- ensure the player spawn logic searches nearby terrain columns and falls from a safe height
- add collision rescue handling that nudges the player upward and warns if a stuck state cannot be resolved
- pass the world terrain height helper into the player controls to support the new spawn heuristics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d168b4baf0832a860972fb6eb05b93