### PR TITLE
Add in-game developer console with command handling

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -9,6 +9,8 @@ import {
 } from './world/generation.js'
 import { createChunkManager } from './world/chunk-manager.js'
 import { createPlayerControls } from './player/controls.js'
+import { createCommandConsole } from './ui/command-console.js'
+import { registerDeveloperCommands } from './player/dev-commands.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -158,6 +160,31 @@ try {
 
   chunkManager.update(playerControls.getPosition())
   updateHud(playerControls.getState())
+
+  const commandConsole = createCommandConsole({
+    onToggle: (isOpen) => {
+      if (playerControls) {
+        playerControls.setInputEnabled(!isOpen)
+        if (isOpen && playerControls.controls?.isLocked) {
+          try {
+            playerControls.controls.unlock()
+          } catch (error) {
+            console.warn('Failed to release pointer lock for console toggle.', error)
+          }
+        }
+      }
+      if (!isOpen) {
+        renderer.domElement.focus?.()
+      }
+    },
+  })
+
+  registerDeveloperCommands({
+    commandConsole,
+    playerControls,
+  })
+
+  commandConsole.log('Developer console ready. Press ` to toggle. Type /help for commands.')
 } catch (error) {
   initializationError = error instanceof Error ? error : new Error(String(error))
   console.error('Failed to initialize world:', initializationError)

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,0 +1,102 @@
+export function registerDeveloperCommands({
+  commandConsole,
+  playerControls,
+}) {
+  if (!commandConsole) {
+    throw new Error('registerDeveloperCommands requires a commandConsole instance.');
+  }
+  if (!playerControls) {
+    throw new Error('registerDeveloperCommands requires playerControls.');
+  }
+
+  const { registerCommand } = commandConsole;
+
+  registerCommand({
+    name: 'godmode',
+    description: 'Toggle invulnerability to damage.',
+    usage: '/godmode [on|off|1|0|toggle]',
+    handler: ({ args, toggle, success }) => {
+      const next = toggle(args[0], playerControls.isGodModeEnabled());
+      playerControls.setGodModeEnabled(next);
+      success(`God mode ${next ? 'enabled' : 'disabled'}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'fly',
+    description: 'Toggle free-flight movement mode.',
+    usage: '/fly [on|off|1|0|toggle]',
+    handler: ({ args, toggle, success }) => {
+      const next = toggle(args[0], playerControls.isFlightEnabled());
+      playerControls.setFlightEnabled(next);
+      success(`Flight mode ${next ? 'enabled' : 'disabled'}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'unstuck',
+    description: 'Attempt to move the player to the nearest safe location.',
+    usage: '/unstuck',
+    handler: ({ success, warn }) => {
+      const resolved = playerControls.unstuck();
+      if (resolved) {
+        success('Attempted to move you to a nearby safe spot.');
+      } else {
+        warn('Unable to find a safe location. Try enabling flight or reloading.');
+      }
+    },
+  });
+
+  registerCommand({
+    name: 'heal',
+    description: 'Restore health to a specific value (defaults to full).',
+    usage: '/heal [amount]',
+    handler: ({ args, success }) => {
+      const target = args.length > 0 ? args[0] : 100;
+      const value = playerControls.setHealth(target);
+      success(`Health set to ${Math.round(value)}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'oxygen',
+    description: 'Set the current oxygen level.',
+    usage: '/oxygen [amount]',
+    handler: ({ args, success }) => {
+      const target =
+        args.length > 0 ? args[0] : playerControls.getMaxOxygen();
+      const value = playerControls.setOxygen(target);
+      success(`Oxygen set to ${value.toFixed(1)}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'whereami',
+    description: 'Print the current player coordinates.',
+    usage: '/whereami',
+    handler: ({ success }) => {
+      const position = playerControls.getPosition();
+      success(
+        `Position — X: ${position.x.toFixed(2)}, Y: ${position.y.toFixed(
+          2,
+        )}, Z: ${position.z.toFixed(2)}`,
+      );
+    },
+  });
+
+  registerCommand({
+    name: 'status',
+    description: 'Set or clear the HUD status message.',
+    usage: '/status [message]',
+    handler: ({ args, success }) => {
+      if (args.length === 0) {
+        playerControls.clearStatusMessage();
+        success('Cleared status message.');
+        return;
+      }
+      const message = args.join(' ');
+      playerControls.setStatusMessage(message, 5);
+      success('Updated status message.');
+    },
+  });
+}

--- a/three-demo/src/style.css
+++ b/three-demo/src/style.css
@@ -82,6 +82,86 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.command-console {
+  position: fixed;
+  inset: auto 1.5rem 2rem 1.5rem;
+  max-width: 640px;
+  margin: 0 auto;
+  background: rgba(14, 17, 26, 0.88);
+  color: #f5f7ff;
+  border: 1px solid rgba(94, 124, 223, 0.5);
+  border-radius: 8px;
+  box-shadow: 0 18px 38px rgba(8, 11, 19, 0.65);
+  backdrop-filter: blur(6px);
+  font-family: 'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 160ms ease, transform 160ms ease;
+  z-index: 80;
+}
+
+.command-console.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.command-console-log {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 1rem 1rem 0.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.command-console-form {
+  border-top: 1px solid rgba(94, 124, 223, 0.35);
+  padding: 0.65rem 1rem 0.85rem 1rem;
+}
+
+.command-console-input {
+  width: 100%;
+  background: rgba(9, 12, 20, 0.85);
+  border: 1px solid rgba(114, 144, 246, 0.35);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  color: inherit;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.command-console-input:focus {
+  outline: none;
+  border-color: rgba(164, 192, 255, 0.9);
+  box-shadow: 0 0 0 2px rgba(114, 144, 246, 0.25);
+}
+
+.command-console-entry {
+  font-size: 0.9rem;
+  line-height: 1.3;
+  color: rgba(238, 243, 255, 0.92);
+  word-break: break-word;
+}
+
+.command-console-entry.level-success {
+  color: #8de4a8;
+}
+
+.command-console-entry.level-warn {
+  color: #f5d67b;
+}
+
+.command-console-entry.level-error {
+  color: #ff8c8c;
+}
+
+.command-console-entry.level-info {
+  color: rgba(221, 229, 255, 0.92);
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/three-demo/src/ui/command-console.js
+++ b/three-demo/src/ui/command-console.js
@@ -1,0 +1,390 @@
+const DEFAULT_OPTIONS = {
+  openKey: 'Backquote',
+  commandPrefix: '/',
+  historyLimit: 64,
+  logLimit: 200,
+  placeholder: 'Enter command…',
+  onToggle: () => {},
+};
+
+const TRUE_WORDS = new Set(['on', '1', 'true', 'enable', 'enabled', 'yes']);
+const FALSE_WORDS = new Set(['off', '0', 'false', 'disable', 'disabled', 'no']);
+
+function createElement(tag, className) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  return element;
+}
+
+function tokenize(input) {
+  const tokens = [];
+  let current = '';
+  let inQuote = false;
+  let quoteChar = '';
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (inQuote) {
+      if (char === '\\' && i + 1 < input.length) {
+        current += input[i + 1];
+        i += 1;
+        continue;
+      }
+      if (char === quoteChar) {
+        inQuote = false;
+        quoteChar = '';
+        continue;
+      }
+      current += char;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inQuote = true;
+      quoteChar = char;
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    if (char === ' ') {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (inQuote) {
+    throw new Error('Unterminated quote in command input.');
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+function resolveToggleValue(value, current) {
+  if (value === undefined) {
+    return !current;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) {
+    return !current;
+  }
+  if (TRUE_WORDS.has(normalized)) {
+    return true;
+  }
+  if (FALSE_WORDS.has(normalized)) {
+    return false;
+  }
+  if (normalized === 'toggle') {
+    return !current;
+  }
+  throw new Error('Expected ON or OFF (also accepts 1/0, true/false).');
+}
+
+export function createCommandConsole(options = {}) {
+  const settings = { ...DEFAULT_OPTIONS, ...options };
+  const commandMap = new Map();
+  const aliasMap = new Map();
+  const history = [];
+  let historyIndex = -1;
+  let isOpen = false;
+
+  const container = createElement('div', 'command-console hidden');
+  const logElement = createElement('div', 'command-console-log');
+  const form = createElement('form', 'command-console-form');
+  const input = createElement('input', 'command-console-input');
+  input.type = 'text';
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.placeholder = settings.placeholder;
+  form.appendChild(input);
+  container.appendChild(logElement);
+  container.appendChild(form);
+  document.body.appendChild(container);
+
+  function appendLog(message, level = 'info') {
+    const entry = createElement('div', `command-console-entry level-${level}`);
+    entry.textContent = message;
+    logElement.appendChild(entry);
+    while (logElement.children.length > settings.logLimit) {
+      logElement.removeChild(logElement.firstChild);
+    }
+    logElement.scrollTop = logElement.scrollHeight;
+  }
+
+  function clearHistoryNavigation() {
+    historyIndex = -1;
+  }
+
+  function setOpen(next) {
+    if (isOpen === next) {
+      return;
+    }
+    isOpen = next;
+    container.classList.toggle('hidden', !isOpen);
+    container.classList.toggle('visible', isOpen);
+    if (isOpen) {
+      input.value = '';
+      window.setTimeout(() => input.focus(), 0);
+    } else {
+      input.blur();
+      clearHistoryNavigation();
+    }
+    try {
+      settings.onToggle(isOpen);
+    } catch (error) {
+      console.error('Error while handling command console toggle:', error);
+    }
+  }
+
+  function toggleOpen() {
+    setOpen(!isOpen);
+  }
+
+  function normalizeCommandName(name) {
+    return String(name).trim().toLowerCase();
+  }
+
+  function registerCommand(definition) {
+    if (!definition || !definition.name || typeof definition.handler !== 'function') {
+      throw new Error('Invalid command definition. Expected a name and handler.');
+    }
+    const normalized = normalizeCommandName(definition.name);
+    const entry = {
+      ...definition,
+      name: normalized,
+      description: definition.description ?? '',
+      usage: definition.usage ?? `/${normalized}`,
+    };
+    commandMap.set(normalized, entry);
+    if (Array.isArray(definition.aliases)) {
+      definition.aliases.forEach((alias) => {
+        const aliasName = normalizeCommandName(alias);
+        aliasMap.set(aliasName, normalized);
+      });
+    }
+    return () => {
+      commandMap.delete(normalized);
+      if (Array.isArray(definition.aliases)) {
+        definition.aliases.forEach((alias) => {
+          aliasMap.delete(normalizeCommandName(alias));
+        });
+      }
+    };
+  }
+
+  function findCommand(name) {
+    const normalized = normalizeCommandName(name);
+    if (commandMap.has(normalized)) {
+      return commandMap.get(normalized);
+    }
+    const resolved = aliasMap.get(normalized);
+    if (resolved && commandMap.has(resolved)) {
+      return commandMap.get(resolved);
+    }
+    return null;
+  }
+
+  function listCommands() {
+    return Array.from(commandMap.values()).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }
+
+  function executeCommand(rawInput) {
+    const trimmed = rawInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (!trimmed.startsWith(settings.commandPrefix)) {
+      appendLog(`Commands must start with "${settings.commandPrefix}".`, 'error');
+      return;
+    }
+
+    let tokens;
+    try {
+      tokens = tokenize(trimmed.slice(settings.commandPrefix.length));
+    } catch (error) {
+      appendLog(error instanceof Error ? error.message : String(error), 'error');
+      return;
+    }
+
+    if (tokens.length === 0) {
+      appendLog('No command provided.', 'error');
+      return;
+    }
+
+    const [commandName, ...args] = tokens;
+    const command = findCommand(commandName);
+    if (!command) {
+      appendLog(`Unknown command: ${commandName}. Type /help for a list of commands.`, 'error');
+      return;
+    }
+
+    const context = {
+      args,
+      rawInput: trimmed,
+      command,
+      toggle: (value, current) => resolveToggleValue(value, current),
+      print: (message) => appendLog(message, 'info'),
+      info: (message) => appendLog(message, 'info'),
+      success: (message) => appendLog(message, 'success'),
+      warn: (message) => appendLog(message, 'warn'),
+      error: (message) => appendLog(message, 'error'),
+      listCommands,
+      execute: executeCommand,
+    };
+
+    try {
+      const result = command.handler(context);
+      if (typeof result === 'string' && result.trim()) {
+        appendLog(result, 'success');
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Command execution failed.';
+      appendLog(message, 'error');
+      console.error(`Command "${command.name}" failed:`, error);
+    }
+  }
+
+  function handleDocumentKeydown(event) {
+    if (event.code === settings.openKey && !event.repeat) {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        // Allow typing the character in other fields.
+        return;
+      }
+      event.preventDefault();
+      toggleOpen();
+      return;
+    }
+    if (isOpen && event.code === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  }
+
+  function handleFormSubmit(event) {
+    event.preventDefault();
+    const value = input.value;
+    setOpen(false);
+    if (value.trim()) {
+      history.unshift(value);
+      if (history.length > settings.historyLimit) {
+        history.length = settings.historyLimit;
+      }
+      executeCommand(value);
+    }
+    input.value = '';
+  }
+
+  function handleInputKeydown(event) {
+    if (event.code === settings.openKey && !event.repeat) {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.code === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.code === 'ArrowUp') {
+      event.preventDefault();
+      if (history.length === 0) {
+        return;
+      }
+      if (historyIndex + 1 < history.length) {
+        historyIndex += 1;
+      }
+      input.value = history[historyIndex] ?? '';
+      window.setTimeout(() => input.setSelectionRange(input.value.length, input.value.length), 0);
+      return;
+    }
+    if (event.code === 'ArrowDown') {
+      event.preventDefault();
+      if (historyIndex > 0) {
+        historyIndex -= 1;
+      } else {
+        historyIndex = -1;
+      }
+      input.value = historyIndex === -1 ? '' : history[historyIndex];
+      window.setTimeout(() => input.setSelectionRange(input.value.length, input.value.length), 0);
+    }
+  }
+
+  document.addEventListener('keydown', handleDocumentKeydown);
+  form.addEventListener('submit', handleFormSubmit);
+  input.addEventListener('keydown', handleInputKeydown);
+
+  const dispose = () => {
+    document.removeEventListener('keydown', handleDocumentKeydown);
+    form.removeEventListener('submit', handleFormSubmit);
+    input.removeEventListener('keydown', handleInputKeydown);
+    container.remove();
+  };
+
+  registerCommand({
+    name: 'help',
+    description: 'List available commands or get help for a specific command.',
+    usage: '/help [command]',
+    handler: ({ args, info }) => {
+      if (args.length === 0) {
+        const entries = listCommands();
+        if (entries.length === 0) {
+          info('No commands registered.');
+          return;
+        }
+        info('Available commands:');
+        entries.forEach((entry) => {
+          info(`/${entry.name} — ${entry.description || 'No description provided.'}`);
+        });
+        info('Use /help <command> for details about a specific command.');
+        return;
+      }
+
+      const targetName = args[0];
+      const entry = findCommand(targetName);
+      if (!entry) {
+        throw new Error(`No command named "${targetName}".`);
+      }
+      info(`/${entry.name}`);
+      if (entry.description) {
+        info(entry.description);
+      }
+      if (entry.usage) {
+        info(`Usage: ${entry.usage}`);
+      }
+    },
+  });
+
+  return {
+    registerCommand,
+    registerCommands: (commands) => commands.forEach(registerCommand),
+    executeCommand,
+    open: () => setOpen(true),
+    close: () => setOpen(false),
+    isOpen: () => isOpen,
+    dispose,
+    log: appendLog,
+  };
+}
+
+export const CommandConsoleUtils = {
+  tokenize,
+  resolveToggleValue,
+};


### PR DESCRIPTION
## Summary
- add a reusable in-game command console UI with history, help, and robust parsing
- extend player controls with toggleable god mode, flight, input gating, and health/oxygen setters for dev commands
- register developer commands (godmode, fly, unstuck, heal, oxygen, whereami, status) and style the console overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b56e3c14832aaa4bc9d6f4f7b5c6