### PR TITLE
Fix voxel object anchoring and report biome in /whereami

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,3 +1,5 @@
+import { sampleBiomeAt } from '../world/generation.js';
+
 export function registerDeveloperCommands({
   commandConsole,
   playerControls,
@@ -76,10 +78,14 @@ export function registerDeveloperCommands({
     usage: '/whereami',
     handler: ({ success }) => {
       const position = playerControls.getPosition();
+      const biomeSample = sampleBiomeAt(Math.round(position.x), Math.round(position.z));
+      const biomeLabel = biomeSample?.biome?.label ?? 'Unknown biome';
+      const biomeId = biomeSample?.biome?.id;
+      const biomeDescription = biomeId ? `${biomeLabel} [${biomeId}]` : biomeLabel;
       success(
         `Position — X: ${position.x.toFixed(2)}, Y: ${position.y.toFixed(
           2,
-        )}, Z: ${position.z.toFixed(2)}`,
+        )}, Z: ${position.z.toFixed(2)} | Biome: ${biomeDescription}`,
       );
     },
   });

--- a/three-demo/src/world/voxel-object-library.js
+++ b/three-demo/src/world/voxel-object-library.js
@@ -51,16 +51,19 @@ function computeBoundingBox(voxels, voxelScale) {
 
   voxels.forEach((voxel) => {
     const { position, size } = voxel;
-    const halfX = (size.x ?? 1) / 2;
-    const halfY = (size.y ?? 1) / 2;
-    const halfZ = (size.z ?? 1) / 2;
+    const sizeX = size.x ?? 1;
+    const sizeY = size.y ?? 1;
+    const sizeZ = size.z ?? 1;
+    const halfX = sizeX / 2;
+    const halfZ = sizeZ / 2;
 
     const minLocalX = (position.x - halfX) * voxelScale;
-    const minLocalY = (position.y - halfY) * voxelScale;
-    const minLocalZ = (position.z - halfZ) * voxelScale;
     const maxLocalX = (position.x + halfX) * voxelScale;
-    const maxLocalY = (position.y + halfY) * voxelScale;
+    const minLocalZ = (position.z - halfZ) * voxelScale;
     const maxLocalZ = (position.z + halfZ) * voxelScale;
+
+    const minLocalY = position.y * voxelScale;
+    const maxLocalY = (position.y + sizeY) * voxelScale;
 
     minX = Math.min(minX, minLocalX);
     minY = Math.min(minY, minLocalY);

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -36,15 +36,21 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
     return;
   }
   const base = origin ?? { x: 0, y: 0, z: 0 };
+  const groundAnchorOffset = object.attachment?.groundOffset ?? object.voxelScale;
+  const anchor = {
+    x: base.x,
+    y: base.y - groundAnchorOffset,
+    z: base.z,
+  };
 
   const defaultSolidOverride = object.voxelScale < 1;
 
 
   object.voxels.forEach((voxel) => {
     const scale = resolveScaleVector(voxel, object.voxelScale);
-    const worldX = base.x + voxel.position.x * object.voxelScale;
-    const worldY = base.y + voxel.position.y * object.voxelScale;
-    const worldZ = base.z + voxel.position.z * object.voxelScale;
+    const worldX = anchor.x + voxel.position.x * object.voxelScale;
+    const worldY = anchor.y + voxel.position.y * object.voxelScale + scale.y / 2;
+    const worldZ = anchor.z + voxel.position.z * object.voxelScale;
 
     const collisionMode = resolveCollisionMode(voxel, object);
 


### PR DESCRIPTION
## Summary
- Anchor voxel object placement to the ground so stacked shapes render without gaps
- Update voxel object bounding-box math to match the new bottom-aligned Y semantics
- Extend /whereami to display the player's current biome label and id

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ce83581c832a8db1ca48250f70be