### PR TITLE
Clone block geometry per instanced mesh to restore colors

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -225,8 +225,9 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     if (entries.length === 0) {
       return;
     }
+    const geometry = blockGeometry.clone();
     const mesh = new THREE.InstancedMesh(
-      blockGeometry,
+      geometry,
       blockMaterials[type],
       entries.length,
     );


### PR DESCRIPTION
## Summary
- clone the shared cube geometry for each instanced mesh so per-instance colors stay attached to the correct mesh
- ensure terrain meshes render with their biome tint textures instead of falling back to black shading

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d195d29a90832ab77e46f245d3833b