### PR TITLE
Add developer ASCII viewport rendering commands

### DIFF
--- a/three-demo/src/devtools/ascii-viewport.js
+++ b/three-demo/src/devtools/ascii-viewport.js
@@ -1,0 +1,220 @@
+const DEFAULT_RADIUS = 12;
+const DEFAULT_SLICE_THICKNESS = 3;
+
+const GLYPH_RULES = [
+  {
+    glyph: '~',
+    label: 'Water & fluids',
+    test: ({ type, block }) =>
+      block?.isWater === true || /water|fluid|ice/.test(type ?? ''),
+  },
+  {
+    glyph: '#',
+    label: 'Stone & ore',
+    test: ({ type }) => /stone|rock|ore|basalt|granite|slate/.test(type ?? ''),
+  },
+  {
+    glyph: '^',
+    label: 'Vegetation & foliage',
+    test: ({ type }) =>
+      /grass|leaf|leaves|log|wood|tree|mushroom|flower|plant|vine|cactus|shrub/.test(
+        type ?? '',
+      ),
+  },
+  {
+    glyph: '"',
+    label: 'Soil, sand & sediment',
+    test: ({ type }) => /dirt|soil|sand|clay|mud|gravel|silt/.test(type ?? ''),
+  },
+  {
+    glyph: '+',
+    label: 'Built structures & crafted blocks',
+    test: ({ type }) => /brick|plank|metal|glass|torch|lamp|door|stairs/.test(type ?? ''),
+  },
+  {
+    glyph: '%',
+    label: 'Clouds & atmospheric blocks',
+    test: ({ type }) => /cloud|mist|fog/.test(type ?? ''),
+  },
+  {
+    glyph: 'o',
+    label: 'Other solid blocks',
+    test: ({ block }) => block?.isSolid === true,
+  },
+];
+
+const EMPTY_SPACE = { glyph: '.', label: 'Empty space' };
+const PLAYER_MARKER = { glyph: '@', label: 'Player position' };
+const DEFAULT_FALLBACK = { glyph: 'o', label: 'Other solid blocks' };
+
+function normalizeNumber(value, fallback = 0) {
+  const number = Number(value);
+  if (Number.isNaN(number)) {
+    return fallback;
+  }
+  return number;
+}
+
+function resolveSlice(verticalSlice, playerY) {
+  const baseY = Math.round(playerY ?? 0);
+  if (!verticalSlice) {
+    const half = Math.floor(DEFAULT_SLICE_THICKNESS / 2);
+    return { yMin: baseY - half, yMax: baseY + half };
+  }
+  if (typeof verticalSlice === 'number') {
+    const offset = Math.max(0, Math.round(verticalSlice));
+    return { yMin: baseY - offset, yMax: baseY + offset };
+  }
+  const min =
+    typeof verticalSlice.yMin === 'number'
+      ? Math.round(verticalSlice.yMin)
+      : typeof verticalSlice.min === 'number'
+      ? Math.round(verticalSlice.min)
+      : null;
+  const max =
+    typeof verticalSlice.yMax === 'number'
+      ? Math.round(verticalSlice.yMax)
+      : typeof verticalSlice.max === 'number'
+      ? Math.round(verticalSlice.max)
+      : null;
+  if (min !== null || max !== null) {
+    const yMin = min ?? max ?? baseY;
+    const yMax = max ?? min ?? baseY;
+    return {
+      yMin: Math.min(yMin, yMax),
+      yMax: Math.max(yMin, yMax),
+    };
+  }
+  const thickness = normalizeNumber(verticalSlice.thickness, DEFAULT_SLICE_THICKNESS);
+  const offset = normalizeNumber(verticalSlice.offset, 0);
+  const half = Math.max(0, Math.floor(Math.round(thickness) / 2));
+  return {
+    yMin: baseY - half + offset,
+    yMax: baseY + (Math.round(thickness) % 2 === 0 ? half - 1 : half) + offset,
+  };
+}
+
+function buildColumnLookup(chunkSnapshot) {
+  const columns = new Map();
+  const chunks = Array.isArray(chunkSnapshot?.chunks) ? chunkSnapshot.chunks : [];
+  chunks.forEach((chunk) => {
+    const blocks = Array.isArray(chunk?.blocks) ? chunk.blocks : [];
+    blocks.forEach((block) => {
+      const position = block?.position;
+      if (!position) {
+        return;
+      }
+      const worldX = Math.round(position.x ?? position[0] ?? 0);
+      const worldY = Math.round(position.y ?? position[1] ?? 0);
+      const worldZ = Math.round(position.z ?? position[2] ?? 0);
+      const key = `${worldX}|${worldZ}`;
+      if (!columns.has(key)) {
+        columns.set(key, []);
+      }
+      columns.get(key).push({ block, y: worldY });
+    });
+  });
+  columns.forEach((entries) => entries.sort((a, b) => b.y - a.y));
+  return columns;
+}
+
+function selectGlyphForBlock(block) {
+  const type = String(block?.type ?? '').toLowerCase();
+  const match = GLYPH_RULES.find((rule) => rule.test({ type, block }));
+  return match ?? DEFAULT_FALLBACK;
+}
+
+function buildLegend(usedGlyphs) {
+  const legendEntries = new Map();
+  const register = (entry) => {
+    if (!entry || !entry.glyph) {
+      return;
+    }
+    if (legendEntries.has(entry.glyph)) {
+      return;
+    }
+    legendEntries.set(entry.glyph, entry.label ?? '');
+  };
+
+  register(PLAYER_MARKER);
+  GLYPH_RULES.forEach(register);
+  register(DEFAULT_FALLBACK);
+  register(EMPTY_SPACE);
+
+  const lines = ['Legend:'];
+  legendEntries.forEach((label, glyph) => {
+    if (usedGlyphs.has(glyph) || glyph === EMPTY_SPACE.glyph) {
+      lines.push(`${glyph} — ${label}`);
+    }
+  });
+  return lines.join('\n');
+}
+
+export function renderAsciiViewport({
+  chunkSnapshot,
+  playerPosition,
+  radius = DEFAULT_RADIUS,
+  verticalSlice,
+}) {
+  if (!chunkSnapshot) {
+    return {
+      map: 'No chunk snapshot available.',
+      legend: 'Legend: (none — chunk snapshot unavailable)',
+    };
+  }
+
+  const centerX = Math.round(playerPosition?.x ?? 0);
+  const centerZ = Math.round(playerPosition?.z ?? 0);
+  const slice = resolveSlice(verticalSlice, playerPosition?.y);
+  const clampedRadius = Math.max(1, Math.round(radius ?? DEFAULT_RADIUS));
+  const minX = centerX - clampedRadius;
+  const maxX = centerX + clampedRadius;
+  const minZ = centerZ - clampedRadius;
+  const maxZ = centerZ + clampedRadius;
+  const columns = buildColumnLookup(chunkSnapshot);
+  const usedGlyphs = new Set();
+  const lines = [];
+
+  for (let z = maxZ; z >= minZ; z -= 1) {
+    let row = '';
+    for (let x = minX; x <= maxX; x += 1) {
+      let glyph = EMPTY_SPACE.glyph;
+      const key = `${x}|${z}`;
+      const column = columns.get(key);
+      if (column) {
+        const blockEntry = column.find(
+          (entry) => entry.y >= slice.yMin && entry.y <= slice.yMax,
+        );
+        if (blockEntry) {
+          const match = selectGlyphForBlock(blockEntry.block);
+          glyph = match.glyph;
+          usedGlyphs.add(match.glyph);
+        }
+      }
+      if (x === centerX && z === centerZ) {
+        glyph = PLAYER_MARKER.glyph;
+        usedGlyphs.add(PLAYER_MARKER.glyph);
+      }
+      row += glyph;
+    }
+    lines.push(row);
+  }
+
+  if (!usedGlyphs.has(PLAYER_MARKER.glyph)) {
+    usedGlyphs.add(PLAYER_MARKER.glyph);
+  }
+  usedGlyphs.add(EMPTY_SPACE.glyph);
+
+  return {
+    map: lines.join('\n'),
+    legend: buildLegend(usedGlyphs),
+    bounds: {
+      minX,
+      maxX,
+      minZ,
+      maxZ,
+      yMin: slice.yMin,
+      yMax: slice.yMax,
+    },
+  };
+}

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,3 +1,4 @@
+import { renderAsciiViewport } from '../devtools/ascii-viewport.js';
 import { sampleBiomeAt } from '../world/generation.js';
 
 export function registerDeveloperCommands({
@@ -12,6 +13,272 @@ export function registerDeveloperCommands({
   }
 
   const { registerCommand } = commandConsole;
+
+  const asciiState = {
+    options: {
+      radius: 16,
+      lowerOffset: -1,
+      upperOffset: 1,
+    },
+    watch: {
+      mode: 'off',
+      defaultMode: 'interval',
+      intervalMs: 1000,
+      activeIntervalMs: 1000,
+      rafId: null,
+      intervalId: null,
+    },
+    lastErrorMessage: null,
+  };
+
+  const getDebugSnapshot = () => window.__VOXEL_DEBUG__?.chunkSnapshot?.();
+
+  const cloneAsciiOptions = (source = asciiState.options) => ({
+    radius: Math.max(1, Math.round(source.radius ?? 16)),
+    lowerOffset: Math.round(source.lowerOffset ?? -1),
+    upperOffset: Math.round(source.upperOffset ?? 1),
+  });
+
+  const normalizeOffsets = (options) => {
+    if (options.lowerOffset > options.upperOffset) {
+      const temp = options.lowerOffset;
+      options.lowerOffset = options.upperOffset;
+      options.upperOffset = temp;
+    }
+  };
+
+  const applyAsciiTokens = (tokens, options, { allowInterval = false } = {}) => {
+    const updates = [];
+    let nextWatchMode = null;
+    let nextIntervalMs = null;
+
+    tokens.forEach((token) => {
+      const trimmed = token.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      if (allowInterval && ['frame', 'raf'].includes(trimmed.toLowerCase())) {
+        nextWatchMode = 'frame';
+        updates.push('default watch mode=frame');
+        return;
+      }
+
+      if (!trimmed.includes('=')) {
+        if (allowInterval) {
+          const numeric = Number(trimmed);
+          if (!Number.isNaN(numeric)) {
+            nextWatchMode = 'interval';
+            nextIntervalMs = Math.max(16, Math.round(numeric));
+            updates.push(`default interval=${nextIntervalMs}ms`);
+            return;
+          }
+        }
+        throw new Error(
+          'Expected key=value pairs (e.g. radius=16) or interval modifiers when allowed.',
+        );
+      }
+
+      const [rawKey, rawValue] = trimmed.split('=');
+      const key = rawKey.trim().toLowerCase();
+      const value = rawValue.trim();
+      if (!value) {
+        throw new Error(`Missing value for option "${key}".`);
+      }
+
+      if (key === 'radius') {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error('Radius must be a positive number.');
+        }
+        options.radius = Math.max(1, Math.round(parsed));
+        updates.push(`radius=${options.radius}`);
+        return;
+      }
+
+      if (key === 'lower') {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+          throw new Error('Lower offset must be a number.');
+        }
+        options.lowerOffset = Math.round(parsed);
+        updates.push(`lowerOffset=${options.lowerOffset}`);
+        return;
+      }
+
+      if (key === 'upper') {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+          throw new Error('Upper offset must be a number.');
+        }
+        options.upperOffset = Math.round(parsed);
+        updates.push(`upperOffset=${options.upperOffset}`);
+        return;
+      }
+
+      if (key === 'offset') {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+          throw new Error('Offset must be numeric.');
+        }
+        const offset = Math.round(parsed);
+        options.lowerOffset += offset;
+        options.upperOffset += offset;
+        updates.push(`offset=${offset}`);
+        return;
+      }
+
+      if (key === 'thickness') {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error('Thickness must be a positive number.');
+        }
+        const layers = Math.max(1, Math.round(parsed));
+        const half = Math.floor(layers / 2);
+        options.lowerOffset = -half;
+        options.upperOffset = layers % 2 === 0 ? half - 1 : half;
+        updates.push(`thickness=${layers}`);
+        return;
+      }
+
+      if (allowInterval && key === 'interval') {
+        const normalized = value.toLowerCase();
+        if (['frame', 'raf'].includes(normalized)) {
+          nextWatchMode = 'frame';
+          updates.push('default watch mode=frame');
+          return;
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          throw new Error('Interval must be a positive number of milliseconds.');
+        }
+        nextWatchMode = 'interval';
+        nextIntervalMs = Math.max(16, Math.round(parsed));
+        updates.push(`default interval=${nextIntervalMs}ms`);
+        return;
+      }
+
+      throw new Error(`Unknown ASCII option "${key}".`);
+    });
+
+    normalizeOffsets(options);
+
+    return {
+      updates,
+      nextWatchMode,
+      nextIntervalMs,
+    };
+  };
+
+  const buildAsciiView = ({ optionsOverride } = {}) => {
+    const snapshotGetter = getDebugSnapshot();
+    if (typeof snapshotGetter !== 'function') {
+      return { error: 'Chunk snapshot debug hook is not available yet.' };
+    }
+    const snapshot = snapshotGetter();
+    if (!snapshot || !Array.isArray(snapshot.chunks)) {
+      return { error: 'No chunk data has been captured yet.' };
+    }
+    const playerPosition = playerControls.getPosition();
+    const options = optionsOverride ? { ...optionsOverride } : cloneAsciiOptions();
+    normalizeOffsets(options);
+    const baseY = Math.round(playerPosition?.y ?? 0);
+    const yMin = baseY + options.lowerOffset;
+    const yMax = baseY + options.upperOffset;
+    const view = renderAsciiViewport({
+      chunkSnapshot: snapshot,
+      playerPosition,
+      radius: options.radius,
+      verticalSlice: { yMin: Math.min(yMin, yMax), yMax: Math.max(yMin, yMax) },
+    });
+
+    const header = `ASCII viewport — radius ${options.radius}, y ${Math.min(
+      yMin,
+      yMax,
+    )}..${Math.max(yMin, yMax)}`;
+
+    return {
+      header,
+      map: view.map,
+      legend: view.legend,
+    };
+  };
+
+  const outputAsciiView = (view, { showHeader = true } = {}) => {
+    if (!view) {
+      return false;
+    }
+    if (view.error) {
+      if (asciiState.lastErrorMessage !== view.error) {
+        asciiState.lastErrorMessage = view.error;
+        commandConsole.log(`[ASCII] ${view.error}`);
+      }
+      return false;
+    }
+
+    asciiState.lastErrorMessage = null;
+    if (showHeader && view.header) {
+      commandConsole.log(view.header);
+    }
+    if (view.map) {
+      commandConsole.log(view.map);
+    }
+    if (view.legend) {
+      commandConsole.log(view.legend);
+    }
+    return true;
+  };
+
+  const stopAsciiWatch = ({ silent = false } = {}) => {
+    if (asciiState.watch.rafId !== null) {
+      window.cancelAnimationFrame(asciiState.watch.rafId);
+      asciiState.watch.rafId = null;
+    }
+    if (asciiState.watch.intervalId !== null) {
+      window.clearInterval(asciiState.watch.intervalId);
+      asciiState.watch.intervalId = null;
+    }
+    asciiState.watch.mode = 'off';
+    asciiState.watch.activeIntervalMs = asciiState.watch.intervalMs;
+    if (!silent) {
+      commandConsole.log('ASCII watch disabled.');
+    }
+  };
+
+  const startAsciiWatch = ({ mode, intervalMs }) => {
+    stopAsciiWatch({ silent: true });
+    const renderOnce = (showHeader = false) => {
+      const view = buildAsciiView();
+      outputAsciiView(view, { showHeader });
+    };
+
+    if (mode === 'frame') {
+      const frameLoop = () => {
+        renderOnce(false);
+        asciiState.watch.rafId = window.requestAnimationFrame(frameLoop);
+      };
+      asciiState.watch.mode = 'frame';
+      asciiState.watch.activeIntervalMs = null;
+      renderOnce(true);
+      asciiState.watch.rafId = window.requestAnimationFrame(frameLoop);
+      commandConsole.log('ASCII watch enabled (per frame).');
+      return;
+    }
+
+    const effectiveInterval = Math.max(
+      16,
+      Math.round(intervalMs ?? asciiState.watch.intervalMs),
+    );
+    const intervalLoop = () => {
+      renderOnce(false);
+    };
+    asciiState.watch.intervalId = window.setInterval(intervalLoop, effectiveInterval);
+    asciiState.watch.mode = 'interval';
+    asciiState.watch.activeIntervalMs = effectiveInterval;
+    asciiState.watch.intervalMs = effectiveInterval;
+    renderOnce(true);
+    commandConsole.log(`ASCII watch enabled (every ${effectiveInterval} ms).`);
+  };
 
   registerCommand({
     name: 'godmode',
@@ -103,6 +370,129 @@ export function registerDeveloperCommands({
       const message = args.join(' ');
       playerControls.setStatusMessage(message, 5);
       success('Updated status message.');
+    },
+  });
+
+  registerCommand({
+    name: 'asciimap',
+    description: 'Render a top-down ASCII map around the player.',
+    usage: '/asciimap [radius=<n>] [lower=<n>] [upper=<n>] [thickness=<n>] [offset=<n>]',
+    handler: ({ args }) => {
+      const optionsOverride = cloneAsciiOptions();
+      if (args.length > 0) {
+        applyAsciiTokens(args, optionsOverride, { allowInterval: false });
+      }
+      const view = buildAsciiView({ optionsOverride });
+      if (!outputAsciiView(view)) {
+        return;
+      }
+      commandConsole.log('ASCII map render complete.');
+    },
+  });
+
+  registerCommand({
+    name: 'asciioptions',
+    description: 'Configure ASCII map radius and vertical slice.',
+    usage:
+      '/asciioptions [radius=<n>] [lower=<n>] [upper=<n>] [thickness=<n>] [offset=<n>] [interval=<ms|frame>]',
+    handler: ({ args, info }) => {
+      if (args.length === 0) {
+        info(
+          `Radius=${asciiState.options.radius}, vertical offsets=${asciiState.options.lowerOffset}..${asciiState.options.upperOffset}, default watch=${
+            asciiState.watch.defaultMode === 'frame'
+              ? 'per frame'
+              : `${asciiState.watch.intervalMs} ms`
+          }`,
+        );
+        info(
+          'Provide key=value pairs (e.g. radius=20, thickness=5, interval=500) to update these defaults.',
+        );
+        return;
+      }
+
+      const nextOptions = cloneAsciiOptions();
+      const { updates, nextWatchMode, nextIntervalMs } = applyAsciiTokens(args, nextOptions, {
+        allowInterval: true,
+      });
+      asciiState.options = nextOptions;
+      if (nextWatchMode) {
+        asciiState.watch.defaultMode = nextWatchMode;
+      }
+      if (typeof nextIntervalMs === 'number') {
+        asciiState.watch.intervalMs = nextIntervalMs;
+        asciiState.watch.activeIntervalMs = nextIntervalMs;
+      }
+      if (updates.length === 0) {
+        info('No ASCII options changed.');
+      } else {
+        updates.forEach((entry) => commandConsole.log(`Updated ${entry}.`));
+      }
+      const summary =
+        asciiState.watch.defaultMode === 'frame'
+          ? 'per frame'
+          : `${asciiState.watch.intervalMs} ms`;
+      commandConsole.log(
+        `Current ASCII settings — radius=${asciiState.options.radius}, offsets=${asciiState.options.lowerOffset}..${asciiState.options.upperOffset}, default watch cadence=${summary}.`,
+      );
+    },
+  });
+
+  registerCommand({
+    name: 'asciiwatch',
+    description: 'Continuously refresh the ASCII map.',
+    usage: '/asciiwatch [on [frame|ms]]|off',
+    handler: ({ args, info }) => {
+      if (args.length === 0) {
+        if (asciiState.watch.mode === 'off') {
+          info('ASCII watch is currently disabled.');
+        } else if (asciiState.watch.mode === 'frame') {
+          info('ASCII watch is running every frame.');
+        } else {
+          info(
+            `ASCII watch is running every ${asciiState.watch.activeIntervalMs ?? asciiState.watch.intervalMs} ms.`,
+          );
+        }
+        info('Use /asciiwatch on [frame|ms] or /asciiwatch off.');
+        return;
+      }
+
+      const primary = args[0].toLowerCase();
+      if (primary === 'off') {
+        if (asciiState.watch.mode === 'off') {
+          info('ASCII watch is already disabled.');
+          return;
+        }
+        stopAsciiWatch();
+        return;
+      }
+
+      if (primary !== 'on') {
+        throw new Error('Expected "on" or "off" for /asciiwatch.');
+      }
+
+      let mode = asciiState.watch.defaultMode;
+      let intervalMs = asciiState.watch.intervalMs;
+
+      if (args.length > 1) {
+        const modifier = args[1].toLowerCase();
+        if (modifier === 'frame' || modifier === 'raf') {
+          mode = 'frame';
+        } else {
+          const parsed = Number(modifier);
+          if (Number.isFinite(parsed) && parsed > 0) {
+            mode = 'interval';
+            intervalMs = Math.max(16, Math.round(parsed));
+          } else {
+            throw new Error('Provide "frame" or a positive number of milliseconds.');
+          }
+        }
+      }
+
+      if (mode === 'frame') {
+        startAsciiWatch({ mode: 'frame' });
+      } else {
+        startAsciiWatch({ mode: 'interval', intervalMs });
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary
- add an ASCII viewport renderer that bins chunk snapshot blocks, assigns glyphs, and produces a legend for console output
- extend the developer console with /asciimap, /asciioptions, and /asciiwatch commands to render maps on demand or continuously with configurable slices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31e8e16d0832ab47a37dc493ef643