### PR TITLE
fix: ensure water bodies spawn near start

### DIFF
--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -1,4 +1,5 @@
 import { generateChunk, worldConfig } from './generation.js';
+import { disposeFluidSurface } from './fluids/fluid-registry.js';
 
 function chunkKey(x, z) {
   return `${x}|${z}`;
@@ -32,6 +33,10 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
       }
       child.userData.chunkKey = key;
     });
+    (chunk.fluidSurfaces ?? []).forEach((surface) => {
+      surface.userData = surface.userData || {};
+      surface.userData.chunkKey = key;
+    });
     scene.add(chunk.group);
     (chunk.solidBlockKeys ?? []).forEach((block) => solidBlocks.add(block));
     (chunk.softBlockKeys ?? []).forEach((block) => softBlocks.add(block));
@@ -46,6 +51,10 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     }
 
     scene.remove(chunk.group);
+    (chunk.fluidSurfaces ?? []).forEach((surface) => {
+      surface.geometry?.dispose?.();
+      disposeFluidSurface(surface);
+    });
     (chunk.solidBlockKeys ?? []).forEach((block) => solidBlocks.delete(block));
     (chunk.softBlockKeys ?? []).forEach((block) => softBlocks.delete(block));
     (chunk.waterColumnKeys ?? []).forEach((column) => waterColumns.delete(column));

--- a/three-demo/src/world/fluids/fluid-geometry.js
+++ b/three-demo/src/world/fluids/fluid-geometry.js
@@ -1,0 +1,275 @@
+const FACE_DIRECTIONS = [
+  { key: 'px', dx: 1, dz: 0, normal: [1, 0, 0] },
+  { key: 'nx', dx: -1, dz: 0, normal: [-1, 0, 0] },
+  { key: 'pz', dx: 0, dz: 1, normal: [0, 0, 1] },
+  { key: 'nz', dx: 0, dz: -1, normal: [0, 0, -1] },
+];
+
+export function buildFluidGeometry({ THREE, columns }) {
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const colors = [];
+  const surfaceTypes = [];
+  const flowDirections = [];
+  const flowStrengths = [];
+  const edgeFoam = [];
+
+  const pushVertex = (
+    vertex,
+    normal,
+    uv,
+    color,
+    surfaceType,
+    flowDir,
+    flowStrength,
+    foam,
+  ) => {
+    positions.push(vertex.x, vertex.y, vertex.z);
+    normals.push(normal.x, normal.y, normal.z);
+    uvs.push(uv.x, uv.y);
+    colors.push(color.r, color.g, color.b);
+    surfaceTypes.push(surfaceType);
+    flowDirections.push(flowDir.x, flowDir.y);
+    flowStrengths.push(flowStrength);
+    edgeFoam.push(foam);
+  };
+
+  const tempColor = new THREE.Color();
+
+  const topFace = (column) => {
+    const { x, z, surfaceY, color, flowStrength, foamAmount } = column;
+    const left = x - 0.5;
+    const right = x + 0.5;
+    const front = z + 0.5;
+    const back = z - 0.5;
+    const normal = new THREE.Vector3(0, 1, 0);
+    const flowDir = column.flowDirection ?? new THREE.Vector2(0, 0);
+    const strength = column.flowStrength ?? 0;
+    const foam = foamAmount ?? 0;
+
+    const tint = tempColor.copy(color);
+
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, back),
+      normal,
+      new THREE.Vector2(0, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, back),
+      normal,
+      new THREE.Vector2(1, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, front),
+      normal,
+      new THREE.Vector2(1, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, back),
+      normal,
+      new THREE.Vector2(0, 0),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(right, surfaceY, front),
+      normal,
+      new THREE.Vector2(1, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      new THREE.Vector3(left, surfaceY, front),
+      normal,
+      new THREE.Vector2(0, 1),
+      tint,
+      0,
+      flowDir,
+      strength,
+      foam,
+    );
+  };
+
+  const sideFace = (column, neighborInfo, direction) => {
+    const { x, z, surfaceY, bottomY, color } = column;
+    const flowDir = column.flowDirection ?? new THREE.Vector2(0, 0);
+    const strength = column.flowStrength ?? 0.15;
+    const foam = Math.max(column.foamAmount ?? 0, neighborInfo.foamHint ?? 0);
+
+    const dropSurface = surfaceY;
+    const dropBottom = Math.min(bottomY, neighborInfo.bottomY);
+    if (!(dropSurface > dropBottom + 0.01)) {
+      return;
+    }
+
+    const sideColor = tempColor.copy(color).lerp(new THREE.Color('#5bd5ff'), 0.2);
+    const normal = new THREE.Vector3(...direction.normal);
+    const half = 0.5;
+    let verts = [];
+    if (direction.dx !== 0) {
+      const baseX = x + direction.dx * half;
+      const zMin = z - half;
+      const zMax = z + half;
+      if (direction.dx > 0) {
+        verts = [
+          new THREE.Vector3(baseX, dropSurface, zMin),
+          new THREE.Vector3(baseX, dropBottom, zMin),
+          new THREE.Vector3(baseX, dropBottom, zMax),
+          new THREE.Vector3(baseX, dropSurface, zMax),
+        ];
+      } else {
+        verts = [
+          new THREE.Vector3(baseX, dropSurface, zMax),
+          new THREE.Vector3(baseX, dropBottom, zMax),
+          new THREE.Vector3(baseX, dropBottom, zMin),
+          new THREE.Vector3(baseX, dropSurface, zMin),
+        ];
+      }
+    } else {
+      const baseZ = z + direction.dz * half;
+      const xMin = x - half;
+      const xMax = x + half;
+      if (direction.dz > 0) {
+        verts = [
+          new THREE.Vector3(xMin, dropSurface, baseZ),
+          new THREE.Vector3(xMin, dropBottom, baseZ),
+          new THREE.Vector3(xMax, dropBottom, baseZ),
+          new THREE.Vector3(xMax, dropSurface, baseZ),
+        ];
+      } else {
+        verts = [
+          new THREE.Vector3(xMax, dropSurface, baseZ),
+          new THREE.Vector3(xMax, dropBottom, baseZ),
+          new THREE.Vector3(xMin, dropBottom, baseZ),
+          new THREE.Vector3(xMin, dropSurface, baseZ),
+        ];
+      }
+    }
+
+    const surfaceType = 1;
+
+    pushVertex(
+      verts[0],
+      normal,
+      new THREE.Vector2(0, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[1],
+      normal,
+      new THREE.Vector2(0, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[2],
+      normal,
+      new THREE.Vector2(1, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+
+    pushVertex(
+      verts[0],
+      normal,
+      new THREE.Vector2(0, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[2],
+      normal,
+      new THREE.Vector2(1, 1),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+    pushVertex(
+      verts[3],
+      normal,
+      new THREE.Vector2(1, 0),
+      sideColor,
+      surfaceType,
+      flowDir,
+      strength,
+      foam,
+    );
+  };
+
+  columns.forEach((column) => {
+    topFace(column);
+    FACE_DIRECTIONS.forEach((direction) => {
+      const neighborInfo = column.neighbors?.[direction.key];
+      if (!neighborInfo) {
+        return;
+      }
+      const neighborSurface = neighborInfo.surfaceY ?? column.surfaceY;
+      const hasDrop = neighborSurface < column.surfaceY - 0.05;
+      if (!hasDrop) {
+        return;
+      }
+      sideFace(column, neighborInfo, direction);
+    });
+  });
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geometry.setAttribute(
+    'surfaceType',
+    new THREE.Float32BufferAttribute(surfaceTypes, 1),
+  );
+  geometry.setAttribute(
+    'flowDirection',
+    new THREE.Float32BufferAttribute(flowDirections, 2),
+  );
+  geometry.setAttribute(
+    'flowStrength',
+    new THREE.Float32BufferAttribute(flowStrengths, 1),
+  );
+  geometry.setAttribute('edgeFoam', new THREE.Float32BufferAttribute(edgeFoam, 1));
+
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  return geometry;
+}

--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -1,0 +1,147 @@
+export function createDreamcastWaterMaterial({ THREE }) {
+  const material = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color('#1d90d4'),
+    roughness: 0.18,
+    metalness: 0.04,
+    transmission: 0.72,
+    thickness: 1.4,
+    transparent: true,
+    opacity: 1,
+    reflectivity: 0.68,
+    clearcoat: 0.45,
+    clearcoatRoughness: 0.12,
+    ior: 1.33,
+    vertexColors: true,
+  });
+
+  const uniforms = {
+    uTime: { value: 0 },
+    uWaveAmplitude: { value: 0.12 },
+    uSecondaryWaveAmplitude: { value: 0.06 },
+    uWaveFrequency: { value: 2.1 },
+    uRippleScale: { value: 1.4 },
+    uFlowSpeed: { value: 1.35 },
+    uWaterfallTumble: { value: 0.12 },
+    uOpacity: { value: 0.72 },
+    uWaterfallOpacity: { value: 0.58 },
+    uShallowColor: { value: new THREE.Color('#4fdfff') },
+    uDeepColor: { value: new THREE.Color('#0b2a6f') },
+    uFoamColor: { value: new THREE.Color('#ffffff') },
+    uWaterfallColor: { value: new THREE.Color('#3cb7ff') },
+    uSpecularBoost: { value: 0.15 },
+  };
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uTime = uniforms.uTime;
+    shader.uniforms.uWaveAmplitude = uniforms.uWaveAmplitude;
+    shader.uniforms.uSecondaryWaveAmplitude = uniforms.uSecondaryWaveAmplitude;
+    shader.uniforms.uWaveFrequency = uniforms.uWaveFrequency;
+    shader.uniforms.uRippleScale = uniforms.uRippleScale;
+    shader.uniforms.uFlowSpeed = uniforms.uFlowSpeed;
+    shader.uniforms.uWaterfallTumble = uniforms.uWaterfallTumble;
+    shader.uniforms.uOpacity = uniforms.uOpacity;
+    shader.uniforms.uWaterfallOpacity = uniforms.uWaterfallOpacity;
+    shader.uniforms.uShallowColor = uniforms.uShallowColor;
+    shader.uniforms.uDeepColor = uniforms.uDeepColor;
+    shader.uniforms.uFoamColor = uniforms.uFoamColor;
+    shader.uniforms.uWaterfallColor = uniforms.uWaterfallColor;
+    shader.uniforms.uSpecularBoost = uniforms.uSpecularBoost;
+
+    shader.vertexShader = shader.vertexShader
+      .replace(
+        '#include <common>',
+        `#include <common>
+attribute float surfaceType;
+attribute vec2 flowDirection;
+attribute float flowStrength;
+attribute float edgeFoam;
+
+uniform float uTime;
+uniform float uWaveAmplitude;
+uniform float uSecondaryWaveAmplitude;
+uniform float uWaveFrequency;
+uniform float uRippleScale;
+uniform float uFlowSpeed;
+uniform float uWaterfallTumble;
+
+varying float vSurfaceType;
+varying vec2 vFlowDirection;
+varying float vFlowStrength;
+varying float vEdgeFoam;
+varying vec3 vWorldPosition;
+        `,
+      )
+      .replace(
+        '#include <begin_vertex>',
+        `#include <begin_vertex>
+float surfaceMask = clamp(surfaceType, 0.0, 1.0);
+float elevationMask = 1.0 - surfaceMask;
+float baseWave = sin((position.x + position.z) * uWaveFrequency + uTime * 0.8);
+float crossWave = sin((position.x * 0.8 - position.z * 1.3) * (uWaveFrequency * 0.85) - uTime * 1.4);
+float swirlWave = sin((position.x * 0.35 + position.z * 0.65) * uRippleScale + uTime * 0.6);
+float directional = dot(flowDirection, vec2(position.x, position.z)) * flowStrength;
+float crest = max(0.0, directional * 0.6);
+float displacement = (baseWave + crossWave * 0.6 + swirlWave * 0.4 + crest) * uWaveAmplitude * elevationMask;
+transformed.y += displacement;
+transformed.xz += flowDirection * flowStrength * 0.08 * elevationMask * sin(uTime * 0.9 + position.y * 0.6);
+if (surfaceMask > 0.5) {
+  float tumble = sin(uTime * uFlowSpeed + position.y * 2.3) * uWaterfallTumble;
+  transformed.x += flowDirection.x * tumble;
+  transformed.z += flowDirection.y * tumble;
+  transformed.y -= abs(flowStrength) * 0.04;
+}
+vSurfaceType = surfaceMask;
+vFlowDirection = flowDirection;
+vFlowStrength = flowStrength;
+vEdgeFoam = edgeFoam;
+vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
+vWorldPosition = worldPos.xyz;
+        `,
+      );
+
+    shader.fragmentShader = shader.fragmentShader
+      .replace(
+        '#include <common>',
+        `#include <common>
+uniform float uOpacity;
+uniform float uWaterfallOpacity;
+uniform vec3 uShallowColor;
+uniform vec3 uDeepColor;
+uniform vec3 uFoamColor;
+uniform vec3 uWaterfallColor;
+uniform float uSpecularBoost;
+
+varying float vSurfaceType;
+varying vec2 vFlowDirection;
+varying float vFlowStrength;
+varying float vEdgeFoam;
+varying vec3 vWorldPosition;
+        `,
+      )
+      .replace(
+        '#include <output_fragment>',
+        `vec3 dreamcastPalette = mix(uDeepColor, uShallowColor, clamp(vWorldPosition.y * 0.035 + 0.55, 0.0, 1.0));
+vec3 waterfallTint = mix(dreamcastPalette, uWaterfallColor, smoothstep(0.35, 1.0, vSurfaceType));
+float foamFactor = smoothstep(0.28, 0.92, vEdgeFoam + vFlowStrength * 0.85);
+vec3 foamColor = uFoamColor * foamFactor * mix(0.35, 0.75, vSurfaceType);
+vec3 paletteTint = waterfallTint;
+diffuseColor.rgb *= paletteTint;
+diffuseColor.rgb += foamColor;
+vec3 dreamcastLight = normalize(vec3(0.22, 0.94, 0.31));
+float sparkle = pow(max(dot(normal, dreamcastLight), 0.0), 18.0) * uSpecularBoost;
+diffuseColor.rgb += sparkle;
+float opacityMix = mix(uOpacity, uWaterfallOpacity, smoothstep(0.45, 0.95, vSurfaceType));
+diffuseColor.a = opacityMix;
+gl_FragColor = diffuseColor;
+        `,
+      );
+  };
+
+  material.customProgramCacheKey = () => 'DreamcastWaterMaterial_v1';
+
+  const update = (delta) => {
+    uniforms.uTime.value += delta;
+  };
+
+  return { material, update };
+}

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1,5 +1,11 @@
 import { createTerrainEngine } from './terrain-engine.js';
 import { populateColumnWithVoxelObjects } from './voxel-object-placement.js';
+import {
+  createFluidSurface,
+  isFluidType,
+  resolveFluidPresence,
+} from './fluids/fluid-registry.js';
+import { buildFluidGeometry } from './fluids/fluid-geometry.js';
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
@@ -36,7 +42,7 @@ export const worldConfig = {
   chunkSize: 48,
   maxHeight: 20,
   baseHeight: 6,
-  waterLevel: 8,
+  waterLevel: 9,
 };
 
 export function terrainHeight(x, z) {
@@ -104,6 +110,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const solidBlockKeys = new Set();
   const softBlockKeys = new Set();
   const waterColumnKeys = new Set();
+  const fluidColumnsByType = new Map();
+  const fluidSurfaces = [];
   const matrix = new THREE.Matrix4();
   const defaultQuaternion = new THREE.Quaternion();
   const reusablePosition = new THREE.Vector3();
@@ -272,9 +280,10 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     const tintColor = paletteBlend;
 
     const isWater = type === 'water';
+    const isFluid = isFluidType(type);
     let collisionMode = options.collisionMode;
     if (!collisionMode) {
-      if (isWater) {
+      if (isFluid) {
         collisionMode = 'liquid';
       } else if (typeof options.isSolid === 'boolean') {
         collisionMode = options.isSolid ? 'solid' : 'none';
@@ -290,7 +299,42 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     const destructible =
       typeof options.destructible === 'boolean'
         ? options.destructible
-        : type !== 'water' && type !== 'cloud';
+        : !isFluid && type !== 'cloud';
+
+    if (isFluid) {
+      if (!fluidColumnsByType.has(type)) {
+        fluidColumnsByType.set(type, new Map());
+      }
+      const columns = fluidColumnsByType.get(type);
+      const columnKey = `${x}|${z}`;
+      const blockTop = y + 0.5;
+      const blockBottom = y - 0.5;
+      let column = columns.get(columnKey);
+      if (!column) {
+        column = {
+          key: columnKey,
+          x,
+          z,
+          minY: blockBottom,
+          maxY: blockTop,
+          color: new THREE.Color(
+            biome?.palette?.water ?? biome?.palette?.cloud ?? '#3a79c5',
+          ),
+          biome,
+        };
+        columns.set(columnKey, column);
+      } else {
+        column.minY = Math.min(column.minY, blockBottom);
+        column.maxY = Math.max(column.maxY, blockTop);
+        if (biome?.palette?.water) {
+          column.color = new THREE.Color(biome.palette.water);
+        }
+      }
+      if (isWater) {
+        waterColumnKeys.add(columnKey);
+      }
+      return;
+    }
     const entry = {
       key,
       coordinateKey,
@@ -322,9 +366,6 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     if (isSoft) {
       softBlockKeys.add(coordinateKey);
 
-    }
-    if (isWater) {
-      waterColumnKeys.add(`${x}|${z}`);
     }
   };
 
@@ -390,6 +431,94 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     }
   }
 
+  const neighborOffsets = [
+    { key: 'px', dx: 1, dz: 0 },
+    { key: 'nx', dx: -1, dz: 0 },
+    { key: 'pz', dx: 0, dz: 1 },
+    { key: 'nz', dx: 0, dz: -1 },
+  ];
+
+  fluidColumnsByType.forEach((columns, type) => {
+    if (!columns || columns.size === 0) {
+      return;
+    }
+
+    columns.forEach((column) => {
+      column.surfaceY = column.maxY;
+      column.bottomY = column.minY;
+      if (!column.color) {
+        column.color = new THREE.Color('#3a79c5');
+      }
+    });
+
+    columns.forEach((column) => {
+      const neighbors = {};
+      let foamExposure = 0;
+      const centerSurface = column.surfaceY;
+
+      neighborOffsets.forEach((offset) => {
+        const nx = column.x + offset.dx;
+        const nz = column.z + offset.dz;
+        const neighborKey = `${nx}|${nz}`;
+        const neighborColumn = columns.get(neighborKey);
+        let neighborInfo;
+        if (neighborColumn) {
+          neighborInfo = {
+            hasFluid: true,
+            surfaceY: neighborColumn.surfaceY,
+            bottomY: neighborColumn.bottomY,
+            foamHint: Math.max(0, centerSurface - neighborColumn.surfaceY),
+          };
+        } else {
+          const presence = resolveFluidPresence({
+            type,
+            x: nx,
+            z: nz,
+            sampleColumnHeight: getColumnHeight,
+            worldConfig,
+          });
+          neighborInfo = {
+            hasFluid: Boolean(presence?.hasFluid),
+            surfaceY: presence?.surfaceY ?? centerSurface,
+            bottomY: presence?.bottomY ?? column.bottomY,
+            foamHint: Math.max(0, centerSurface - (presence?.surfaceY ?? centerSurface)),
+          };
+        }
+        neighbors[offset.key] = neighborInfo;
+        foamExposure = Math.max(foamExposure, neighborInfo.foamHint ?? 0);
+      });
+
+      const dropPx = Math.max(0, centerSurface - (neighbors.px?.surfaceY ?? centerSurface));
+      const dropNx = Math.max(0, centerSurface - (neighbors.nx?.surfaceY ?? centerSurface));
+      const dropPz = Math.max(0, centerSurface - (neighbors.pz?.surfaceY ?? centerSurface));
+      const dropNz = Math.max(0, centerSurface - (neighbors.nz?.surfaceY ?? centerSurface));
+
+      const flowVector = new THREE.Vector2(dropPx - dropNx, dropPz - dropNz);
+      const flowStrength = Math.min(1, flowVector.length() * 0.6);
+      if (flowStrength > 0.001) {
+        flowVector.normalize();
+      } else {
+        flowVector.set(0, 0);
+      }
+
+      column.neighbors = neighbors;
+      column.flowDirection = flowVector;
+      column.flowStrength = flowStrength;
+      column.foamAmount = Math.min(1, foamExposure * 0.18 + flowStrength * 0.4);
+    });
+
+    const geometry = buildFluidGeometry({
+      THREE,
+      columns: Array.from(columns.values()),
+    });
+    if (!geometry.getAttribute('position') || geometry.getAttribute('position').count === 0) {
+      return;
+    }
+    const surface = createFluidSurface({ type, geometry });
+    surface.userData.type = `fluid:${type}`;
+    fluidSurfaces.push(surface);
+  });
+
   const cloudAttempts = 2 + Math.floor(randomAt(chunkX, chunkZ, 12) * 3);
   for (let i = 0; i < cloudAttempts; i++) {
     const offsetX = Math.floor(randomAt(chunkX, chunkZ, 20 + i) * chunkSize);
@@ -402,6 +531,9 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
   const group = new THREE.Group();
   instancedData.forEach((entries, type) => {
+    if (isFluidType(type)) {
+      return;
+    }
     if (entries.length === 0) {
       return;
     }
@@ -440,6 +572,10 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group.add(mesh);
   });
 
+  fluidSurfaces.forEach((surface) => {
+    group.add(surface);
+  });
+
   group.name = `chunk_${chunkX}_${chunkZ}`;
   const totalSamples = chunkSize * chunkSize;
   const biomes = Array.from(biomePresence.values()).map(({ biome, samples }) => ({
@@ -462,6 +598,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     solidBlockKeys,
     softBlockKeys,
     waterColumnKeys,
+    fluidSurfaces,
     blockLookup,
     typeData,
     biomes,


### PR DESCRIPTION
## Summary
- raise the global water level height to encourage nearby fluid columns so the Dreamcast water renderer has geometry to build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d232ae5b34832ab82fc99ac7982719