### PR TITLE
Fix water shader varying conflict

### DIFF
--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -74,8 +74,6 @@ varying vec2 vFlowDirection;
 varying float vFlowStrength;
 varying float vEdgeFoam;
 
-varying vec3 vWorldPosition;
-
         `,
       )
       .replace(


### PR DESCRIPTION
## Summary
- rely on MeshPhysicalMaterial's built-in world-position varying while keeping the Dreamcast water displacement intact

## Testing
- npx vite --host --clearScreen false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2e07ceb68832abd63fa0fae2fe244