### PR TITLE
Handle fluid intersections in scans

### DIFF
--- a/three-demo/src/devtools/headless-scanner.js
+++ b/three-demo/src/devtools/headless-scanner.js
@@ -97,7 +97,7 @@ export function createHeadlessScanner({ THREE, scene, chunkManager }) {
     const hits = [];
 
     for (const intersection of intersections) {
-      if (!intersection || typeof intersection.instanceId !== 'number') {
+      if (!intersection) {
         continue;
       }
       const blockInfo = chunkManager.getBlockFromIntersection(intersection);


### PR DESCRIPTION
## Summary
- synthesize block descriptors for fluid surfaces when raycasting in the chunk manager
- allow the headless scanner to consume those synthetic fluid hits so diagnostics cover water

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36af8d650832aaf0a05b3ef9a6d02