### PR TITLE
Refine developer console experience

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -9,6 +9,8 @@ import {
 } from './world/generation.js'
 import { createChunkManager } from './world/chunk-manager.js'
 import { createPlayerControls } from './player/controls.js'
+import { createCommandConsole } from './ui/command-console.js'
+import { registerDeveloperCommands } from './player/dev-commands.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -158,6 +160,33 @@ try {
 
   chunkManager.update(playerControls.getPosition())
   updateHud(playerControls.getState())
+
+  const commandConsole = createCommandConsole({
+    onToggle: (isOpen) => {
+      if (playerControls) {
+        playerControls.setInputEnabled(!isOpen)
+        if (isOpen && playerControls.controls?.isLocked) {
+          try {
+            playerControls.controls.unlock()
+          } catch (error) {
+            console.warn('Failed to release pointer lock for console toggle.', error)
+          }
+        }
+      }
+      if (!isOpen) {
+        renderer.domElement.focus?.()
+      }
+    },
+  })
+
+  registerDeveloperCommands({
+    commandConsole,
+    playerControls,
+  })
+
+  commandConsole.log(
+    'Developer console ready. Press ` to open and Esc to close. Type /help for commands.',
+  )
 } catch (error) {
   initializationError = error instanceof Error ? error : new Error(String(error))
   console.error('Failed to initialize world:', initializationError)

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -68,6 +68,18 @@ export function createPlayerControls({
     sprint: false,
   };
 
+  const flyState = {
+    ascend: false,
+    descend: false,
+  };
+
+  let inputEnabled = true;
+
+  const cheatState = {
+    godMode: false,
+    flightEnabled: false,
+  };
+
   const cameraForward = new THREE.Vector3();
   const cameraRight = new THREE.Vector3();
   const cameraUp = new THREE.Vector3(0, 1, 0);
@@ -197,6 +209,9 @@ export function createPlayerControls({
   }
 
   function applyDamage(amount, message) {
+    if (cheatState.godMode) {
+      return;
+    }
     if (amount <= 0) {
       return;
     }
@@ -389,6 +404,9 @@ export function createPlayerControls({
   initializeSpawn();
 
   const onKeyDown = (event) => {
+    if (!inputEnabled) {
+      return;
+    }
     switch (event.code) {
       case 'KeyW':
       case 'ArrowUp':
@@ -407,11 +425,25 @@ export function createPlayerControls({
         moveState.right = true;
         break;
       case 'Space':
-        jumpRequested = true;
+        if (cheatState.flightEnabled) {
+          flyState.ascend = true;
+        } else {
+          jumpRequested = true;
+        }
         break;
       case 'ShiftLeft':
       case 'ShiftRight':
-        moveState.sprint = true;
+        if (cheatState.flightEnabled) {
+          flyState.descend = true;
+        } else {
+          moveState.sprint = true;
+        }
+        break;
+      case 'ControlLeft':
+      case 'ControlRight':
+        if (cheatState.flightEnabled) {
+          flyState.descend = true;
+        }
         break;
       default:
         break;
@@ -419,6 +451,9 @@ export function createPlayerControls({
   };
 
   const onKeyUp = (event) => {
+    if (!inputEnabled) {
+      return;
+    }
     switch (event.code) {
       case 'KeyW':
       case 'ArrowUp':
@@ -436,9 +471,24 @@ export function createPlayerControls({
       case 'ArrowRight':
         moveState.right = false;
         break;
+      case 'Space':
+        if (cheatState.flightEnabled) {
+          flyState.ascend = false;
+        }
+        break;
       case 'ShiftLeft':
       case 'ShiftRight':
-        moveState.sprint = false;
+        if (cheatState.flightEnabled) {
+          flyState.descend = false;
+        } else {
+          moveState.sprint = false;
+        }
+        break;
+      case 'ControlLeft':
+      case 'ControlRight':
+        if (cheatState.flightEnabled) {
+          flyState.descend = false;
+        }
         break;
       default:
         break;
@@ -508,6 +558,9 @@ export function createPlayerControls({
   }
 
   function handlePointerDown(event) {
+    if (!inputEnabled) {
+      return;
+    }
     if (controls.isLocked) {
       if (event.button === 0) {
         attackState.swinging = true;
@@ -828,9 +881,17 @@ export function createPlayerControls({
         movementStep.normalize();
       }
 
-      const baseSpeed = 5.2;
-      const sprintBonus = sprint && forward && !feetInWater ? 3.2 : 0;
-      const mediumPenalty = feetInWater ? 0.42 : inSoftMedium ? 0.7 : 1;
+      const flightActive = cheatState.flightEnabled;
+      const baseSpeed = flightActive ? 14 : 5.2;
+      const sprintBonus =
+        !flightActive && sprint && forward && !feetInWater ? 3.2 : 0;
+      const mediumPenalty = flightActive
+        ? 1
+        : feetInWater
+        ? 0.42
+        : inSoftMedium
+        ? 0.7
+        : 1;
       const moveSpeed = (baseSpeed + sprintBonus) * mediumPenalty;
       movementStep.multiplyScalar(moveSpeed * delta);
 
@@ -859,74 +920,89 @@ export function createPlayerControls({
       }
     }
 
-    const standingSurface = findStandingSurface(position);
-    const supportTargetY = standingSurface
-      ? standingSurface.height + playerEyeHeight
-      : Number.NEGATIVE_INFINITY;
-    const waterTarget =
-      worldConfig.waterLevel + 0.5 + playerEyeHeight - 0.2;
-    let targetY = supportTargetY;
-    if (!feetInWater && inWaterColumn) {
-      targetY = Math.max(targetY, waterTarget);
-    }
-
-    if (jumpRequested) {
-
-      const nearGround =
-        Number.isFinite(supportTargetY) &&
-        position.y <= supportTargetY + nearGroundThreshold;
-
-      if (isGrounded || nearGround) {
-        verticalVelocity = jumpVelocity;
-        isGrounded = false;
-      } else if (feetInWater) {
-        verticalVelocity = Math.max(verticalVelocity, 4.6);
+    if (cheatState.flightEnabled) {
+      const verticalDirection =
+        Number(flyState.ascend) - Number(flyState.descend);
+      if (verticalDirection !== 0) {
+        attemptPosition.copy(position);
+        attemptPosition.y += verticalDirection * 18 * delta;
+        if (!collidesAt(attemptPosition)) {
+          position.copy(attemptPosition);
+        }
       }
-    }
-    jumpRequested = false;
-
-    const effectiveGravity = feetInWater ? gravity * 0.35 : gravity;
-    verticalVelocity -= effectiveGravity * delta;
-    if (feetInWater) {
-      const submersion = THREE.MathUtils.clamp(waterSurface - feetY, 0, 6);
-      const buoyancy = submersion * 2.4;
-      verticalVelocity += buoyancy * delta;
-      verticalVelocity *= 0.82;
-      if (sprint && !isGrounded) {
-        verticalVelocity -= 4.2 * delta;
-      }
-    }
-
-    const previousY = position.y;
-    position.y += verticalVelocity * delta;
-
-    if (collidesAt(position) && verticalVelocity > 0) {
-      position.y = previousY;
       verticalVelocity = 0;
-    }
-
-    if (verticalVelocity < maxDownwardSpeed) {
-      maxDownwardSpeed = verticalVelocity;
-    }
-
-    if (Number.isFinite(targetY) && position.y <= targetY) {
-      const landedOnSupport =
-        Number.isFinite(supportTargetY) &&
-        position.y <= supportTargetY + 1e-3;
-      if (
-        landedOnSupport &&
-        !feetInWater &&
-        maxDownwardSpeed < -12
-      ) {
-        const impact = Math.abs(maxDownwardSpeed) - 10;
-        applyDamage(impact * 4.5, 'You hit the ground hard.');
-      }
-      position.y = landedOnSupport ? supportTargetY : targetY;
-      verticalVelocity = 0;
-      maxDownwardSpeed = 0;
-      isGrounded = landedOnSupport;
-    } else {
+      maxDownwardSpeed = Math.min(maxDownwardSpeed, 0);
       isGrounded = false;
+      jumpRequested = false;
+    } else {
+      const standingSurface = findStandingSurface(position);
+      const supportTargetY = standingSurface
+        ? standingSurface.height + playerEyeHeight
+        : Number.NEGATIVE_INFINITY;
+      const waterTarget =
+        worldConfig.waterLevel + 0.5 + playerEyeHeight - 0.2;
+      let targetY = supportTargetY;
+      if (!feetInWater && inWaterColumn) {
+        targetY = Math.max(targetY, waterTarget);
+      }
+
+      if (jumpRequested) {
+        const nearGround =
+          Number.isFinite(supportTargetY) &&
+          position.y <= supportTargetY + nearGroundThreshold;
+
+        if (isGrounded || nearGround) {
+          verticalVelocity = jumpVelocity;
+          isGrounded = false;
+        } else if (feetInWater) {
+          verticalVelocity = Math.max(verticalVelocity, 4.6);
+        }
+      }
+      jumpRequested = false;
+
+      const effectiveGravity = feetInWater ? gravity * 0.35 : gravity;
+      verticalVelocity -= effectiveGravity * delta;
+      if (feetInWater) {
+        const submersion = THREE.MathUtils.clamp(waterSurface - feetY, 0, 6);
+        const buoyancy = submersion * 2.4;
+        verticalVelocity += buoyancy * delta;
+        verticalVelocity *= 0.82;
+        if (sprint && !isGrounded) {
+          verticalVelocity -= 4.2 * delta;
+        }
+      }
+
+      const previousY = position.y;
+      position.y += verticalVelocity * delta;
+
+      if (collidesAt(position) && verticalVelocity > 0) {
+        position.y = previousY;
+        verticalVelocity = 0;
+      }
+
+      if (verticalVelocity < maxDownwardSpeed) {
+        maxDownwardSpeed = verticalVelocity;
+      }
+
+      if (Number.isFinite(targetY) && position.y <= targetY) {
+        const landedOnSupport =
+          Number.isFinite(supportTargetY) &&
+          position.y <= supportTargetY + 1e-3;
+        if (
+          landedOnSupport &&
+          !feetInWater &&
+          maxDownwardSpeed < -12
+        ) {
+          const impact = Math.abs(maxDownwardSpeed) - 10;
+          applyDamage(impact * 4.5, 'You hit the ground hard.');
+        }
+        position.y = landedOnSupport ? supportTargetY : targetY;
+        verticalVelocity = 0;
+        maxDownwardSpeed = 0;
+        isGrounded = landedOnSupport;
+      } else {
+        isGrounded = false;
+      }
     }
 
     if (statusTimer > 0) {
@@ -1037,6 +1113,100 @@ export function createPlayerControls({
     }
   }
 
+  function setInputEnabled(enabled) {
+    const next = Boolean(enabled);
+    if (inputEnabled === next) {
+      return;
+    }
+    inputEnabled = next;
+    if (!inputEnabled) {
+      moveState.forward = false;
+      moveState.backward = false;
+      moveState.left = false;
+      moveState.right = false;
+      moveState.sprint = false;
+      flyState.ascend = false;
+      flyState.descend = false;
+      jumpRequested = false;
+      stopAttack();
+    }
+  }
+
+  function setGodModeEnabled(enabled) {
+    cheatState.godMode = Boolean(enabled);
+    return cheatState.godMode;
+  }
+
+  function isGodModeEnabled() {
+    return cheatState.godMode;
+  }
+
+  function setFlightEnabled(enabled) {
+    const next = Boolean(enabled);
+    if (cheatState.flightEnabled === next) {
+      return cheatState.flightEnabled;
+    }
+    cheatState.flightEnabled = next;
+    if (next) {
+      jumpRequested = false;
+      moveState.sprint = false;
+      verticalVelocity = 0;
+      maxDownwardSpeed = Math.min(maxDownwardSpeed, 0);
+    } else {
+      flyState.ascend = false;
+      flyState.descend = false;
+    }
+    return cheatState.flightEnabled;
+  }
+
+  function isFlightEnabled() {
+    return cheatState.flightEnabled;
+  }
+
+  function unstuck() {
+    return attemptCollisionRescue('command');
+  }
+
+  function setHealth(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      throw new Error('Health value must be a finite number.');
+    }
+    const clamped = THREE.MathUtils.clamp(numeric, 0, 100);
+    if (playerState.health !== clamped) {
+      playerState.health = clamped;
+      markStateDirty();
+      pushState();
+    }
+    return playerState.health;
+  }
+
+  function setOxygen(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      throw new Error('Oxygen value must be a finite number.');
+    }
+    const clamped = THREE.MathUtils.clamp(numeric, 0, playerState.maxOxygen);
+    if (playerState.oxygen !== clamped) {
+      playerState.oxygen = clamped;
+      markStateDirty();
+      pushState();
+    }
+    return playerState.oxygen;
+  }
+
+  function getMaxOxygen() {
+    return playerState.maxOxygen;
+  }
+
+  function setStatusMessage(message, duration = 2.2) {
+    setStatus(message, duration);
+  }
+
+  function clearStatusMessage() {
+    clearStatus();
+  }
+
   function dispose() {
     scene.remove(controlObject);
     overlay?.removeEventListener('click', handleOverlayClick);
@@ -1063,5 +1233,24 @@ export function createPlayerControls({
     return { ...playerState };
   }
 
-  return { controls, moveState, collidesAt, update, dispose, getPosition, getState };
+  return {
+    controls,
+    moveState,
+    collidesAt,
+    update,
+    dispose,
+    getPosition,
+    getState,
+    setInputEnabled,
+    setGodModeEnabled,
+    isGodModeEnabled,
+    setFlightEnabled,
+    isFlightEnabled,
+    unstuck,
+    setHealth,
+    setOxygen,
+    getMaxOxygen,
+    setStatusMessage,
+    clearStatusMessage,
+  };
 }

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,0 +1,102 @@
+export function registerDeveloperCommands({
+  commandConsole,
+  playerControls,
+}) {
+  if (!commandConsole) {
+    throw new Error('registerDeveloperCommands requires a commandConsole instance.');
+  }
+  if (!playerControls) {
+    throw new Error('registerDeveloperCommands requires playerControls.');
+  }
+
+  const { registerCommand } = commandConsole;
+
+  registerCommand({
+    name: 'godmode',
+    description: 'Toggle invulnerability to damage.',
+    usage: '/godmode [on|off|1|0|toggle]',
+    handler: ({ args, toggle, success }) => {
+      const next = toggle(args[0], playerControls.isGodModeEnabled());
+      playerControls.setGodModeEnabled(next);
+      success(`God mode ${next ? 'enabled' : 'disabled'}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'fly',
+    description: 'Toggle free-flight movement mode.',
+    usage: '/fly [on|off|1|0|toggle]',
+    handler: ({ args, toggle, success }) => {
+      const next = toggle(args[0], playerControls.isFlightEnabled());
+      playerControls.setFlightEnabled(next);
+      success(`Flight mode ${next ? 'enabled' : 'disabled'}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'unstuck',
+    description: 'Attempt to move the player to the nearest safe location.',
+    usage: '/unstuck',
+    handler: ({ success, warn }) => {
+      const resolved = playerControls.unstuck();
+      if (resolved) {
+        success('Attempted to move you to a nearby safe spot.');
+      } else {
+        warn('Unable to find a safe location. Try enabling flight or reloading.');
+      }
+    },
+  });
+
+  registerCommand({
+    name: 'heal',
+    description: 'Restore health to a specific value (defaults to full).',
+    usage: '/heal [amount]',
+    handler: ({ args, success }) => {
+      const target = args.length > 0 ? args[0] : 100;
+      const value = playerControls.setHealth(target);
+      success(`Health set to ${Math.round(value)}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'oxygen',
+    description: 'Set the current oxygen level.',
+    usage: '/oxygen [amount]',
+    handler: ({ args, success }) => {
+      const target =
+        args.length > 0 ? args[0] : playerControls.getMaxOxygen();
+      const value = playerControls.setOxygen(target);
+      success(`Oxygen set to ${value.toFixed(1)}.`);
+    },
+  });
+
+  registerCommand({
+    name: 'whereami',
+    description: 'Print the current player coordinates.',
+    usage: '/whereami',
+    handler: ({ success }) => {
+      const position = playerControls.getPosition();
+      success(
+        `Position — X: ${position.x.toFixed(2)}, Y: ${position.y.toFixed(
+          2,
+        )}, Z: ${position.z.toFixed(2)}`,
+      );
+    },
+  });
+
+  registerCommand({
+    name: 'status',
+    description: 'Set or clear the HUD status message.',
+    usage: '/status [message]',
+    handler: ({ args, success }) => {
+      if (args.length === 0) {
+        playerControls.clearStatusMessage();
+        success('Cleared status message.');
+        return;
+      }
+      const message = args.join(' ');
+      playerControls.setStatusMessage(message, 5);
+      success('Updated status message.');
+    },
+  });
+}

--- a/three-demo/src/style.css
+++ b/three-demo/src/style.css
@@ -82,6 +82,87 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.command-console {
+  position: fixed;
+  top: 8vh;
+  left: 50%;
+  width: min(720px, calc(100% - 4rem));
+  transform: translate(-50%, -12px);
+  background: rgba(8, 10, 15, 0.72);
+  color: rgba(238, 243, 255, 0.9);
+  border: 1px solid rgba(160, 182, 255, 0.18);
+  border-radius: 10px;
+  box-shadow: 0 14px 48px rgba(6, 8, 12, 0.35);
+  backdrop-filter: blur(4px);
+  font-family: 'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 200ms ease;
+  z-index: 80;
+}
+
+.command-console.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+
+.command-console-log {
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 0.85rem 1rem 0.6rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.command-console-form {
+  border-top: 1px solid rgba(160, 182, 255, 0.14);
+  padding: 0.6rem 1rem 0.85rem 1rem;
+}
+
+.command-console-input {
+  width: 100%;
+  background: rgba(10, 12, 18, 0.78);
+  border: 1px solid rgba(170, 190, 255, 0.28);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  color: inherit;
+  font-size: 0.92rem;
+  font-family: inherit;
+}
+
+.command-console-input:focus {
+  outline: none;
+  border-color: rgba(206, 220, 255, 0.68);
+  box-shadow: 0 0 0 2px rgba(160, 182, 255, 0.24);
+}
+
+.command-console-entry {
+  font-size: 0.86rem;
+  line-height: 1.35;
+  color: rgba(224, 233, 255, 0.86);
+  word-break: break-word;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+}
+
+.command-console-entry.level-success {
+  color: #9feab8;
+}
+
+.command-console-entry.level-warn {
+  color: #f8d27a;
+}
+
+.command-console-entry.level-error {
+  color: #ff9a9a;
+}
+
+.command-console-entry.level-info {
+  color: rgba(224, 233, 255, 0.86);
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/three-demo/src/ui/command-console.js
+++ b/three-demo/src/ui/command-console.js
@@ -1,0 +1,390 @@
+const DEFAULT_OPTIONS = {
+  openKey: 'Backquote',
+  commandPrefix: '/',
+  historyLimit: 64,
+  logLimit: 200,
+  placeholder: 'Enter command…',
+  onToggle: () => {},
+};
+
+const TRUE_WORDS = new Set(['on', '1', 'true', 'enable', 'enabled', 'yes']);
+const FALSE_WORDS = new Set(['off', '0', 'false', 'disable', 'disabled', 'no']);
+
+function createElement(tag, className) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  return element;
+}
+
+function tokenize(input) {
+  const tokens = [];
+  let current = '';
+  let inQuote = false;
+  let quoteChar = '';
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (inQuote) {
+      if (char === '\\' && i + 1 < input.length) {
+        current += input[i + 1];
+        i += 1;
+        continue;
+      }
+      if (char === quoteChar) {
+        inQuote = false;
+        quoteChar = '';
+        continue;
+      }
+      current += char;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inQuote = true;
+      quoteChar = char;
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    if (char === ' ') {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (inQuote) {
+    throw new Error('Unterminated quote in command input.');
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+function resolveToggleValue(value, current) {
+  if (value === undefined) {
+    return !current;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) {
+    return !current;
+  }
+  if (TRUE_WORDS.has(normalized)) {
+    return true;
+  }
+  if (FALSE_WORDS.has(normalized)) {
+    return false;
+  }
+  if (normalized === 'toggle') {
+    return !current;
+  }
+  throw new Error('Expected ON or OFF (also accepts 1/0, true/false).');
+}
+
+export function createCommandConsole(options = {}) {
+  const settings = { ...DEFAULT_OPTIONS, ...options };
+  const commandMap = new Map();
+  const aliasMap = new Map();
+  const history = [];
+  let historyIndex = -1;
+  let isOpen = false;
+
+  const container = createElement('div', 'command-console hidden');
+  const logElement = createElement('div', 'command-console-log');
+  const form = createElement('form', 'command-console-form');
+  const input = createElement('input', 'command-console-input');
+  input.type = 'text';
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.placeholder = settings.placeholder;
+  form.appendChild(input);
+  container.appendChild(logElement);
+  container.appendChild(form);
+  document.body.appendChild(container);
+
+  function appendLog(message, level = 'info') {
+    const entry = createElement('div', `command-console-entry level-${level}`);
+    entry.textContent = message;
+    logElement.appendChild(entry);
+    while (logElement.children.length > settings.logLimit) {
+      logElement.removeChild(logElement.firstChild);
+    }
+    logElement.scrollTop = logElement.scrollHeight;
+  }
+
+  function clearHistoryNavigation() {
+    historyIndex = -1;
+  }
+
+  function setOpen(next) {
+    if (isOpen === next) {
+      return;
+    }
+    isOpen = next;
+    container.classList.toggle('hidden', !isOpen);
+    container.classList.toggle('visible', isOpen);
+    if (isOpen) {
+      input.value = '';
+      window.setTimeout(() => input.focus(), 0);
+    } else {
+      input.blur();
+      clearHistoryNavigation();
+    }
+    try {
+      settings.onToggle(isOpen);
+    } catch (error) {
+      console.error('Error while handling command console toggle:', error);
+    }
+  }
+
+  function toggleOpen() {
+    setOpen(!isOpen);
+  }
+
+  function normalizeCommandName(name) {
+    return String(name).trim().toLowerCase();
+  }
+
+  function registerCommand(definition) {
+    if (!definition || !definition.name || typeof definition.handler !== 'function') {
+      throw new Error('Invalid command definition. Expected a name and handler.');
+    }
+    const normalized = normalizeCommandName(definition.name);
+    const entry = {
+      ...definition,
+      name: normalized,
+      description: definition.description ?? '',
+      usage: definition.usage ?? `/${normalized}`,
+    };
+    commandMap.set(normalized, entry);
+    if (Array.isArray(definition.aliases)) {
+      definition.aliases.forEach((alias) => {
+        const aliasName = normalizeCommandName(alias);
+        aliasMap.set(aliasName, normalized);
+      });
+    }
+    return () => {
+      commandMap.delete(normalized);
+      if (Array.isArray(definition.aliases)) {
+        definition.aliases.forEach((alias) => {
+          aliasMap.delete(normalizeCommandName(alias));
+        });
+      }
+    };
+  }
+
+  function findCommand(name) {
+    const normalized = normalizeCommandName(name);
+    if (commandMap.has(normalized)) {
+      return commandMap.get(normalized);
+    }
+    const resolved = aliasMap.get(normalized);
+    if (resolved && commandMap.has(resolved)) {
+      return commandMap.get(resolved);
+    }
+    return null;
+  }
+
+  function listCommands() {
+    return Array.from(commandMap.values()).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }
+
+  function executeCommand(rawInput) {
+    const trimmed = rawInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (!trimmed.startsWith(settings.commandPrefix)) {
+      appendLog(`Commands must start with "${settings.commandPrefix}".`, 'error');
+      return;
+    }
+
+    let tokens;
+    try {
+      tokens = tokenize(trimmed.slice(settings.commandPrefix.length));
+    } catch (error) {
+      appendLog(error instanceof Error ? error.message : String(error), 'error');
+      return;
+    }
+
+    if (tokens.length === 0) {
+      appendLog('No command provided.', 'error');
+      return;
+    }
+
+    const [commandName, ...args] = tokens;
+    const command = findCommand(commandName);
+    if (!command) {
+      appendLog(`Unknown command: ${commandName}. Type /help for a list of commands.`, 'error');
+      return;
+    }
+
+    const context = {
+      args,
+      rawInput: trimmed,
+      command,
+      toggle: (value, current) => resolveToggleValue(value, current),
+      print: (message) => appendLog(message, 'info'),
+      info: (message) => appendLog(message, 'info'),
+      success: (message) => appendLog(message, 'success'),
+      warn: (message) => appendLog(message, 'warn'),
+      error: (message) => appendLog(message, 'error'),
+      listCommands,
+      execute: executeCommand,
+    };
+
+    try {
+      const result = command.handler(context);
+      if (typeof result === 'string' && result.trim()) {
+        appendLog(result, 'success');
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Command execution failed.';
+      appendLog(message, 'error');
+      console.error(`Command "${command.name}" failed:`, error);
+    }
+  }
+
+  function handleDocumentKeydown(event) {
+    if (event.code === settings.openKey && !event.repeat) {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        if (!isOpen) {
+          // Allow typing the character in other fields when the console is closed.
+          return;
+        }
+        // When the console is focused, let the key press type normally without
+        // toggling the overlay.
+        return;
+      }
+      event.preventDefault();
+      toggleOpen();
+      return;
+    }
+    if (isOpen && event.code === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  }
+
+  function handleFormSubmit(event) {
+    event.preventDefault();
+    const value = input.value;
+    setOpen(false);
+    if (value.trim()) {
+      history.unshift(value);
+      if (history.length > settings.historyLimit) {
+        history.length = settings.historyLimit;
+      }
+      executeCommand(value);
+    }
+    input.value = '';
+  }
+
+  function handleInputKeydown(event) {
+    if (event.code === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.code === 'ArrowUp') {
+      event.preventDefault();
+      if (history.length === 0) {
+        return;
+      }
+      if (historyIndex + 1 < history.length) {
+        historyIndex += 1;
+      }
+      input.value = history[historyIndex] ?? '';
+      window.setTimeout(() => input.setSelectionRange(input.value.length, input.value.length), 0);
+      return;
+    }
+    if (event.code === 'ArrowDown') {
+      event.preventDefault();
+      if (historyIndex > 0) {
+        historyIndex -= 1;
+      } else {
+        historyIndex = -1;
+      }
+      input.value = historyIndex === -1 ? '' : history[historyIndex];
+      window.setTimeout(() => input.setSelectionRange(input.value.length, input.value.length), 0);
+    }
+  }
+
+  document.addEventListener('keydown', handleDocumentKeydown);
+  form.addEventListener('submit', handleFormSubmit);
+  input.addEventListener('keydown', handleInputKeydown);
+
+  const dispose = () => {
+    document.removeEventListener('keydown', handleDocumentKeydown);
+    form.removeEventListener('submit', handleFormSubmit);
+    input.removeEventListener('keydown', handleInputKeydown);
+    container.remove();
+  };
+
+  registerCommand({
+    name: 'help',
+    description: 'List available commands or get help for a specific command.',
+    usage: '/help [command]',
+    handler: ({ args, info }) => {
+      if (args.length === 0) {
+        const entries = listCommands();
+        if (entries.length === 0) {
+          info('No commands registered.');
+          return;
+        }
+        info('Available commands:');
+        entries.forEach((entry) => {
+          info(`/${entry.name} — ${entry.description || 'No description provided.'}`);
+        });
+        info('Use /help <command> for details about a specific command.');
+        return;
+      }
+
+      const targetName = args[0];
+      const entry = findCommand(targetName);
+      if (!entry) {
+        throw new Error(`No command named "${targetName}".`);
+      }
+      info(`/${entry.name}`);
+      if (entry.description) {
+        info(entry.description);
+      }
+      if (entry.usage) {
+        info(`Usage: ${entry.usage}`);
+      }
+    },
+  });
+
+  return {
+    registerCommand,
+    registerCommands: (commands) => commands.forEach(registerCommand),
+    executeCommand,
+    open: () => setOpen(true),
+    close: () => setOpen(false),
+    isOpen: () => isOpen,
+    dispose,
+    log: appendLog,
+  };
+}
+
+export const CommandConsoleUtils = {
+  tokenize,
+  resolveToggleValue,
+};


### PR DESCRIPTION
## Summary
- restyle the developer console overlay for a lighter, top-of-screen presentation and updated messaging in `main.js`
- adjust console keyboard handling so Backquote only opens it and Escape cleanly closes it without interfering with typing
- double the horizontal and vertical flight speeds for the cheat flight mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b56e3c14832aaa4bc9d6f4f7b5c6