### PR TITLE
Fix Dreamcast water shader tint and opacity

### DIFF
--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -142,6 +142,12 @@ vec3 gDreamcastPalette;
       .replace(
         '#include <color_fragment>',
         `#include <color_fragment>
+#ifdef USE_COLOR_ALPHA
+diffuseColor *= vColor;
+#elif defined( USE_COLOR )
+diffuseColor.rgb *= vColor;
+#endif
+float baseAlpha = diffuseColor.a;
 float surfaceMix = clamp(vSurfaceType, 0.0, 1.0);
 #ifdef USE_TRANSMISSION
 gSurfaceMix = surfaceMix;
@@ -196,7 +202,10 @@ float translucency = clamp(1.0 - opacityMix, 0.0, 1.0);
 
 vec3 transmittedBiome = mix(lagoonPalette, waterfallPalette, 0.55);
 outgoingLight += transmittedBiome * translucency * 0.36;
-diffuseColor.a = mix(opacityMix, 0.94, fresnel * 0.3);
+float finalAlpha = mix(opacityMix, 0.94, fresnel * 0.3);
+float tintedAlpha = finalAlpha * baseAlpha;
+float fadeFloor = max(0.18, baseAlpha * 0.5);
+diffuseColor.a = clamp(tintedAlpha, fadeFloor, 1.0);
 
         `,
       );


### PR DESCRIPTION
## Summary
- restore vertex color weighting for the Dreamcast water shader before palette mixing
- clamp the computed alpha with a tint-aware floor so water never fades to full transparency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f0b6ffa4832aa201cf7c180b06a7