### PR TITLE
Add procedural node growth for minivoxel flora

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,3 +1,5 @@
+import { sampleBiomeAt } from '../world/generation.js';
+
 export function registerDeveloperCommands({
   commandConsole,
   playerControls,
@@ -76,10 +78,14 @@ export function registerDeveloperCommands({
     usage: '/whereami',
     handler: ({ success }) => {
       const position = playerControls.getPosition();
+      const biomeSample = sampleBiomeAt(Math.round(position.x), Math.round(position.z));
+      const biomeLabel = biomeSample?.biome?.label ?? 'Unknown biome';
+      const biomeId = biomeSample?.biome?.id;
+      const biomeDescription = biomeId ? `${biomeLabel} [${biomeId}]` : biomeLabel;
       success(
         `Position — X: ${position.x.toFixed(2)}, Y: ${position.y.toFixed(
           2,
-        )}, Z: ${position.z.toFixed(2)}`,
+        )}, Z: ${position.z.toFixed(2)} | Biome: ${biomeDescription}`,
       );
     },
   });

--- a/three-demo/src/world/procedural/node-growth-generator.js
+++ b/three-demo/src/world/procedural/node-growth-generator.js
@@ -1,0 +1,267 @@
+const DEFAULT_STEP = 0.5;
+const MIN_STEP = 0.05;
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function clampStep(step) {
+  if (typeof step !== 'number' || Number.isNaN(step) || step <= 0) {
+    return DEFAULT_STEP;
+  }
+  return Math.max(MIN_STEP, step);
+}
+
+function toVector3(value, fallback = { x: 0, y: 0, z: 0 }) {
+  if (Array.isArray(value)) {
+    const [x = fallback.x, y = fallback.y, z = fallback.z] = value;
+    return { x, y, z };
+  }
+  if (value && typeof value === 'object') {
+    const x = typeof value.x === 'number' ? value.x : fallback.x;
+    const y = typeof value.y === 'number' ? value.y : fallback.y;
+    const z = typeof value.z === 'number' ? value.z : fallback.z;
+    return { x, y, z };
+  }
+  return { ...fallback };
+}
+
+function toSize(value, fallback = { x: 1, y: 1, z: 1 }) {
+  if (typeof value === 'number') {
+    return { x: value, y: value, z: value };
+  }
+  if (Array.isArray(value)) {
+    const [x = fallback.x, y = fallback.y, z = fallback.z] = value;
+    return { x, y, z };
+  }
+  if (value && typeof value === 'object') {
+    const x = typeof value.x === 'number' ? value.x : fallback.x;
+    const y = typeof value.y === 'number' ? value.y : fallback.y;
+    const z = typeof value.z === 'number' ? value.z : fallback.z;
+    return { x, y, z };
+  }
+  return { ...fallback };
+}
+
+function normalizeVoxelConfig(voxel, fallback = null) {
+  const source = voxel || fallback;
+  if (!source || typeof source.type !== 'string') {
+    return null;
+  }
+  return {
+    type: source.type,
+    tint: typeof source.tint === 'string' ? source.tint : null,
+    isSolid:
+      typeof source.isSolid === 'boolean' ? source.isSolid : undefined,
+    destructible:
+      typeof source.destructible === 'boolean'
+        ? source.destructible
+        : undefined,
+    collisionMode:
+      typeof source.collision === 'string'
+        ? source.collision
+        : typeof source.collisionMode === 'string'
+        ? source.collisionMode
+        : null,
+    metadata:
+      source.metadata && typeof source.metadata === 'object'
+        ? { ...source.metadata }
+        : null,
+  };
+}
+
+function parseTint(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const hex = value.trim();
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex);
+  if (!match) {
+    return null;
+  }
+  const int = parseInt(match[1], 16);
+  return {
+    r: (int >> 16) & 0xff,
+    g: (int >> 8) & 0xff,
+    b: int & 0xff,
+  };
+}
+
+function tintToHex(tint) {
+  const clamp = (component) =>
+    Math.max(0, Math.min(255, Math.round(component)));
+  const r = clamp(tint.r).toString(16).padStart(2, '0');
+  const g = clamp(tint.g).toString(16).padStart(2, '0');
+  const b = clamp(tint.b).toString(16).padStart(2, '0');
+  return `#${r}${g}${b}`;
+}
+
+function lerpTint(startTint, endTint, t) {
+  if (!startTint || !endTint) {
+    return startTint || endTint || null;
+  }
+  return {
+    r: lerp(startTint.r, endTint.r, t),
+    g: lerp(startTint.g, endTint.g, t),
+    b: lerp(startTint.b, endTint.b, t),
+  };
+}
+
+function cloneVector(vector) {
+  return { x: vector.x, y: vector.y, z: vector.z };
+}
+
+function cloneSize(size) {
+  return { x: size.x, y: size.y, z: size.z };
+}
+
+function addVoxel(target, usedKeys, voxel) {
+  const size = voxel.size ? cloneSize(voxel.size) : { x: 1, y: 1, z: 1 };
+  const position = cloneVector(voxel.position);
+  const key = [
+    voxel.type,
+    position.x.toFixed(4),
+    position.y.toFixed(4),
+    position.z.toFixed(4),
+    size.x.toFixed(4),
+    size.y.toFixed(4),
+    size.z.toFixed(4),
+    voxel.tint || '',
+  ].join('|');
+  if (usedKeys.has(key)) {
+    return;
+  }
+  usedKeys.add(key);
+  target.push({
+    type: voxel.type,
+    position,
+    size,
+    tint: voxel.tint || null,
+    isSolid: voxel.isSolid,
+    destructible: voxel.destructible,
+    collisionMode: voxel.collisionMode || null,
+    metadata: voxel.metadata ? { ...voxel.metadata } : null,
+  });
+}
+
+export function generateNodeGrowthVoxels(object, config) {
+  if (!object || !config) {
+    return [];
+  }
+
+  const nodes = new Map();
+  const voxels = [];
+  const usedKeys = new Set();
+
+  const defaultNodeVoxel = normalizeVoxelConfig(
+    config.defaultNodeVoxel,
+    config.defaultVoxel,
+  );
+
+  (config.nodes || []).forEach((node) => {
+    if (!node || typeof node.id !== 'string') {
+      return;
+    }
+    const position = toVector3(node.position);
+    nodes.set(node.id, { ...node, position });
+    const nodeVoxelConfig = normalizeVoxelConfig(node.voxel, defaultNodeVoxel);
+    if (nodeVoxelConfig) {
+      const size = toSize(
+        node.voxel?.size ?? config.nodeSize ?? config.segmentSize ?? 1,
+      );
+      addVoxel(voxels, usedKeys, {
+        ...nodeVoxelConfig,
+        position,
+        size,
+      });
+    }
+  });
+
+  const defaultSegmentVoxel = normalizeVoxelConfig(
+    config.segmentVoxel,
+    config.defaultVoxel,
+  );
+
+  (config.segments || []).forEach((segment) => {
+    if (!segment || typeof segment.from !== 'string' || typeof segment.to !== 'string') {
+      return;
+    }
+    const fromNode = nodes.get(segment.from);
+    const toNode = nodes.get(segment.to);
+    if (!fromNode || !toNode) {
+      return;
+    }
+
+    const start = toVector3(segment.startPosition, fromNode.position);
+    const end = toVector3(segment.endPosition, toNode.position);
+    const delta = {
+      x: end.x - start.x,
+      y: end.y - start.y,
+      z: end.z - start.z,
+    };
+    const length = Math.hypot(delta.x, delta.y, delta.z);
+    if (length === 0) {
+      return;
+    }
+
+    const stepSize = clampStep(segment.step ?? config.step ?? DEFAULT_STEP);
+    const steps = segment.steps
+      ? Math.max(1, Math.floor(segment.steps))
+      : Math.max(1, Math.ceil(length / stepSize));
+
+    const startSize = toSize(
+      segment.startSize ?? segment.size ?? config.segmentSize ?? 1,
+    );
+    const endSize = toSize(
+      segment.endSize ?? segment.size ?? config.segmentSize ?? startSize,
+    );
+
+    const segmentVoxel = normalizeVoxelConfig(segment.voxel, defaultSegmentVoxel);
+    if (!segmentVoxel) {
+      return;
+    }
+
+    const startTint = parseTint(segment.startTint ?? segmentVoxel.tint);
+    const endTint = parseTint(segment.endTint ?? segmentVoxel.tint);
+
+    const includeStart = segment.includeStart ?? false;
+    const includeEnd = segment.includeEnd ?? true;
+
+    for (let i = 0; i <= steps; i += 1) {
+      if (i === 0 && !includeStart) {
+        continue;
+      }
+      if (i === steps && !includeEnd) {
+        continue;
+      }
+      const t = steps === 0 ? 0 : i / steps;
+      const position = {
+        x: start.x + delta.x * t,
+        y: start.y + delta.y * t,
+        z: start.z + delta.z * t,
+      };
+      const size = {
+        x: lerp(startSize.x, endSize.x, t),
+        y: lerp(startSize.y, endSize.y, t),
+        z: lerp(startSize.z, endSize.z, t),
+      };
+
+      let tint = segmentVoxel.tint;
+      if (startTint || endTint) {
+        const mixed = lerpTint(startTint, endTint, t);
+        tint = mixed ? tintToHex(mixed) : tint;
+      }
+
+      addVoxel(voxels, usedKeys, {
+        ...segmentVoxel,
+        position,
+        size,
+        tint,
+      });
+    }
+  });
+
+  return voxels;
+}
+
+export default generateNodeGrowthVoxels;

--- a/three-demo/src/world/voxel-object-library.js
+++ b/three-demo/src/world/voxel-object-library.js
@@ -51,16 +51,19 @@ function computeBoundingBox(voxels, voxelScale) {
 
   voxels.forEach((voxel) => {
     const { position, size } = voxel;
-    const halfX = (size.x ?? 1) / 2;
-    const halfY = (size.y ?? 1) / 2;
-    const halfZ = (size.z ?? 1) / 2;
+    const sizeX = size.x ?? 1;
+    const sizeY = size.y ?? 1;
+    const sizeZ = size.z ?? 1;
+    const halfX = sizeX / 2;
+    const halfZ = sizeZ / 2;
 
     const minLocalX = (position.x - halfX) * voxelScale;
-    const minLocalY = (position.y - halfY) * voxelScale;
-    const minLocalZ = (position.z - halfZ) * voxelScale;
     const maxLocalX = (position.x + halfX) * voxelScale;
-    const maxLocalY = (position.y + halfY) * voxelScale;
+    const minLocalZ = (position.z - halfZ) * voxelScale;
     const maxLocalZ = (position.z + halfZ) * voxelScale;
+
+    const minLocalY = position.y * voxelScale;
+    const maxLocalY = (position.y + sizeY) * voxelScale;
 
     minX = Math.min(minX, minLocalX);
     minY = Math.min(minY, minLocalY);

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -1,4 +1,8 @@
-import { getWeightedVoxelObject, isVoxelObjectAllowedInBiome } from './voxel-object-library.js';
+import {
+  getWeightedVoxelObject,
+  isVoxelObjectAllowedInBiome,
+} from './voxel-object-library.js';
+import { resolveVoxelObjectVoxels } from './voxel-object-processor.js';
 
 function ensureRandomSource(randomSource) {
   if (typeof randomSource === 'function') {
@@ -36,15 +40,23 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
     return;
   }
   const base = origin ?? { x: 0, y: 0, z: 0 };
+  const groundAnchorOffset = object.attachment?.groundOffset ?? object.voxelScale;
+  const anchor = {
+    x: base.x,
+    y: base.y - groundAnchorOffset,
+    z: base.z,
+  };
 
   const defaultSolidOverride = object.voxelScale < 1;
 
 
-  object.voxels.forEach((voxel) => {
+  const voxels = resolveVoxelObjectVoxels(object);
+
+  voxels.forEach((voxel) => {
     const scale = resolveScaleVector(voxel, object.voxelScale);
-    const worldX = base.x + voxel.position.x * object.voxelScale;
-    const worldY = base.y + voxel.position.y * object.voxelScale;
-    const worldZ = base.z + voxel.position.z * object.voxelScale;
+    const worldX = anchor.x + voxel.position.x * object.voxelScale;
+    const worldY = anchor.y + voxel.position.y * object.voxelScale + scale.y / 2;
+    const worldZ = anchor.z + voxel.position.z * object.voxelScale;
 
     const collisionMode = resolveCollisionMode(voxel, object);
 

--- a/three-demo/src/world/voxel-object-processor.js
+++ b/three-demo/src/world/voxel-object-processor.js
@@ -1,0 +1,92 @@
+import generateNodeGrowthVoxels from './procedural/node-growth-generator.js';
+
+const resolvedVoxelCache = new WeakMap();
+
+function cloneVoxel(voxel) {
+  return {
+    ...voxel,
+    position: voxel.position ? { ...voxel.position } : { x: 0, y: 0, z: 0 },
+    size: voxel.size ? { ...voxel.size } : { x: 1, y: 1, z: 1 },
+    metadata: voxel.metadata ? { ...voxel.metadata } : null,
+  };
+}
+
+function computeBoundingBox(voxels, voxelScale) {
+  if (!voxels || voxels.length === 0) {
+    return null;
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+
+  voxels.forEach((voxel) => {
+    const { position, size } = voxel;
+    const sizeX = size?.x ?? 1;
+    const sizeY = size?.y ?? 1;
+    const sizeZ = size?.z ?? 1;
+    const halfX = sizeX / 2;
+    const halfZ = sizeZ / 2;
+
+    const minLocalX = (position.x - halfX) * voxelScale;
+    const maxLocalX = (position.x + halfX) * voxelScale;
+    const minLocalZ = (position.z - halfZ) * voxelScale;
+    const maxLocalZ = (position.z + halfZ) * voxelScale;
+
+    const minLocalY = position.y * voxelScale;
+    const maxLocalY = (position.y + sizeY) * voxelScale;
+
+    minX = Math.min(minX, minLocalX);
+    minY = Math.min(minY, minLocalY);
+    minZ = Math.min(minZ, minLocalZ);
+    maxX = Math.max(maxX, maxLocalX);
+    maxY = Math.max(maxY, maxLocalY);
+    maxZ = Math.max(maxZ, maxLocalZ);
+  });
+
+  return {
+    min: { x: minX, y: minY, z: minZ },
+    max: { x: maxX, y: maxY, z: maxZ },
+    size: { x: maxX - minX, y: maxY - minY, z: maxZ - minZ },
+  };
+}
+
+export function resolveVoxelObjectVoxels(object) {
+  if (!object) {
+    return [];
+  }
+  if (resolvedVoxelCache.has(object)) {
+    return resolvedVoxelCache.get(object);
+  }
+
+  const baseVoxels = Array.isArray(object.voxels)
+    ? object.voxels.map((voxel) => cloneVoxel(voxel))
+    : [];
+
+  let proceduralVoxels = [];
+  const proceduralConfig = object.raw?.procedural ?? null;
+  if (proceduralConfig?.nodeGrowth) {
+    proceduralVoxels = generateNodeGrowthVoxels(object, proceduralConfig.nodeGrowth);
+  }
+
+  const combined = [...baseVoxels, ...proceduralVoxels].map((voxel, index) => ({
+    ...voxel,
+    index,
+  }));
+
+  if (combined.length > 0) {
+    object.boundingBox = computeBoundingBox(combined, object.voxelScale);
+  }
+
+  resolvedVoxelCache.set(object, combined);
+  return combined;
+}
+
+export function invalidateResolvedVoxelCache(object) {
+  if (!object) {
+    return;
+  }
+  resolvedVoxelCache.delete(object);
+}

--- a/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
+++ b/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
@@ -16,9 +16,42 @@
     "forbidUnderwater": false,
     "jitterRadius": 0.6
   },
+  "procedural": {
+    "nodeGrowth": {
+      "step": 0.4,
+      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#6a4d84" },
+      "nodes": [
+        {
+          "id": "base",
+          "position": [0, 0, 0],
+          "voxel": { "type": "log", "size": [1.3, 0.6, 1.3], "tint": "#6a4d84", "isSolid": true }
+        },
+        { "id": "mid", "position": [0.18, 2.8, -0.1] },
+        {
+          "id": "crown",
+          "position": [-0.12, 5.8, 0.16],
+          "voxel": { "type": "log", "size": [1.0, 0.8, 1.0], "tint": "#735694", "isSolid": true }
+        }
+      ],
+      "segments": [
+        {
+          "from": "base",
+          "to": "mid",
+          "voxel": { "type": "log", "tint": "#6f558d", "isSolid": true },
+          "startSize": [1.25, 1.2, 1.25],
+          "endSize": [1.1, 1.1, 1.1]
+        },
+        {
+          "from": "mid",
+          "to": "crown",
+          "voxel": { "type": "log", "tint": "#735694", "isSolid": true },
+          "startSize": [1.1, 1.05, 1.1],
+          "endSize": [0.95, 0.95, 0.95]
+        }
+      ]
+    }
+  },
   "voxels": [
-    { "type": "log", "position": [0, 0, 0], "size": [1.2, 5.5, 1.2], "tint": "#6a4d84" },
-    { "type": "log", "position": [0, 5.8, 0], "size": [1.0, 1.0, 1.0], "tint": "#735694" },
     { "type": "leaf", "position": [0, 5.6, 0], "size": [3.4, 0.8, 3.4], "tint": "#6fe9f1", "isSolid": false },
     { "type": "leaf", "position": [0, 6.4, 0], "size": [2.4, 0.6, 2.4], "tint": "#9bfdf7", "isSolid": false },
     { "type": "leaf", "position": [0, 4.2, 0], "size": [1.6, 1.2, 1.6], "tint": "#5cd6dc", "isSolid": false },

--- a/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
+++ b/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
@@ -17,10 +17,42 @@
     "forbidUnderwater": true,
     "jitterRadius": 0.7
   },
+  "procedural": {
+    "nodeGrowth": {
+      "step": 0.38,
+      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#37b47a" },
+      "nodes": [
+        {
+          "id": "base",
+          "position": [0, 0, 0],
+          "voxel": { "type": "log", "size": [1.25, 0.6, 1.25], "tint": "#2f9f6f", "isSolid": true }
+        },
+        { "id": "mid", "position": [0, 3.2, 0] },
+        {
+          "id": "upper",
+          "position": [0, 6.4, 0],
+          "voxel": { "type": "log", "size": [0.9, 0.6, 0.9], "tint": "#3fc488", "isSolid": true }
+        }
+      ],
+      "segments": [
+        {
+          "from": "base",
+          "to": "mid",
+          "voxel": { "type": "log", "tint": "#37b47a", "isSolid": true },
+          "startSize": [1.2, 1.1, 1.2],
+          "endSize": [1.05, 1.05, 1.05]
+        },
+        {
+          "from": "mid",
+          "to": "upper",
+          "voxel": { "type": "log", "tint": "#3fc488", "isSolid": true },
+          "startSize": [1.05, 1.0, 1.05],
+          "endSize": [0.9, 0.9, 0.9]
+        }
+      ]
+    }
+  },
   "voxels": [
-    { "type": "log", "position": [0, 0, 0], "size": [1.2, 3.4, 1.2], "tint": "#2f9f6f" },
-    { "type": "log", "position": [0, 3.6, 0], "size": [1.1, 2.8, 1.1], "tint": "#37b47a" },
-    { "type": "log", "position": [0, 6.2, 0], "size": [1.0, 2.4, 1.0], "tint": "#3fc488" },
     { "type": "leaf", "position": [1.4, 2.6, 0], "size": [1.1, 2.4, 1.1], "tint": "#3fb98a" },
     { "type": "leaf", "position": [-1.4, 4.2, 0], "size": [0.9, 2.2, 0.9], "tint": "#42c996" },
     { "type": "leaf", "position": [0, 4.6, 1.4], "size": [1.0, 2.1, 1.0], "tint": "#3fb98a" },

--- a/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
+++ b/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
@@ -16,9 +16,42 @@
     "forbidUnderwater": false,
     "jitterRadius": 0.8
   },
+  "procedural": {
+    "nodeGrowth": {
+      "step": 0.42,
+      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#f8a7ff" },
+      "nodes": [
+        {
+          "id": "base",
+          "position": [0, 0, 0],
+          "voxel": { "type": "log", "size": [1.15, 0.6, 1.15], "tint": "#f38ff9", "isSolid": true }
+        },
+        { "id": "mid", "position": [0.25, 2.4, -0.15] },
+        {
+          "id": "crown",
+          "position": [0.05, 4.5, 0.2],
+          "voxel": { "type": "log", "size": [0.8, 0.6, 0.8], "tint": "#ffbffb", "isSolid": true }
+        }
+      ],
+      "segments": [
+        {
+          "from": "base",
+          "to": "mid",
+          "voxel": { "type": "log", "tint": "#f8a7ff", "isSolid": true },
+          "startSize": [1.05, 0.9, 1.05],
+          "endSize": [0.9, 0.85, 0.9]
+        },
+        {
+          "from": "mid",
+          "to": "crown",
+          "voxel": { "type": "log", "tint": "#ffbdfc", "isSolid": true },
+          "startSize": [0.9, 0.8, 0.9],
+          "endSize": [0.7, 0.7, 0.7]
+        }
+      ]
+    }
+  },
   "voxels": [
-    { "type": "log", "position": [0, 0, 0], "size": [1.0, 3.6, 1.0], "tint": "#f8a7ff" },
-    { "type": "log", "position": [0, 3.8, 0], "size": [0.9, 1.2, 0.9], "tint": "#ffbffb" },
     { "type": "leaf", "position": [0, 4.2, 0], "size": [3.2, 0.6, 1.1], "tint": "#6dffd2", "isSolid": false },
     { "type": "leaf", "position": [0, 4.2, 0], "size": [1.1, 0.6, 3.2], "tint": "#7affff", "isSolid": false },
     { "type": "leaf", "position": [1.8, 4.4, 1.8], "size": [2.4, 0.5, 1.0], "tint": "#9dffe0", "isSolid": false },


### PR DESCRIPTION
## Summary
- introduce a procedural node-growth generator that expands voxel objects into contiguous minivoxel segments and caches the resolved geometry
- update voxel object placement to use the resolved voxel list so procedural shapes share the same anchoring logic as static objects
- convert the vaporwave palm, sunset cactus, and noctilucent pillarcap definitions to use node-growth trunks for gap-free silhouettes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ce83581c832a8db1ca48250f70be