### PR TITLE
Fix ASCII debug snapshot getter

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -56,7 +56,7 @@ export function registerDeveloperCommands({
     lastKey: null,
   };
 
-  const getDebugSnapshot = () => window.__VOXEL_DEBUG__?.chunkSnapshot?.();
+  const getDebugSnapshot = () => window.__VOXEL_DEBUG__?.chunkSnapshot;
 
   const cloneAsciiOptions = (source = asciiState.options) => ({
     radius: Math.max(1, Math.round(source.radius ?? 16)),


### PR DESCRIPTION
## Summary
- update the developer snapshot accessor to return the chunkSnapshot callable instead of invoking it immediately
- keep the ASCII map renderer tolerant of the deferred snapshot callable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34fc34e4c832abca4828e87386780