### PR TITLE
Restore Dreamcast water height mix

### DIFF
--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -74,8 +74,6 @@ varying vec2 vFlowDirection;
 varying float vFlowStrength;
 varying float vEdgeFoam;
 
-varying vec3 vWorldPosition;
-
         `,
       )
       .replace(
@@ -149,11 +147,7 @@ float surfaceMix = clamp(vSurfaceType, 0.0, 1.0);
 gSurfaceMix = surfaceMix;
 #endif
 #ifdef USE_TRANSMISSION
-
-float dreamcastHeight = clamp(vWorldPosition.y * 0.038 + 0.54, 0.0, 1.0);
-
 float dreamcastHeight = clamp(vWorldPosition.y * 0.04 + 0.48, 0.0, 1.0);
-
 #else
 float dreamcastHeight = 0.62;
 #endif


### PR DESCRIPTION
## Summary
- remove the duplicate dreamcastHeight assignment in the Dreamcast water fragment to let the shader compile cleanly with MeshPhysicalMaterial's built-in world-position varying

## Testing
- npm run dev -- --host
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2e07ceb68832abd63fa0fae2fe244