### PR TITLE
Add biome-driven terrain system

### DIFF
--- a/three-demo/src/rendering/textures.js
+++ b/three-demo/src/rendering/textures.js
@@ -269,23 +269,25 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
   });
 
   return {
-    grass: new THREE.MeshStandardMaterial({ map: textures.grass }),
-    dirt: new THREE.MeshStandardMaterial({ map: textures.dirt }),
-    stone: new THREE.MeshStandardMaterial({ map: textures.stone }),
-    sand: new THREE.MeshStandardMaterial({ map: textures.sand }),
+    grass: new THREE.MeshStandardMaterial({ map: textures.grass, vertexColors: true }),
+    dirt: new THREE.MeshStandardMaterial({ map: textures.dirt, vertexColors: true }),
+    stone: new THREE.MeshStandardMaterial({ map: textures.stone, vertexColors: true }),
+    sand: new THREE.MeshStandardMaterial({ map: textures.sand, vertexColors: true }),
     water: new THREE.MeshStandardMaterial({
       map: textures.water,
       transparent: true,
       opacity: 0.75,
       depthWrite: false,
+      vertexColors: true,
     }),
-    leaf: new THREE.MeshStandardMaterial({ map: textures.leaf }),
-    log: new THREE.MeshStandardMaterial({ map: textures.log }),
+    leaf: new THREE.MeshStandardMaterial({ map: textures.leaf, vertexColors: true }),
+    log: new THREE.MeshStandardMaterial({ map: textures.log, vertexColors: true }),
     cloud: new THREE.MeshStandardMaterial({
       map: textures.cloud,
       transparent: true,
       opacity: 0.85,
       depthWrite: false,
+      vertexColors: true,
     }),
     damageStages,
   };

--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -1,0 +1,162 @@
+import { ValueNoise2D } from './noise.js';
+import temperate from './biomes/temperate.json';
+import desert from './biomes/desert.json';
+import tundra from './biomes/tundra.json';
+
+const rawBiomeDefinitions = [temperate, desert, tundra];
+
+const DEFAULT_PALETTE = {
+  grass: '#ffffff',
+  dirt: '#ffffff',
+  stone: '#ffffff',
+  sand: '#ffffff',
+  water: '#ffffff',
+  leaf: '#ffffff',
+  log: '#ffffff',
+  cloud: '#ffffff',
+};
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function mixValues(a, b, weight) {
+  return a * (1 - weight) + b * weight;
+}
+
+export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
+  if (!THREE) {
+    throw new Error('createBiomeEngine requires a THREE instance');
+  }
+
+  const temperatureNoise = new ValueNoise2D(seed * 1.37 + 97);
+  const temperatureDetailNoise = new ValueNoise2D(seed * 1.91 + 227);
+  const moistureNoise = new ValueNoise2D(seed * 1.51 + 157);
+  const moistureDetailNoise = new ValueNoise2D(seed * 2.03 + 311);
+  const varianceNoise = new ValueNoise2D(seed * 1.73 + 443);
+
+  const climateScale = 0.003;
+  const detailScale = climateScale * 2.15;
+  const varianceScale = climateScale * 0.45;
+
+  const defaultColor = new THREE.Color(DEFAULT_PALETTE.grass);
+
+  const biomes = rawBiomeDefinitions.map((definition, index) => {
+    const palette = { ...DEFAULT_PALETTE, ...(definition.palette ?? {}) };
+    const paletteColors = Object.fromEntries(
+      Object.entries(palette).map(([type, hex]) => [type, new THREE.Color(hex)]),
+    );
+
+    const terrainDefinition = definition.terrain ?? {};
+    const treeHeight = terrainDefinition.treeHeight ?? {};
+
+    const shaderDefinition = definition.shader ?? {};
+
+    return {
+      id: definition.id ?? `biome_${index}`,
+      label: definition.label ?? definition.id ?? `Biome ${index + 1}`,
+      climate: {
+        temperature: clamp01(definition.climate?.temperature ?? 0.5),
+        moisture: clamp01(definition.climate?.moisture ?? 0.5),
+        weight: Math.max(0.001, definition.climate?.weight ?? 1),
+      },
+      palette,
+      paletteColors,
+      terrain: {
+        surfaceBlock: terrainDefinition.surfaceBlock ?? 'grass',
+        shoreBlock: terrainDefinition.shoreBlock ?? 'sand',
+        subSurfaceBlock: terrainDefinition.subSurfaceBlock ?? 'dirt',
+        subSurfaceDepth: Math.max(1, Math.floor(terrainDefinition.subSurfaceDepth ?? 4)),
+        deepBlock: terrainDefinition.deepBlock ?? 'stone',
+        treeDensity: clamp01(terrainDefinition.treeDensity ?? 0.08),
+        shrubChance: clamp01(terrainDefinition.shrubChance ?? 0.02),
+        treeHeight: {
+          min: Math.max(1, Math.floor(treeHeight.min ?? 3)),
+          max: Math.max(Math.floor(treeHeight.max ?? 6), Math.floor(treeHeight.min ?? 3)),
+        },
+        heightOffset: terrainDefinition.heightOffset ?? 0,
+      },
+      shader: {
+        fogColor: new THREE.Color(shaderDefinition.fogColor ?? '#a9d6ff'),
+        tintColor: new THREE.Color(shaderDefinition.tintColor ?? '#ffffff'),
+        tintStrength: clamp01(shaderDefinition.tintStrength ?? 0),
+      },
+    };
+  });
+
+  function sampleNoisePair(noiseA, noiseB, x, z, baseScale, detailScale) {
+    const base = noiseA.noise(x * baseScale, z * baseScale);
+    const detail = noiseB.noise(x * detailScale, z * detailScale);
+    return clamp01(mixValues(base, detail, 0.35));
+  }
+
+  function sampleClimate(x, z) {
+    const temperature = sampleNoisePair(
+      temperatureNoise,
+      temperatureDetailNoise,
+      x,
+      z,
+      climateScale,
+      detailScale,
+    );
+    const moisture = sampleNoisePair(
+      moistureNoise,
+      moistureDetailNoise,
+      x,
+      z,
+      climateScale,
+      detailScale * 1.18,
+    );
+
+    return { temperature, moisture };
+  }
+
+  function selectBiome(climate, x, z) {
+    let selected = biomes[0];
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    biomes.forEach((biome, index) => {
+      const dx = climate.temperature - biome.climate.temperature;
+      const dy = climate.moisture - biome.climate.moisture;
+      const distance = Math.sqrt(dx * dx + dy * dy) / biome.climate.weight;
+      const variation = varianceNoise.noise(
+        x * varianceScale + index * 17.13,
+        z * varianceScale + index * 31.17,
+      );
+      const adjustedDistance = distance - (variation - 0.5) * 0.18;
+      if (adjustedDistance < bestScore) {
+        bestScore = adjustedDistance;
+        selected = biome;
+      }
+    });
+
+    return { biome: selected, score: bestScore };
+  }
+
+  function getBiomeAt(x, z) {
+    const climate = sampleClimate(x, z);
+    const selection = selectBiome(climate, x, z);
+    return {
+      biome: selection.biome,
+      climate,
+      score: selection.score,
+    };
+  }
+
+  function getBlockColor(biome, type) {
+    if (!biome?.paletteColors) {
+      return defaultColor;
+    }
+    return biome.paletteColors[type] ?? defaultColor;
+  }
+
+  return {
+    biomes,
+    sampleClimate,
+    getBiomeAt,
+    getBlockColor,
+    getDefaultBlockColor() {
+      return defaultColor;
+    },
+  };
+}

--- a/three-demo/src/world/biomes/desert.json
+++ b/three-demo/src/world/biomes/desert.json
@@ -1,0 +1,36 @@
+{
+  "id": "sunset_dunes",
+  "label": "Sunset Dunes",
+  "climate": {
+    "temperature": 0.92,
+    "moisture": 0.12
+  },
+  "terrain": {
+    "surfaceBlock": "sand",
+    "shoreBlock": "sand",
+    "subSurfaceBlock": "sand",
+    "subSurfaceDepth": 5,
+    "deepBlock": "stone",
+    "treeDensity": 0.0,
+    "shrubChance": 0.01,
+    "treeHeight": {
+      "min": 2,
+      "max": 3
+    },
+    "heightOffset": -1
+  },
+  "palette": {
+    "sand": "#f4dc94",
+    "dirt": "#e2b978",
+    "stone": "#d0b48d",
+    "grass": "#e6d19b",
+    "leaf": "#d0c46d",
+    "log": "#c49a63",
+    "water": "#3f9dac"
+  },
+  "shader": {
+    "fogColor": "#f3d8a6",
+    "tintColor": "#ffe3b0",
+    "tintStrength": 0.45
+  }
+}

--- a/three-demo/src/world/biomes/temperate.json
+++ b/three-demo/src/world/biomes/temperate.json
@@ -1,0 +1,33 @@
+{
+  "id": "temperate_forest",
+  "label": "Temperate Forest",
+  "climate": {
+    "temperature": 0.58,
+    "moisture": 0.72
+  },
+  "terrain": {
+    "surfaceBlock": "grass",
+    "shoreBlock": "sand",
+    "subSurfaceBlock": "dirt",
+    "subSurfaceDepth": 4,
+    "deepBlock": "stone",
+    "treeDensity": 0.08,
+    "shrubChance": 0.025,
+    "treeHeight": {
+      "min": 3,
+      "max": 6
+    },
+    "heightOffset": 0
+  },
+  "palette": {
+    "grass": "#ffffff",
+    "leaf": "#ffffff",
+    "log": "#ffffff",
+    "water": "#ffffff"
+  },
+  "shader": {
+    "fogColor": "#a9d6ff",
+    "tintColor": "#ffffff",
+    "tintStrength": 0.0
+  }
+}

--- a/three-demo/src/world/biomes/tundra.json
+++ b/three-demo/src/world/biomes/tundra.json
@@ -1,0 +1,36 @@
+{
+  "id": "frostbound_steppe",
+  "label": "Frostbound Steppe",
+  "climate": {
+    "temperature": 0.18,
+    "moisture": 0.58
+  },
+  "terrain": {
+    "surfaceBlock": "grass",
+    "shoreBlock": "sand",
+    "subSurfaceBlock": "dirt",
+    "subSurfaceDepth": 3,
+    "deepBlock": "stone",
+    "treeDensity": 0.02,
+    "shrubChance": 0.015,
+    "treeHeight": {
+      "min": 2,
+      "max": 4
+    },
+    "heightOffset": 1
+  },
+  "palette": {
+    "grass": "#b7c0b1",
+    "dirt": "#8f8a7c",
+    "stone": "#c6ccd2",
+    "sand": "#d5dbe0",
+    "leaf": "#e2e9ed",
+    "log": "#bcaea1",
+    "water": "#6f94b9"
+  },
+  "shader": {
+    "fogColor": "#dce8f1",
+    "tintColor": "#e9f1f6",
+    "tintStrength": 0.4
+  }
+}

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -152,6 +152,9 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
       const swapped = entries[lastIndex];
       entries[instanceId] = swapped;
       mesh.setMatrixAt(instanceId, swapped.matrix);
+      if (typeof mesh.setColorAt === 'function') {
+        mesh.setColorAt(instanceId, swapped.color ?? mesh.userData?.defaultColor);
+      }
       mesh.instanceMatrix.needsUpdate = true;
       if (chunk.blockLookup) {
         const swappedInfo = chunk.blockLookup.get(swapped.key);
@@ -165,6 +168,9 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     entries.pop();
     mesh.count = entries.length;
     mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) {
+      mesh.instanceColor.needsUpdate = true;
+    }
 
     if (chunk.blockLookup) {
       chunk.blockLookup.delete(removed.key);

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1,41 +1,4 @@
-class ValueNoise2D {
-  constructor(seed = 1) {
-    this.seed = seed;
-  }
-
-  hash(x, y) {
-    const s = Math.sin(x * 374761393 + y * 668265263 + this.seed * 951.1357);
-    return s - Math.floor(s);
-  }
-
-  smoothstep(t) {
-    return t * t * (3 - 2 * t);
-  }
-
-  noise(x, y) {
-    const x0 = Math.floor(x);
-    const y0 = Math.floor(y);
-    const x1 = x0 + 1;
-    const y1 = y0 + 1;
-
-    const sx = this.smoothstep(x - x0);
-    const sy = this.smoothstep(y - y0);
-
-    const n0 = this.hash(x0, y0);
-    const n1 = this.hash(x1, y0);
-    const ix0 = lerp(n0, n1, sx);
-
-    const n2 = this.hash(x0, y1);
-    const n3 = this.hash(x1, y1);
-    const ix1 = lerp(n2, n3, sx);
-
-    return lerp(ix0, ix1, sy);
-  }
-}
-
-function lerp(a, b, t) {
-  return a + (b - a) * t;
-}
+import { createTerrainEngine } from './terrain-engine.js';
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
@@ -43,6 +6,7 @@ function clamp(value, min, max) {
 
 let THREERef = null;
 let blockGeometry = null;
+let terrainEngine = null;
 
 function ensureThree() {
   if (!THREERef) {
@@ -51,15 +15,21 @@ function ensureThree() {
   return THREERef;
 }
 
+function ensureTerrainEngine() {
+  if (!terrainEngine) {
+    throw new Error('World generation requires the terrain engine to be initialized');
+  }
+  return terrainEngine;
+}
+
 export function initializeWorldGeneration({ THREE }) {
   if (!THREE) {
     throw new Error('initializeWorldGeneration requires a THREE instance');
   }
   THREERef = THREE;
   blockGeometry = new THREE.BoxGeometry(1, 1, 1);
+  terrainEngine = createTerrainEngine({ THREE, seed: 1337, worldConfig });
 }
-
-const noiseGenerator = new ValueNoise2D(1337);
 
 export const worldConfig = {
   chunkSize: 48,
@@ -69,16 +39,14 @@ export const worldConfig = {
 };
 
 export function terrainHeight(x, z) {
-  const frequency1 = 0.06;
-  const frequency2 = 0.12;
-  const amplitude1 = 8;
-  const amplitude2 = 3;
+  const engine = ensureTerrainEngine();
+  const sample = engine.sampleColumn(x, z);
+  return Math.floor(clamp(sample.height, 2, worldConfig.maxHeight));
+}
 
-  const n1 = noiseGenerator.noise(x * frequency1, z * frequency1);
-  const n2 = noiseGenerator.noise(x * frequency2 + 100, z * frequency2 + 100);
-  const combined = n1 * amplitude1 + n2 * amplitude2;
-  const height = worldConfig.baseHeight + combined;
-  return Math.floor(clamp(height, 2, worldConfig.maxHeight));
+export function sampleBiomeAt(x, z) {
+  const engine = ensureTerrainEngine();
+  return engine.getBiomeAt(x, z);
 }
 
 export function randomAt(x, z, offset = 0) {
@@ -92,20 +60,24 @@ function blockKey(x, y, z) {
   return `${x}|${y}|${z}`;
 }
 
-function addTree(addBlock, x, z, groundHeight) {
-  const treeHeight = 3 + Math.floor(randomAt(x, z, 2) * 3);
+function addTree(addBlock, x, z, groundHeight, biome) {
+  const treeRange = biome?.terrain?.treeHeight ?? { min: 3, max: 6 };
+  const minHeight = Math.max(1, treeRange.min ?? 3);
+  const maxHeight = Math.max(minHeight, treeRange.max ?? minHeight);
+  const randomValue = randomAt(x, z, 2);
+  const treeHeight = minHeight + Math.floor(randomValue * (maxHeight - minHeight + 1));
   for (let y = 1; y <= treeHeight; y++) {
-    addBlock('log', x, groundHeight + y, z);
+    addBlock('log', x, groundHeight + y, z, biome);
   }
 
-  const canopyRadius = 2;
+  const canopyRadius = Math.max(1, Math.round(treeHeight / 2));
   const canopyCenter = groundHeight + treeHeight;
   for (let dx = -canopyRadius; dx <= canopyRadius; dx++) {
     for (let dy = -canopyRadius; dy <= canopyRadius; dy++) {
       for (let dz = -canopyRadius; dz <= canopyRadius; dz++) {
         const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
         if (distance <= canopyRadius + (dy === canopyRadius ? 0 : -0.3)) {
-          addBlock('leaf', x + dx, canopyCenter + dy, z + dz);
+          addBlock('leaf', x + dx, canopyCenter + dy, z + dz, biome);
         }
       }
     }
@@ -122,7 +94,7 @@ function addCloud(addBlock, x, y, z) {
     [1, 0, 1],
     [-1, 0, -1],
   ];
-  blocks.forEach(([dx, dy, dz]) => addBlock('cloud', x + dx, y + dy, z + dz));
+  blocks.forEach(([dx, dy, dz]) => addBlock('cloud', x + dx, y + dy, z + dz, null));
 }
 
 function chunkWorldBounds(chunkX, chunkZ) {
@@ -136,6 +108,7 @@ function chunkWorldBounds(chunkX, chunkZ) {
 
 export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const THREE = ensureThree();
+  const engine = ensureTerrainEngine();
   if (!blockGeometry) {
     blockGeometry = new THREE.BoxGeometry(1, 1, 1);
   }
@@ -145,21 +118,25 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const matrix = new THREE.Matrix4();
   const blockLookup = new Map();
   const typeData = new Map();
+  const biomePresence = new Map();
 
   const { minX, minZ } = chunkWorldBounds(chunkX, chunkZ);
   const { chunkSize, waterLevel } = worldConfig;
 
-  const addBlock = (type, x, y, z) => {
+  const addBlock = (type, x, y, z, biome) => {
     matrix.setPosition(x, y, z);
     if (!instancedData.has(type)) {
       instancedData.set(type, []);
     }
     const key = blockKey(x, y, z);
+    const color = engine.getBlockColor(biome, type);
     const entry = {
       key,
       matrix: matrix.clone(),
       position: new THREE.Vector3(x, y, z),
       type,
+      biomeId: biome?.id ?? null,
+      color,
       isSolid: solidTypes.has(type),
       isWater: type === 'water',
       destructible: type !== 'water' && type !== 'cloud',
@@ -178,32 +155,56 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     const worldX = minX + lx;
     for (let lz = 0; lz < chunkSize; lz++) {
       const worldZ = minZ + lz;
-      const height = terrainHeight(worldX, worldZ);
-      const surfaceType = height <= waterLevel + 1 ? 'sand' : 'grass';
+      const columnSample = engine.sampleColumn(worldX, worldZ);
+      const biome = columnSample.biome;
+      const height = Math.floor(clamp(columnSample.height, 2, worldConfig.maxHeight));
+      const isShore = height <= waterLevel + 1;
+      const isUnderwater = height < waterLevel;
+
+      if (biome) {
+        const stats = biomePresence.get(biome.id) ?? { biome, samples: 0 };
+        stats.samples += 1;
+        biomePresence.set(biome.id, stats);
+      }
+
+      const surfaceBlock = isUnderwater
+        ? biome?.terrain?.shoreBlock ?? 'sand'
+        : isShore
+        ? biome?.terrain?.shoreBlock ?? 'sand'
+        : biome?.terrain?.surfaceBlock ?? 'grass';
+      const subSurfaceBlock = isUnderwater
+        ? biome?.terrain?.shoreBlock ?? 'sand'
+        : biome?.terrain?.subSurfaceBlock ?? 'dirt';
+      const deepBlock = biome?.terrain?.deepBlock ?? 'stone';
+      const subSurfaceDepth = Math.max(1, biome?.terrain?.subSurfaceDepth ?? 4);
 
       for (let y = 0; y <= height; y++) {
         if (y === height) {
-          addBlock(surfaceType, worldX, y, worldZ);
-        } else if (y < height - 4) {
-          addBlock('stone', worldX, y, worldZ);
+          addBlock(surfaceBlock, worldX, y, worldZ, biome);
+        } else if (y >= height - subSurfaceDepth) {
+          addBlock(subSurfaceBlock, worldX, y, worldZ, biome);
         } else {
-          addBlock('dirt', worldX, y, worldZ);
+          addBlock(deepBlock, worldX, y, worldZ, biome);
         }
       }
 
       if (height < waterLevel) {
         for (let y = height + 1; y <= waterLevel; y++) {
-          addBlock('water', worldX, y, worldZ);
+          addBlock('water', worldX, y, worldZ, biome);
         }
-      } else if (surfaceType === 'grass' && randomAt(worldX, worldZ, 1) > 0.92) {
-        addTree(addBlock, worldX, worldZ, height);
-      }
+      } else {
+        const treeDensity = biome?.terrain?.treeDensity ?? 0;
+        if (treeDensity > 0 && randomAt(worldX, worldZ, 1) > 1 - treeDensity) {
+          addTree(addBlock, worldX, worldZ, height, biome);
+        }
 
-      if (randomAt(worldX, worldZ, 5) > 0.98 && height > waterLevel + 4) {
-        const shrubHeight = height + 1;
-        addBlock('leaf', worldX, shrubHeight, worldZ);
-        if (randomAt(worldX + 10, worldZ + 10, 6) > 0.6) {
-          addBlock('leaf', worldX, shrubHeight + 1, worldZ);
+        const shrubChance = biome?.terrain?.shrubChance ?? 0;
+        if (shrubChance > 0 && randomAt(worldX, worldZ, 5) > 1 - shrubChance) {
+          const shrubHeight = height + 1;
+          addBlock('leaf', worldX, shrubHeight, worldZ, biome);
+          if (randomAt(worldX + 10, worldZ + 10, 6) > 0.6) {
+            addBlock('leaf', worldX, shrubHeight + 1, worldZ, biome);
+          }
         }
       }
     }
@@ -227,22 +228,43 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     const mesh = new THREE.InstancedMesh(
       blockGeometry,
       blockMaterials[type],
-      entries.length
+      entries.length,
     );
+    mesh.userData.defaultColor = engine.getDefaultBlockColor();
     entries.forEach((entry, index) => {
       mesh.setMatrixAt(index, entry.matrix);
       entry.index = index;
+      if (typeof mesh.setColorAt === 'function') {
+        mesh.setColorAt(index, entry.color ?? engine.getDefaultBlockColor());
+      }
     });
     mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) {
+      mesh.instanceColor.needsUpdate = true;
+    }
     mesh.castShadow = ['cloud', 'water'].includes(type) ? false : true;
     mesh.receiveShadow = type !== 'cloud';
     mesh.frustumCulled = false;
     mesh.userData.type = type;
+    mesh.userData.biomePalette = true;
     typeData.set(type, { entries, mesh });
     group.add(mesh);
   });
 
   group.name = `chunk_${chunkX}_${chunkZ}`;
+  const totalSamples = chunkSize * chunkSize;
+  const biomes = Array.from(biomePresence.values()).map(({ biome, samples }) => ({
+    id: biome.id,
+    label: biome.label,
+    weight: samples / totalSamples,
+    shader: {
+      fogColor: `#${biome.shader.fogColor.getHexString()}`,
+      tintColor: `#${biome.shader.tintColor.getHexString()}`,
+      tintStrength: biome.shader.tintStrength,
+    },
+  }));
+
+  group.userData.biomes = biomes;
 
   return {
     chunkX,
@@ -252,6 +274,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     waterColumnKeys,
     blockLookup,
     typeData,
+    biomes,
   };
 }
 
@@ -261,5 +284,6 @@ export function generateWorld(blockMaterials) {
     meshes: [...chunk.group.children],
     solidBlocks: new Set(chunk.solidBlockKeys),
     waterColumns: new Set(chunk.waterColumnKeys),
+    biomes: chunk.biomes,
   };
 }

--- a/three-demo/src/world/noise.js
+++ b/three-demo/src/world/noise.js
@@ -1,0 +1,38 @@
+export class ValueNoise2D {
+  constructor(seed = 1) {
+    this.seed = seed;
+  }
+
+  hash(x, y) {
+    const s = Math.sin(x * 374761393 + y * 668265263 + this.seed * 951.1357);
+    return s - Math.floor(s);
+  }
+
+  smoothstep(t) {
+    return t * t * (3 - 2 * t);
+  }
+
+  noise(x, y) {
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const x1 = x0 + 1;
+    const y1 = y0 + 1;
+
+    const sx = this.smoothstep(x - x0);
+    const sy = this.smoothstep(y - y0);
+
+    const n0 = this.hash(x0, y0);
+    const n1 = this.hash(x1, y0);
+    const ix0 = lerp(n0, n1, sx);
+
+    const n2 = this.hash(x0, y1);
+    const n3 = this.hash(x1, y1);
+    const ix1 = lerp(n2, n3, sx);
+
+    return lerp(ix0, ix1, sy);
+  }
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}

--- a/three-demo/src/world/terrain-engine.js
+++ b/three-demo/src/world/terrain-engine.js
@@ -1,0 +1,46 @@
+import { ValueNoise2D } from './noise.js';
+import { createBiomeEngine } from './biome-engine.js';
+
+export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {}) {
+  if (!THREE) {
+    throw new Error('createTerrainEngine requires a THREE instance');
+  }
+
+  const config = {
+    baseHeight: worldConfig.baseHeight ?? 6,
+    maxHeight: worldConfig.maxHeight ?? 20,
+  };
+
+  const elevationNoise = new ValueNoise2D(seed * 1.11 + 67);
+  const detailNoise = new ValueNoise2D(seed * 1.59 + 139);
+  const ridgeNoise = new ValueNoise2D(seed * 2.03 + 211);
+
+  const biomeEngine = createBiomeEngine({ THREE, seed: seed * 1.37 + 19 });
+
+  function computeElevation(x, z) {
+    const n1 = elevationNoise.noise(x * 0.06, z * 0.06);
+    const n2 = detailNoise.noise(x * 0.12 + 100, z * 0.12 + 100);
+    const ridges = ridgeNoise.noise(x * 0.02 + 220, z * 0.02 + 220);
+    const ridgeInfluence = (ridges - 0.5) * 2.4;
+    return config.baseHeight + n1 * 8 + n2 * 3 + ridgeInfluence;
+  }
+
+  function sampleColumn(x, z) {
+    const biomeSample = biomeEngine.getBiomeAt(x, z);
+    let height = computeElevation(x, z);
+    const climateAdjustment = (biomeSample.climate.moisture - 0.5) * 1.2;
+    height += climateAdjustment + (biomeSample.biome.terrain.heightOffset ?? 0);
+    return {
+      ...biomeSample,
+      height,
+    };
+  }
+
+  return {
+    sampleColumn,
+    getBiomeAt: (x, z) => biomeEngine.getBiomeAt(x, z),
+    getBlockColor: (biome, type) => biomeEngine.getBlockColor(biome, type),
+    getDefaultBlockColor: () => biomeEngine.getDefaultBlockColor(),
+    biomeEngine,
+  };
+}


### PR DESCRIPTION
## Summary
- add JSON-backed biome definitions and biome/terrain engines to drive climate sampling and terrain heights
- update chunk generation to apply biome palettes, vary surface composition, and expose chunk biome metadata
- enable instanced block tinting with vertex colors and preserve colors when removing block instances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16f2f37bc832aa4c64e86ddf2b266