### PR TITLE
Restore temperate biome palette colors

### DIFF
--- a/three-demo/src/rendering/textures.js
+++ b/three-demo/src/rendering/textures.js
@@ -268,26 +268,38 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
     return material;
   });
 
+  const createStandardBlockMaterial = (texture, overrides = {}) =>
+    new THREE.MeshStandardMaterial({
+      map: texture,
+      flatShading: true,
+      vertexColors: true,
+      roughness: 0.85,
+      metalness: 0,
+      ...overrides,
+    });
+
   return {
-    grass: new THREE.MeshStandardMaterial({ map: textures.grass, vertexColors: true }),
-    dirt: new THREE.MeshStandardMaterial({ map: textures.dirt, vertexColors: true }),
-    stone: new THREE.MeshStandardMaterial({ map: textures.stone, vertexColors: true }),
-    sand: new THREE.MeshStandardMaterial({ map: textures.sand, vertexColors: true }),
-    water: new THREE.MeshStandardMaterial({
-      map: textures.water,
+    grass: createStandardBlockMaterial(textures.grass, { roughness: 0.9 }),
+    dirt: createStandardBlockMaterial(textures.dirt, { roughness: 0.92 }),
+    stone: createStandardBlockMaterial(textures.stone, { roughness: 0.75 }),
+    sand: createStandardBlockMaterial(textures.sand, { roughness: 0.8 }),
+    water: createStandardBlockMaterial(textures.water, {
+      flatShading: false,
       transparent: true,
-      opacity: 0.75,
+      opacity: 0.78,
+      roughness: 0.35,
+      metalness: 0.02,
       depthWrite: false,
-      vertexColors: true,
     }),
-    leaf: new THREE.MeshStandardMaterial({ map: textures.leaf, vertexColors: true }),
-    log: new THREE.MeshStandardMaterial({ map: textures.log, vertexColors: true }),
-    cloud: new THREE.MeshStandardMaterial({
-      map: textures.cloud,
+    leaf: createStandardBlockMaterial(textures.leaf, { roughness: 0.65 }),
+    log: createStandardBlockMaterial(textures.log, { roughness: 0.7 }),
+    cloud: createStandardBlockMaterial(textures.cloud, {
+      flatShading: false,
       transparent: true,
-      opacity: 0.85,
+      opacity: 0.9,
+      roughness: 0.6,
+      metalness: 0,
       depthWrite: false,
-      vertexColors: true,
     }),
     damageStages,
   };

--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -8,14 +8,14 @@ import tundra from './biomes/tundra.json' with { type: 'json' };
 const rawBiomeDefinitions = [temperate, desert, tundra];
 
 const DEFAULT_PALETTE = {
-  grass: '#ffffff',
-  dirt: '#ffffff',
-  stone: '#ffffff',
-  sand: '#ffffff',
-  water: '#ffffff',
-  leaf: '#ffffff',
-  log: '#ffffff',
-  cloud: '#ffffff',
+  grass: '#4a9c47',
+  dirt: '#6b4a2f',
+  stone: '#8c8c8c',
+  sand: '#d7c27a',
+  water: '#1f4d8f',
+  leaf: '#3f7c35',
+  log: '#725032',
+  cloud: '#f7f8fb',
 };
 
 function clamp01(value) {

--- a/three-demo/src/world/biomes/temperate.json
+++ b/three-demo/src/world/biomes/temperate.json
@@ -20,10 +20,14 @@
     "heightOffset": 0
   },
   "palette": {
-    "grass": "#ffffff",
-    "leaf": "#ffffff",
-    "log": "#ffffff",
-    "water": "#ffffff"
+    "grass": "#5aa34f",
+    "dirt": "#7a5436",
+    "stone": "#8f949e",
+    "sand": "#d9c88d",
+    "leaf": "#66b756",
+    "log": "#7f5839",
+    "water": "#3a79c5",
+    "cloud": "#f7f8fb"
   },
   "shader": {
     "fogColor": "#a9d6ff",


### PR DESCRIPTION
## Summary
- restore the default biome palette to the base grass, dirt, stone, sand, water, leaf, log, and cloud hues so vertex colors reflect the authored textures
- reintroduce rich temperate biome tints for every block type in temperate.json so grass, foliage, wood, soil, and water regain their intended colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17cb9a4a0832a93f7dac4fbf8a3da