### PR TITLE
Document headless dev server command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@
   npm run dev
   ```
   This serves the app at `http://localhost:5173/` by default.
+- For remote or headless QA sessions, expose the dev server on all interfaces:
+  ```sh
+  npm run dev -- --host 0.0.0.0
+  ```
 - Before submitting changes, ensure the demo still builds:
   ```sh
   npm run build


### PR DESCRIPTION
## Summary
- document the npm dev server command with --host flag in AGENTS guidance for QA workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d373f520b4832aa587ccaed920f68d