### PR TITLE
Scale structure spawn odds

### DIFF
--- a/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
+++ b/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
@@ -18,7 +18,7 @@
     "rockChance": 0.06,
     "fungiChance": 0.0,
     "waterPlantChance": 0.0,
-    "structureChance": 0.2,
+    "structureChance": 0.07,
     "treeHeight": {
       "min": 2,
       "max": 4

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -361,7 +361,9 @@ export function populateColumnWithVoxelObjects({
     { allowUnderwater: true, requireUnderwater: true },
   );
 
-  attemptCategory('structures', Math.max(0, terrain.structureChance ?? 0), 151, {
+  const structureChanceRaw = Math.max(0, terrain.structureChance ?? 0);
+  const structureChance = Math.min(1, structureChanceRaw) * densityScale;
+  attemptCategory('structures', structureChance, 151, {
     allowUnderwater: true,
   });
 }


### PR DESCRIPTION
## Summary
- scale structure placements with the same density factor used for other décor categories
- retune the Librarium biome structure chance to match the new scaling expectations

## Testing
- npm run build
- npm run dev -- --host (manual verification of Librarium structure spacing)


------
https://chatgpt.com/codex/tasks/task_e_68d212c83768832a8254e9a931f0bd47