### PR TITLE
Add fluid debugging logs

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -443,6 +443,13 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       return;
     }
 
+    if (type === 'water') {
+      console.log(
+        '[fluid debug] processing water columns',
+        columns.size,
+      );
+    }
+
     columns.forEach((column) => {
       column.surfaceY = column.maxY;
       column.bottomY = column.minY;
@@ -512,9 +519,15 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       columns: Array.from(columns.values()),
     });
     if (!geometry.getAttribute('position') || geometry.getAttribute('position').count === 0) {
+      if (type === 'water') {
+        console.log('[fluid debug] water geometry has no vertices');
+      }
       return;
     }
     const surface = createFluidSurface({ type, geometry });
+    if (type === 'water') {
+      console.log('[fluid debug] created water surface', surface?.uuid);
+    }
     surface.userData.type = `fluid:${type}`;
     fluidSurfaces.push(surface);
   });
@@ -572,7 +585,11 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group.add(mesh);
   });
 
+  console.log('[fluid debug] fluid surfaces count before group add', fluidSurfaces.length);
   fluidSurfaces.forEach((surface) => {
+    if (surface.userData?.type === 'fluid:water') {
+      console.log('[fluid debug] adding water surface to group', surface.uuid);
+    }
     group.add(surface);
   });
 


### PR DESCRIPTION
## Summary
- add targeted console logging around water fluid geometry creation to trace surface generation
- log fluid surface counts when assembling the chunk group to confirm meshes are added

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ebfda470832aba3277677d704ee1