### PR TITLE
feat: introduce fluid engine and dreamcast water

### DIFF
--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -1,4 +1,5 @@
 import { generateChunk, worldConfig } from './generation.js';
+import { disposeFluidSurface } from './fluids/fluid-registry.js';
 
 function chunkKey(x, z) {
   return `${x}|${z}`;
@@ -32,6 +33,10 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
       }
       child.userData.chunkKey = key;
     });
+    (chunk.fluidSurfaces ?? []).forEach((surface) => {
+      surface.userData = surface.userData || {};
+      surface.userData.chunkKey = key;
+    });
     scene.add(chunk.group);
     (chunk.solidBlockKeys ?? []).forEach((block) => solidBlocks.add(block));
     (chunk.softBlockKeys ?? []).forEach((block) => softBlocks.add(block));
@@ -46,6 +51,10 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     }
 
     scene.remove(chunk.group);
+    (chunk.fluidSurfaces ?? []).forEach((surface) => {
+      surface.geometry?.dispose?.();
+      disposeFluidSurface(surface);
+    });
     (chunk.solidBlockKeys ?? []).forEach((block) => solidBlocks.delete(block));
     (chunk.softBlockKeys ?? []).forEach((block) => softBlocks.delete(block));
     (chunk.waterColumnKeys ?? []).forEach((column) => waterColumns.delete(column));

--- a/three-demo/src/world/fluids/fluid-geometry.js
+++ b/three-demo/src/world/fluids/fluid-geometry.js
@@ -1,0 +1,275 @@
+const FACE_DIRECTIONS = [
+  { key: 'px', dx: 1, dz: 0, normal: [1, 0, 0] },
+  { key: 'nx', dx: -1, dz: 0, normal: [-1, 0, 0] },
+  { key: 'pz', dx: 0, dz: 1, normal: [0, 0, 1] },
+  { key: 'nz', dx: 0, dz: -1, normal: [0, 0, -1] },
+];
+
+export function buildFluidGeometry({ THREE, columns }) {
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const colors = [];
+  const surfaceTypes = [];
+  const flowDirections = [];
+  const flowStrengths = [];
+  const edgeFoam = [];
+
+  const pushVertex = (
+    vertex,
+    normal,
+    uv,
+    color,
+    surfaceType,
+    flowDir,
+    flowStrength,
+    foam,
+  ) => {
+    positions.push(vertex.x, vertex.y, vertex.z);
+    normals.push(normal.x, normal.y, normal.z);
+    uvs.push(uv.x, uv.y);
+    colors.push(color.r, color.g, color.b);
+    surfaceTypes.push(surfaceType);
+    flowDirections.push(flowDir.x, flowDir.y);
+    flowStrengths.push(flowStrength);
+    edgeFoam.push(foam);
+  };
+
+  const tempColor = new THREE.Color();
+
+  const topFace = (column) => {
+    const { x, z, surfaceY, color, flowStrength, foamAmount } = column;
+    const left = x - 0.5;
+    const right = x + 0.5;
+    const front = z + 0.5;
+    const back = z - 0.5;
+    const normal = new THREE.Vector3(0, 1, 0);
+    const flowDir = column.flowDirection ?? new THREE.Vector2(0, 0);
+    const strength = column.flowStrength ?? 0;
+    const foam = foamAmount ?? 0;
+
+    const tint = tempColor.copy(color);
+
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, back),
+      normal,
+      new THREE.Vector2(0, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, back),
+      normal,
+      new THREE.Vector2(1, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, front),
+      normal,
+      new THREE.Vector2(1, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, back),
+      normal,
+      new THREE.Vector2(0, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, front),
+      normal,
+      new THREE.Vector2(1, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, front),
+      normal,
+      new THREE.Vector2(0, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+  };
+
+  const sideFace = (column, neighborInfo, direction) => {
+    const { x, z, surfaceY, bottomY, color } = column;
+    const flowDir = column.flowDirection ?? new THREE.Vector2(0, 0);
+    const strength = column.flowStrength ?? 0.15;
+    const foam = Math.max(column.foamAmount ?? 0, neighborInfo.foamHint ?? 0);
+
+    const dropSurface = surfaceY;
+    const dropBottom = Math.min(bottomY, neighborInfo.bottomY);
+    if (!(dropSurface > dropBottom + 0.01)) {
+      return;
+    }
+
+    const sideColor = tempColor.copy(color).lerp(new THREE.Color('#5bd5ff'), 0.2);
+    const normal = new THREE.Vector3(...direction.normal);
+    const half = 0.5;
+    let verts = [];
+    if (direction.dx !== 0) {
+      const baseX = x + direction.dx * half;
+      const zMin = z - half;
+      const zMax = z + half;
+      if (direction.dx > 0) {
+        verts = [
+          new THREE.Vector3(baseX, dropSurface, zMin),
+          new THREE.Vector3(baseX, dropBottom, zMin),
+          new THREE.Vector3(baseX, dropBottom, zMax),
+          new THREE.Vector3(baseX, dropSurface, zMax),
+        ];
+      } else {
+        verts = [
+          new THREE.Vector3(baseX, dropSurface, zMax),
+          new THREE.Vector3(baseX, dropBottom, zMax),
+          new THREE.Vector3(baseX, dropBottom, zMin),
+          new THREE.Vector3(baseX, dropSurface, zMin),
+        ];
+      }
+    } else {
+      const baseZ = z + direction.dz * half;
+      const xMin = x - half;
+      const xMax = x + half;
+      if (direction.dz > 0) {
+        verts = [
+          new THREE.Vector3(xMin, dropSurface, baseZ),
+          new THREE.Vector3(xMin, dropBottom, baseZ),
+          new THREE.Vector3(xMax, dropBottom, baseZ),
+          new THREE.Vector3(xMax, dropSurface, baseZ),
+        ];
+      } else {
+        verts = [
+          new THREE.Vector3(xMax, dropSurface, baseZ),
+          new THREE.Vector3(xMax, dropBottom, baseZ),
+          new THREE.Vector3(xMin, dropBottom, baseZ),
+          new THREE.Vector3(xMin, dropSurface, baseZ),
+        ];
+      }
+    }
+
+    const surfaceType = 1;
+
+    pushVertex(
+      verts[0],
+      normal,
+      new THREE.Vector2(0, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[1],
+      normal,
+      new THREE.Vector2(0, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[2],
+      normal,
+      new THREE.Vector2(1, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+
+    pushVertex(
+      verts[0],
+      normal,
+      new THREE.Vector2(0, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[2],
+      normal,
+      new THREE.Vector2(1, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[3],
+      normal,
+      new THREE.Vector2(1, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+  };
+
+  columns.forEach((column) => {
+    topFace(column);
+    FACE_DIRECTIONS.forEach((direction) => {
+      const neighborInfo = column.neighbors?.[direction.key];
+      if (!neighborInfo) {
+        return;
+      }
+      const neighborSurface = neighborInfo.surfaceY ?? column.surfaceY;
+      const hasDrop = neighborSurface < column.surfaceY - 0.05;
+      if (!hasDrop) {
+        return;
+      }
+      sideFace(column, neighborInfo, direction);
+    });
+  });
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geometry.setAttribute(
+    'surfaceType',
+    new THREE.Float32BufferAttribute(surfaceTypes, 1),
+  );
+  geometry.setAttribute(
+    'flowDirection',
+    new THREE.Float32BufferAttribute(flowDirections, 2),
+  );
+  geometry.setAttribute(
+    'flowStrength',
+    new THREE.Float32BufferAttribute(flowStrengths, 1),
+  );
+  geometry.setAttribute('edgeFoam', new THREE.Float32BufferAttribute(edgeFoam, 1));
+
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  return geometry;
+}

--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -1,0 +1,147 @@
+export function createDreamcastWaterMaterial({ THREE }) {
+  const material = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color('#1d90d4'),
+    roughness: 0.18,
+    metalness: 0.04,
+    transmission: 0.72,
+    thickness: 1.4,
+    transparent: true,
+    opacity: 1,
+    reflectivity: 0.68,
+    clearcoat: 0.45,
+    clearcoatRoughness: 0.12,
+    ior: 1.33,
+    vertexColors: true,
+  });
+
+  const uniforms = {
+    uTime: { value: 0 },
+    uWaveAmplitude: { value: 0.12 },
+    uSecondaryWaveAmplitude: { value: 0.06 },
+    uWaveFrequency: { value: 2.1 },
+    uRippleScale: { value: 1.4 },
+    uFlowSpeed: { value: 1.35 },
+    uWaterfallTumble: { value: 0.12 },
+    uOpacity: { value: 0.72 },
+    uWaterfallOpacity: { value: 0.58 },
+    uShallowColor: { value: new THREE.Color('#4fdfff') },
+    uDeepColor: { value: new THREE.Color('#0b2a6f') },
+    uFoamColor: { value: new THREE.Color('#ffffff') },
+    uWaterfallColor: { value: new THREE.Color('#3cb7ff') },
+    uSpecularBoost: { value: 0.15 },
+  };
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uTime = uniforms.uTime;
+    shader.uniforms.uWaveAmplitude = uniforms.uWaveAmplitude;
+    shader.uniforms.uSecondaryWaveAmplitude = uniforms.uSecondaryWaveAmplitude;
+    shader.uniforms.uWaveFrequency = uniforms.uWaveFrequency;
+    shader.uniforms.uRippleScale = uniforms.uRippleScale;
+    shader.uniforms.uFlowSpeed = uniforms.uFlowSpeed;
+    shader.uniforms.uWaterfallTumble = uniforms.uWaterfallTumble;
+    shader.uniforms.uOpacity = uniforms.uOpacity;
+    shader.uniforms.uWaterfallOpacity = uniforms.uWaterfallOpacity;
+    shader.uniforms.uShallowColor = uniforms.uShallowColor;
+    shader.uniforms.uDeepColor = uniforms.uDeepColor;
+    shader.uniforms.uFoamColor = uniforms.uFoamColor;
+    shader.uniforms.uWaterfallColor = uniforms.uWaterfallColor;
+    shader.uniforms.uSpecularBoost = uniforms.uSpecularBoost;
+
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        '#include <common>',
+        `#include <common>
+attribute float surfaceType;
+attribute vec2 flowDirection;
+attribute float flowStrength;
+attribute float edgeFoam;
+
+uniform float uTime;
+uniform float uWaveAmplitude;
+uniform float uSecondaryWaveAmplitude;
+uniform float uWaveFrequency;
+uniform float uRippleScale;
+uniform float uFlowSpeed;
+uniform float uWaterfallTumble;
+
+varying float vSurfaceType;
+varying vec2 vFlowDirection;
+varying float vFlowStrength;
+varying float vEdgeFoam;
+varying vec3 vWorldPosition;
+        `,
+      )
+      .replace(
+        '#include <begin_vertex>',
+        `#include <begin_vertex>
+float surfaceMask = clamp(surfaceType, 0.0, 1.0);
+float elevationMask = 1.0 - surfaceMask;
+float baseWave = sin((position.x + position.z) * uWaveFrequency + uTime * 0.8);
+float crossWave = sin((position.x * 0.8 - position.z * 1.3) * (uWaveFrequency * 0.85) - uTime * 1.4);
+float swirlWave = sin((position.x * 0.35 + position.z * 0.65) * uRippleScale + uTime * 0.6);
+float directional = dot(flowDirection, vec2(position.x, position.z)) * flowStrength;
+float crest = max(0.0, directional * 0.6);
+float displacement = (baseWave + crossWave * 0.6 + swirlWave * 0.4 + crest) * uWaveAmplitude * elevationMask;
+transformed.y += displacement;
+transformed.xz += flowDirection * flowStrength * 0.08 * elevationMask * sin(uTime * 0.9 + position.y * 0.6);
+if (surfaceMask > 0.5) {
+  float tumble = sin(uTime * uFlowSpeed + position.y * 2.3) * uWaterfallTumble;
+  transformed.x += flowDirection.x * tumble;
+  transformed.z += flowDirection.y * tumble;
+  transformed.y -= abs(flowStrength) * 0.04;
+}
+vSurfaceType = surfaceMask;
+vFlowDirection = flowDirection;
+vFlowStrength = flowStrength;
+vEdgeFoam = edgeFoam;
+vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
+vWorldPosition = worldPos.xyz;
+        `,
+      );
+
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        '#include <common>',
+        `#include <common>
+uniform float uOpacity;
+uniform float uWaterfallOpacity;
+uniform vec3 uShallowColor;
+uniform vec3 uDeepColor;
+uniform vec3 uFoamColor;
+uniform vec3 uWaterfallColor;
+uniform float uSpecularBoost;
+
+varying float vSurfaceType;
+varying vec2 vFlowDirection;
+varying float vFlowStrength;
+varying float vEdgeFoam;
+varying vec3 vWorldPosition;
+        `,
+      )
+      .replace(
+        '#include <output_fragment>',
+        `vec3 dreamcastPalette = mix(uDeepColor, uShallowColor, clamp(vWorldPosition.y * 0.035 + 0.55, 0.0, 1.0));
+vec3 waterfallTint = mix(dreamcastPalette, uWaterfallColor, smoothstep(0.35, 1.0, vSurfaceType));
+float foamFactor = smoothstep(0.28, 0.92, vEdgeFoam + vFlowStrength * 0.85);
+vec3 foamColor = uFoamColor * foamFactor * mix(0.35, 0.75, vSurfaceType);
+vec3 paletteTint = waterfallTint;
+diffuseColor.rgb *= paletteTint;
+diffuseColor.rgb += foamColor;
+vec3 dreamcastLight = normalize(vec3(0.22, 0.94, 0.31));
+float sparkle = pow(max(dot(normal, dreamcastLight), 0.0), 18.0) * uSpecularBoost;
+diffuseColor.rgb += sparkle;
+float opacityMix = mix(uOpacity, uWaterfallOpacity, smoothstep(0.45, 0.95, vSurfaceType));
+diffuseColor.a = opacityMix;
+gl_FragColor = diffuseColor;
+        `,
+      );
+  };
+
+  material.customProgramCacheKey = () => 'DreamcastWaterMaterial_v1';
+
+  const update = (delta) => {
+    uniforms.uTime.value += delta;
+  };
+
+  return { material, update };
+}


### PR DESCRIPTION
## Summary
- add a fluid registry and Dreamcast-inspired water material to support reusable liquid types
- generate dynamic water surfaces per chunk with wave flow attributes and reusable geometry builder
- integrate the fluid system into chunk lifecycle and the main render loop for ongoing simulation updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d232ae5b34832ab82fc99ac7982719