### PR TITLE
Expose ASCII debug tools for headless testing

### DIFF
--- a/three-demo/src/ui/command-console.js
+++ b/three-demo/src/ui/command-console.js
@@ -118,6 +118,18 @@ export function createCommandConsole(options = {}) {
   container.appendChild(form);
   document.body.appendChild(container);
 
+  const logListeners = new Set();
+
+  function notifyLogListeners(entry) {
+    logListeners.forEach((listener) => {
+      try {
+        listener(entry);
+      } catch (error) {
+        console.error('Command console log listener failed:', error);
+      }
+    });
+  }
+
   function appendLog(message, level = 'info') {
     const entry = createElement('div', `command-console-entry level-${level}`);
     entry.textContent = message;
@@ -126,6 +138,11 @@ export function createCommandConsole(options = {}) {
       logElement.removeChild(logElement.firstChild);
     }
     logElement.scrollTop = logElement.scrollHeight;
+    notifyLogListeners({
+      level,
+      message,
+      timestamp: Date.now(),
+    });
   }
 
   function clearHistoryNavigation() {
@@ -205,6 +222,30 @@ export function createCommandConsole(options = {}) {
     return Array.from(commandMap.values()).sort((a, b) =>
       a.name.localeCompare(b.name),
     );
+  }
+
+  function getLogEntries() {
+    return Array.from(logElement.children).map((child) => {
+      const entry = child;
+      const levelClass = Array.from(entry.classList).find((className) =>
+        className.startsWith('level-'),
+      );
+      const level = levelClass ? levelClass.slice('level-'.length) : 'info';
+      return {
+        level,
+        message: entry.textContent ?? '',
+      };
+    });
+  }
+
+  function addLogListener(listener) {
+    if (typeof listener !== 'function') {
+      throw new Error('addLogListener expects a function.');
+    }
+    logListeners.add(listener);
+    return () => {
+      logListeners.delete(listener);
+    };
   }
 
   function executeCommand(rawInput) {
@@ -390,11 +431,14 @@ export function createCommandConsole(options = {}) {
     registerCommand,
     registerCommands: (commands) => commands.forEach(registerCommand),
     executeCommand,
+    listCommands,
     open: () => setOpen(true),
     close: () => setOpen(false),
     isOpen: () => isOpen,
     dispose,
     log: appendLog,
+    getEntries: getLogEntries,
+    addLogListener,
   };
 }
 


### PR DESCRIPTION
## Summary
- add log subscriptions and command listings to the in-game console so automated tooling can observe command output
- emit ASCII map events and expose debug helpers for fetching views, formatting them, and managing watches from the window.__VOXEL_DEBUG__ namespace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34fc34e4c832abca4828e87386780