### PR TITLE
Rebuild biome tinting with biome-aware instanced shader

### DIFF
--- a/three-demo/src/rendering/biome-tint-material.js
+++ b/three-demo/src/rendering/biome-tint-material.js
@@ -1,0 +1,64 @@
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function createBiomeTintMaterial({
+  THREE,
+  texture,
+  name = 'BiomeTintMaterial',
+  tintStrength = 1,
+  materialOptions = {},
+} = {}) {
+  if (!THREE) {
+    throw new Error('createBiomeTintMaterial requires a THREE instance');
+  }
+  if (!texture) {
+    throw new Error('createBiomeTintMaterial requires a texture map');
+  }
+
+  const material = new THREE.MeshStandardMaterial({
+    map: texture,
+    flatShading: true,
+    metalness: 0,
+    roughness: 0.85,
+    ...materialOptions,
+  });
+
+  material.name = name;
+  material.defines = material.defines || {};
+  material.defines.BIOME_TINT = 1;
+
+  const uniforms = {
+    biomeTintStrength: { value: clamp(tintStrength, 0, 1) },
+  };
+
+  material.userData.biomeTintUniforms = uniforms;
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.biomeTintStrength = uniforms.biomeTintStrength;
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <common>',
+      `#include <common>\nattribute vec3 biomeTint;\nvarying vec3 vBiomeTint;`,
+    );
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <begin_vertex>',
+      `#include <begin_vertex>\n\tvBiomeTint = biomeTint;`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <common>',
+      `#include <common>\nvarying vec3 vBiomeTint;\nuniform float biomeTintStrength;`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <map_fragment>',
+      `#include <map_fragment>\n\tdiffuseColor.rgb = mix(diffuseColor.rgb, diffuseColor.rgb * vBiomeTint, biomeTintStrength);`,
+    );
+  };
+
+  material.customProgramCacheKey = () => `${material.uuid}_biome_tint`;
+
+  return material;
+}

--- a/three-demo/src/rendering/textures.js
+++ b/three-demo/src/rendering/textures.js
@@ -1,4 +1,5 @@
 import { TextureEngine } from './texture-engine.js';
+import { createBiomeTintMaterial } from './biome-tint-material.js';
 
 export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
   if (!THREE) {
@@ -268,39 +269,75 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
     return material;
   });
 
-  const createStandardBlockMaterial = (texture, overrides = {}) =>
-    new THREE.MeshStandardMaterial({
-      map: texture,
-      flatShading: true,
-      vertexColors: true,
-      roughness: 0.85,
-      metalness: 0,
-      ...overrides,
+  const createStandardBlockMaterial = (
+    texture,
+    overrides = {},
+    { tintStrength = 1, name } = {},
+  ) =>
+    createBiomeTintMaterial({
+      THREE,
+      texture,
+      tintStrength,
+      name,
+      materialOptions: {
+        flatShading: true,
+        roughness: 0.85,
+        metalness: 0,
+        ...overrides,
+      },
     });
 
   return {
-    grass: createStandardBlockMaterial(textures.grass, { roughness: 0.9 }),
-    dirt: createStandardBlockMaterial(textures.dirt, { roughness: 0.92 }),
-    stone: createStandardBlockMaterial(textures.stone, { roughness: 0.75 }),
-    sand: createStandardBlockMaterial(textures.sand, { roughness: 0.8 }),
-    water: createStandardBlockMaterial(textures.water, {
-      flatShading: false,
-      transparent: true,
-      opacity: 0.78,
-      roughness: 0.35,
-      metalness: 0.02,
-      depthWrite: false,
+    grass: createStandardBlockMaterial(textures.grass, { roughness: 0.9 }, {
+      name: 'GrassBiomeMaterial',
     }),
-    leaf: createStandardBlockMaterial(textures.leaf, { roughness: 0.65 }),
-    log: createStandardBlockMaterial(textures.log, { roughness: 0.7 }),
-    cloud: createStandardBlockMaterial(textures.cloud, {
-      flatShading: false,
-      transparent: true,
-      opacity: 0.9,
-      roughness: 0.6,
-      metalness: 0,
-      depthWrite: false,
+    dirt: createStandardBlockMaterial(textures.dirt, { roughness: 0.92 }, {
+      name: 'DirtBiomeMaterial',
     }),
+    stone: createStandardBlockMaterial(textures.stone, { roughness: 0.75 }, {
+      name: 'StoneBiomeMaterial',
+    }),
+    sand: createStandardBlockMaterial(textures.sand, { roughness: 0.8 }, {
+      name: 'SandBiomeMaterial',
+    }),
+    water: createStandardBlockMaterial(
+      textures.water,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.78,
+        roughness: 0.35,
+        metalness: 0.02,
+        depthWrite: false,
+      },
+      {
+        tintStrength: 0.65,
+        name: 'WaterBiomeMaterial',
+      },
+    ),
+    leaf: createStandardBlockMaterial(textures.leaf, { roughness: 0.65 }, {
+      tintStrength: 0.85,
+      name: 'LeafBiomeMaterial',
+    }),
+    log: createStandardBlockMaterial(textures.log, { roughness: 0.7 }, {
+      tintStrength: 0.75,
+      name: 'LogBiomeMaterial',
+    }),
+    cloud: createStandardBlockMaterial(
+      textures.cloud,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.9,
+        roughness: 0.6,
+        metalness: 0,
+        depthWrite: false,
+      },
+      {
+        tintStrength: 0.4,
+        name: 'CloudBiomeMaterial',
+      },
+    ),
     damageStages,
   };
 }

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -129,14 +129,46 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       instancedData.set(type, []);
     }
     const key = blockKey(x, y, z);
-    const color = engine.getBlockColor(biome, type);
+    const paletteColor = engine.getBlockColor(biome, type);
+    const tintStrength = clamp(biome?.shader?.tintStrength ?? 1, 0, 1);
+
+    const paletteBlend = new THREE.Color(1, 1, 1);
+    if (paletteColor) {
+      paletteBlend.lerp(paletteColor, tintStrength);
+    }
+
+    if (biome?.shader?.tintColor) {
+      const biomeTintBlend = new THREE.Color(1, 1, 1);
+      biomeTintBlend.lerp(biome.shader.tintColor, tintStrength * 0.65);
+      paletteBlend.multiply(biomeTintBlend);
+    }
+
+    if (biome?.climate) {
+      const dryness = clamp(1 - biome.climate.moisture, 0, 1);
+      const climateBlend = new THREE.Color(1, 1, 1);
+      climateBlend.lerp(new THREE.Color(1.02, 0.98, 0.92), dryness * 0.35);
+      paletteBlend.multiply(climateBlend);
+    }
+
+    const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
+    const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
+    const altitudeBlend = new THREE.Color(1, 1, 1);
+    if (altitude > 0) {
+      altitudeBlend.lerp(new THREE.Color(0.95, 0.98, 1.04), altitude * 0.3);
+    } else if (altitude < 0) {
+      altitudeBlend.lerp(new THREE.Color(1.04, 1.01, 0.94), Math.abs(altitude) * 0.25);
+    }
+    paletteBlend.multiply(altitudeBlend);
+
+    const tintColor = paletteBlend;
     const entry = {
       key,
       matrix: matrix.clone(),
       position: new THREE.Vector3(x, y, z),
       type,
       biomeId: biome?.id ?? null,
-      color,
+      paletteColor,
+      tintColor,
       isSolid: solidTypes.has(type),
       isWater: type === 'water',
       destructible: type !== 'water' && type !== 'cloud',
@@ -225,42 +257,38 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     if (entries.length === 0) {
       return;
     }
+    const geometry = blockGeometry.clone();
     const mesh = new THREE.InstancedMesh(
-      blockGeometry,
+      geometry,
       blockMaterials[type],
       entries.length,
     );
-    mesh.userData.defaultColor = engine.getDefaultBlockColor();
+    mesh.userData.defaultTint = new THREE.Color(1, 1, 1);
 
-    const needsNewInstanceColor =
-      !mesh.instanceColor || mesh.instanceColor.count < entries.length;
-    if (needsNewInstanceColor) {
-      const colorArray = new Float32Array(entries.length * 3);
-      mesh.instanceColor = new THREE.InstancedBufferAttribute(colorArray, 3);
-    }
-    mesh.geometry.setAttribute('instanceColor', mesh.instanceColor);
+    const tintArray = new Float32Array(entries.length * 3);
+    const tintAttribute = new THREE.InstancedBufferAttribute(tintArray, 3);
+    tintAttribute.setUsage(THREE.DynamicDrawUsage);
+    mesh.geometry.setAttribute('biomeTint', tintAttribute);
 
     entries.forEach((entry, index) => {
       mesh.setMatrixAt(index, entry.matrix);
       entry.index = index;
-      const color = entry.color ?? engine.getDefaultBlockColor();
-      if (typeof mesh.setColorAt === 'function') {
-        mesh.setColorAt(index, color);
-      } else if (mesh.instanceColor) {
-        mesh.instanceColor.setXYZ(index, color.r, color.g, color.b);
-
-      }
+      const tint = entry.tintColor ?? mesh.userData.defaultTint;
+      const offset = index * 3;
+      tintAttribute.array[offset] = tint.r;
+      tintAttribute.array[offset + 1] = tint.g;
+      tintAttribute.array[offset + 2] = tint.b;
     });
+    mesh.count = entries.length;
     mesh.instanceMatrix.needsUpdate = true;
-    if (mesh.instanceColor) {
-      mesh.instanceColor.needsUpdate = true;
-    }
+    tintAttribute.needsUpdate = true;
     mesh.castShadow = ['cloud', 'water'].includes(type) ? false : true;
     mesh.receiveShadow = type !== 'cloud';
     mesh.frustumCulled = false;
     mesh.userData.type = type;
     mesh.userData.biomePalette = true;
-    typeData.set(type, { entries, mesh });
+    mesh.userData.biomeTintAttribute = tintAttribute;
+    typeData.set(type, { entries, mesh, tintAttribute });
     group.add(mesh);
   });
 


### PR DESCRIPTION
## Summary
- add a biome tint material that injects instanced tint attributes into the standard PBR shader
- drive chunk generation to compute biome-, climate-, and altitude-aware tint colors for every instance and upload them to meshes
- refresh texture material creation and chunk removal so procedurally generated textures stay vibrant while tint attributes stay in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d195d29a90832ab77e46f245d3833b