### PR TITLE
Add dev debug snapshot and player orientation helpers

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -169,6 +169,17 @@ try {
   chunkManager.update(playerControls.getPosition())
   updateHud(playerControls.getState())
 
+  if (import.meta.env.DEV) {
+    const debugNamespace = (window.__VOXEL_DEBUG__ = window.__VOXEL_DEBUG__ || {})
+    debugNamespace.chunkSnapshot = () => chunkManager.debugSnapshot?.()
+    debugNamespace.player = {
+      controls: playerControls,
+      setPosition: (position) => playerControls.setPosition(position),
+      setYawPitch: (yaw, pitch) => playerControls.setYawPitch(yaw, pitch),
+      getYawPitch: () => playerControls.getYawPitch(),
+    }
+  }
+
   const commandConsole = createCommandConsole({
     onToggle: (isOpen) => {
       if (playerControls) {


### PR DESCRIPTION
## Summary
- add a dev-only `debugSnapshot` method to the chunk manager for capturing loaded chunk metadata
- expose `setPosition`, `setYawPitch`, and `getYawPitch` helpers on the player controls while preserving collision safety
- publish the debug helpers from the main bootstrap so they are available during development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31caeaa14832aae2e91bf21991c87