### PR TITLE
Adjust biome palette tint handling

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -7,7 +7,7 @@ import tundra from './biomes/tundra.json' with { type: 'json' };
 
 const rawBiomeDefinitions = [temperate, desert, tundra];
 
-const DEFAULT_PALETTE = {
+const NEUTRAL_BASE_PALETTE = {
   grass: '#4a9c47',
   dirt: '#6b4a2f',
   stone: '#8c8c8c',
@@ -41,12 +41,27 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
   const detailScale = climateScale * 2.15;
   const varianceScale = climateScale * 0.45;
 
-  const defaultColor = new THREE.Color(DEFAULT_PALETTE.grass);
+  const defaultColor = new THREE.Color(0xffffff);
+  const basePaletteColors = Object.fromEntries(
+    Object.entries(NEUTRAL_BASE_PALETTE).map(([type, hex]) => [
+      type,
+      new THREE.Color(hex),
+    ]),
+  );
 
   const biomes = rawBiomeDefinitions.map((definition, index) => {
-    const palette = { ...DEFAULT_PALETTE, ...(definition.palette ?? {}) };
+    const palette = { ...NEUTRAL_BASE_PALETTE, ...(definition.palette ?? {}) };
     const paletteColors = Object.fromEntries(
-      Object.entries(palette).map(([type, hex]) => [type, new THREE.Color(hex)]),
+      Object.entries(palette).map(([type, hex]) => {
+        const targetColor = new THREE.Color(hex);
+        const baseColor = basePaletteColors[type] ?? defaultColor;
+        const tint = new THREE.Color(
+          baseColor.r === 0 ? 1 : targetColor.r / baseColor.r,
+          baseColor.g === 0 ? 1 : targetColor.g / baseColor.g,
+          baseColor.b === 0 ? 1 : targetColor.b / baseColor.b,
+        );
+        return [type, tint];
+      }),
     );
 
     const terrainDefinition = definition.terrain ?? {};


### PR DESCRIPTION
## Summary
- convert biome palette colors into tint multipliers relative to the neutral base palette
- keep a neutral white default block color so missing entries do not darken blocks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d18d528354832a926b40d4dc266177