### PR TITLE
Persist fluid column metadata in debug snapshots

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -619,6 +619,20 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
   group.userData.biomes = biomes;
 
+  const fluidColumns = new Map();
+  fluidColumnsByType.forEach((columns, type) => {
+    if (!columns) {
+      return;
+    }
+    const columnMap = columns instanceof Map ? new Map(columns) : new Map();
+    if (!(columns instanceof Map)) {
+      Object.entries(columns).forEach(([key, value]) => {
+        columnMap.set(key, value);
+      });
+    }
+    fluidColumns.set(type, columnMap);
+  });
+
   return {
     chunkX,
     chunkZ,
@@ -627,6 +641,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     softBlockKeys,
     waterColumnKeys,
     fluidSurfaces,
+    fluidColumns,
+    fluidColumnsByType: fluidColumns,
     blockLookup,
     typeData,
     biomes,


### PR DESCRIPTION
## Summary
- persist generated fluid column metadata on each chunk so debug systems can reuse it after world generation
- extend the chunk manager's debug snapshot builder to synthesize block entries for stored fluid columns
- smoke-test the ASCII viewport helper to ensure water glyphs appear when nearby fluid columns are present

## Testing
- npm run build
- node --input-type=module <<'EOF' ... EOF

------
https://chatgpt.com/codex/tasks/task_e_68d368e492ac832aa42e8a74ea57fb68