### PR TITLE
Document headless dev server command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@
 - Recommended usage:
   - Launch the Vite dev server (`npm run dev`) to ensure `import.meta.env.DEV` is true.
   - Use `/asciioptions` to configure the ASCII renderer, `/asciimap` or `/asciiwatch` to monitor level state, and `/scan`/`/goto`/`/look` (plus scan watch variants) to navigate and inspect.
+- Teleportation quick reference (player command lives in `three-demo/src/player/dev-commands.js`):
+  - Base syntax: `/teleport <direction(step)> [...]`. Directions are relative to your current view — forward/backward, left/right, up/down. Steps default to `1` block when omitted, so `forward` moves one block while `forward(8)` moves eight.
+  - Accepted direction aliases include `forwards`, `fwd`, `reverse`, `strafeleft`, `straferight`, `ascend`, `descend`, `rise`, and `drop`. Mix multiple tokens in one call (e.g. `/teleport forward(6) up(2) right(3)`) to build a compound offset; conflicting steps that cancel out will throw an error instead of silently doing nothing.
+  - The command samples the player’s yaw/pitch on invocation, so “forward” always tracks where you are looking. If you chain many moves, prefer a single `/teleport` call so the orientation snapshot stays consistent.
+  - World-streamed data is required for targetting features; if no chunks are loaded the command will fail with guidance to move around first.
+  - Mode shortcuts:
+    - `/teleport biome <id|name>`: finds the nearest loaded chunk whose biome id or label matches and lands you at its surface, reporting chunk coordinates and weight percentage when available.
+    - `/teleport fluid <type>`: searches loaded fluid columns of the requested type, offsetting you to hover safely above the surface (or slightly within shallow volumes) while echoing depth/height info.
+    - `/teleport object <id>`: jumps near the center of the closest voxel object instance with the matching `sourceObjectId`, including a summary of bounds and vertical span.
+  - All teleport modes converge on `movePlayerTo`, which snaps to a walkable standing spot; if the destination is obstructed, an explicit error is raised instead of clipping.
 - Limitations: utilities are only wired up in dev builds and are not bundled for production; automated QA scripts should guard against `window.__VOXEL_DEBUG__` being undefined in prod.
 
 ## Code Style
@@ -34,6 +44,10 @@
   npm run dev
   ```
   This serves the app at `http://localhost:5173/` by default.
+- For remote or headless QA sessions, expose the dev server on all interfaces:
+  ```sh
+  npm run dev -- --host 0.0.0.0
+  ```
 - Before submitting changes, ensure the demo still builds:
   ```sh
   npm run build


### PR DESCRIPTION
## Summary
- document the npm dev server command with --host flag in AGENTS guidance for QA workflows
- expand the AGENTS teleport section with relative syntax, aliases, and biome/fluid/object shortcut modes so QA can script moves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d373f520b4832aa587ccaed920f68d