### PR TITLE
Rebuild water shader for stronger surface definition

### DIFF
--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -1,27 +1,5 @@
 export function createHydraWaterMaterial({ THREE }) {
-
-  const material = new THREE.MeshPhysicalMaterial({
-    color: new THREE.Color('#1c6dd9'),
-    roughness: 0.08,
-    metalness: 0.02,
-    transmission: 0.68,
-    thickness: 2.1,
-    attenuationDistance: 2.75,
-    attenuationColor: new THREE.Color('#2ca7ff'),
-    transparent: true,
-    opacity: 1,
-    ior: 1.333,
-    reflectivity: 0.52,
-    clearcoat: 0.38,
-    clearcoatRoughness: 0.15,
-
-    vertexColors: true,
-  });
-
-  material.side = THREE.DoubleSide;
-  material.depthWrite = false;
-
-  material.envMapIntensity = 0.82;
+  const lightDirection = new THREE.Vector3(-0.35, 1, 0.25).normalize();
 
   const uniforms = {
     uTime: { value: 0 },
@@ -39,230 +17,214 @@ export function createHydraWaterMaterial({ THREE }) {
     uHorizonTint: { value: new THREE.Color('#7bd4ff') },
     uUnderwaterColor: { value: new THREE.Color('#052946') },
     uSurfaceGlintColor: { value: new THREE.Color('#66e0ff') },
-
+    uAmbientColor: { value: new THREE.Color('#2a3f58') },
+    uLightColor: { value: new THREE.Color('#ffffff') },
+    uLightDirection: { value: lightDirection },
   };
 
-  material.onBeforeCompile = (shader) => {
-    shader.uniforms.uTime = uniforms.uTime;
+  const vertexShader = `
+    #include <common>
+    #include <fog_pars_vertex>
 
-    shader.uniforms.uPrimaryScale = uniforms.uPrimaryScale;
-    shader.uniforms.uSecondaryScale = uniforms.uSecondaryScale;
-    shader.uniforms.uChoppiness = uniforms.uChoppiness;
-    shader.uniforms.uFlowScale = uniforms.uFlowScale;
-    shader.uniforms.uFoamSpeed = uniforms.uFoamSpeed;
-    shader.uniforms.uFadeDepth = uniforms.uFadeDepth;
-    shader.uniforms.uRefractionStrength = uniforms.uRefractionStrength;
-    shader.uniforms.uEdgeFoamBoost = uniforms.uEdgeFoamBoost;
-    shader.uniforms.uShallowTint = uniforms.uShallowTint;
-    shader.uniforms.uDeepTint = uniforms.uDeepTint;
-    shader.uniforms.uFoamColor = uniforms.uFoamColor;
-    shader.uniforms.uHorizonTint = uniforms.uHorizonTint;
-    shader.uniforms.uUnderwaterColor = uniforms.uUnderwaterColor;
-    shader.uniforms.uSurfaceGlintColor = uniforms.uSurfaceGlintColor;
+    uniform float uTime;
+    uniform float uPrimaryScale;
+    uniform float uSecondaryScale;
+    uniform float uChoppiness;
+    uniform float uFlowScale;
+    uniform float uFoamSpeed;
+    uniform float uFadeDepth;
 
+    attribute vec3 color;
+    attribute float surfaceType;
+    attribute vec2 flowDirection;
+    attribute float flowStrength;
+    attribute float edgeFoam;
+    attribute float depth;
+    attribute float shoreline;
 
-    shader.vertexShader = shader.vertexShader
-      .replace(
-        '#include <common>',
-        `#include <common>
-attribute float surfaceType;
-attribute vec2 flowDirection;
-attribute float flowStrength;
-attribute float edgeFoam;
-attribute float depth;
-attribute float shoreline;
+    varying vec3 vColor;
+    varying vec3 vWorldPosition;
+    varying vec3 vNormal;
+    varying vec2 vFlow;
+    varying float vFoamEdge;
+    varying float vDepth;
+    varying float vShore;
+    varying float vSurfaceType;
+    varying vec2 vWorldXZ;
+    varying float vWaveHeight;
+    varying float vCrest;
 
-uniform float uTime;
+    vec2 getWaveDirection(int index) {
+      if (index == 0) return normalize(vec2(0.85, 0.18));
+      if (index == 1) return normalize(vec2(-0.52, 0.9));
+      if (index == 2) return normalize(vec2(0.34, -0.94));
+      return normalize(vec2(-0.92, -0.38));
+    }
 
-uniform float uPrimaryScale;
-uniform float uSecondaryScale;
-uniform float uChoppiness;
-uniform float uFlowScale;
-uniform float uFoamSpeed;
-uniform float uFadeDepth;
+    float sampleWaveSet(vec2 uv, vec2 flowDir, float flowStrength) {
+      float total = 0.0;
+      float weight = 0.0;
+      for (int i = 0; i < 4; i++) {
+        float t = float(i) / 3.0;
+        vec2 dir = getWaveDirection(i);
+        float freq = mix(0.35, 1.7, t);
+        float speed = mix(0.4, 1.3, t);
+        float amplitude = mix(1.0, 0.4, t);
+        vec2 advected = uv + flowDir * flowStrength * (0.3 + t * 0.3);
+        float phase = dot(dir, advected) * (freq * 6.28318) + uTime * speed;
+        total += sin(phase) * amplitude;
+        weight += amplitude;
+      }
+      return total / max(weight, 0.0001);
+    }
 
-varying float vSurfaceType;
-varying vec2 vFlow;
-varying float vFoamEdge;
-varying float vDepth;
-varying float vShore;
-varying vec3 vDisplacedNormal;
-varying vec3 vWorldPosition;
+    float layeredWaves(vec2 uv, vec2 flowDir, float flowStrength) {
+      float macro = sampleWaveSet(uv * 0.45, flowDir, flowStrength);
+      float mid = sampleWaveSet(uv * 1.15, flowDir, flowStrength * 0.7);
+      float detail = sampleWaveSet(uv * 2.4, flowDir, flowStrength * 0.5);
+      return macro * 0.85 + mid * 0.55 + detail * 0.25;
+    }
 
-float sampleHydraWave(vec2 uv, vec2 flowDir, float flowStrength) {
-  vec2 advected = uv;
-  float time = uTime;
-  vec2 flow = flowDir * (flowStrength * 0.85 + 0.12);
-  advected += flow * time * 0.45;
-  float primary = sin(dot(advected, vec2(0.78, 1.04)) + time * 0.92);
-  float cross = sin(dot(advected, vec2(-1.25, 0.64)) - time * 1.18);
-  float swirl = sin(dot(advected * 1.37, vec2(1.6, -1.1)) + time * 1.65);
-  float micro = sin(dot(advected * 3.4, vec2(0.24, -2.8)) + time * 2.4);
-  return primary * 0.7 + cross * 0.55 + swirl * 0.3 + micro * 0.12;
-}
+    void main() {
+      vec3 localPosition = position;
+      vec2 flowDir = flowStrength > 0.001 ? normalize(flowDirection) : vec2(0.0);
+      float depthFactor = clamp(depth / max(uFadeDepth, 0.0001), 0.05, 1.5);
+      vec2 uv = position.xz;
 
-vec2 sampleHydraSlope(vec2 uv, vec2 flowDir, float flowStrength) {
-  float eps = 0.18;
-  float center = sampleHydraWave(uv, flowDir, flowStrength);
-  float offsetX = sampleHydraWave(uv + vec2(eps, 0.0), flowDir, flowStrength);
-  float offsetZ = sampleHydraWave(uv + vec2(0.0, eps), flowDir, flowStrength);
-  return vec2(offsetX - center, offsetZ - center) / eps;
+      float waveHeight = layeredWaves(uv, flowDir, flowStrength);
+      float displacement = waveHeight * (uPrimaryScale + depthFactor * 0.45);
+      displacement += shoreline * uSecondaryScale * 0.9;
+      displacement += flowStrength * uSecondaryScale * 0.35;
+      localPosition.y += displacement;
+      localPosition.xz += flowDir * (flowStrength * uFlowScale) * (0.4 + shoreline * 0.5);
 
-}
+      float eps = 0.35;
+      float heightX = layeredWaves(uv + vec2(eps, 0.0), flowDir, flowStrength);
+      float heightZ = layeredWaves(uv + vec2(0.0, eps), flowDir, flowStrength);
+      float slopeX = (heightX - waveHeight) / eps;
+      float slopeZ = (heightZ - waveHeight) / eps;
+      float choppy = uChoppiness + depthFactor * 0.3;
+      vec3 bentNormal = normalize(vec3(-slopeX * choppy, 1.0, -slopeZ * choppy));
+      vNormal = normalMatrix * bentNormal;
+      vWaveHeight = waveHeight;
+      vCrest = clamp(length(vec2(slopeX, slopeZ)) * 1.4, 0.0, 1.5);
 
-        `,
-      )
-      .replace(
-        '#include <beginnormal_vertex>',
-        `#include <beginnormal_vertex>
+      vec4 worldPosition = modelMatrix * vec4(localPosition, 1.0);
+      vWorldPosition = worldPosition.xyz;
+      vColor = color;
+      vFlow = flowDir * flowStrength;
+      vFoamEdge = edgeFoam;
+      vDepth = depth;
+      vShore = shoreline;
+      vSurfaceType = surfaceType;
+      vWorldXZ = worldPosition.xz;
 
-vec2 hydraSlope = sampleHydraSlope(position.xz, flowDirection, flowStrength);
-float depthAttenuation = clamp(depth / max(uFadeDepth, 0.001), 0.0, 1.0);
-float choppy = uChoppiness + depthAttenuation * 0.4;
-vec3 bentNormal = normalize(vec3(-hydraSlope.x * choppy, 1.0, -hydraSlope.y * choppy));
-objectNormal = bentNormal;
-vDisplacedNormal = normalMatrix * bentNormal;
+      vec4 mvPosition = viewMatrix * worldPosition;
+      gl_Position = projectionMatrix * mvPosition;
+      #include <fog_vertex>
+    }
+  `;
 
+  const fragmentShader = `
+    #include <common>
+    #include <fog_pars_fragment>
+    #include <tonemapping_pars_fragment>
+    #include <colorspace_pars_fragment>
 
-        `,
-      )
-      .replace(
-        '#include <begin_vertex>',
-        `#include <begin_vertex>
+    uniform float uTime;
+    uniform float uFadeDepth;
+    uniform float uRefractionStrength;
+    uniform float uFoamSpeed;
+    uniform float uEdgeFoamBoost;
+    uniform vec3 uShallowTint;
+    uniform vec3 uDeepTint;
+    uniform vec3 uFoamColor;
+    uniform vec3 uHorizonTint;
+    uniform vec3 uUnderwaterColor;
+    uniform vec3 uSurfaceGlintColor;
+    uniform vec3 uAmbientColor;
+    uniform vec3 uLightColor;
+    uniform vec3 uLightDirection;
 
-vec3 transformed = vec3(position);
-float surfaceMask = clamp(surfaceType, 0.0, 1.0);
-float depthFactor = clamp(depth / max(uFadeDepth, 0.0001), 0.1, 1.6);
-float wave = sampleHydraWave(position.xz, flowDirection, flowStrength);
-float choppyWave = sin(dot(position.xz, vec2(1.3, -0.75)) - uTime * 1.4) * uSecondaryScale;
-float crest = sin(dot(position.xz, flowDirection * 1.9) + uTime * 0.82) * flowStrength * (0.6 + shoreline * 0.45);
-float waterfallBoost = surfaceMask * (shoreline * 1.2 + flowStrength * 0.6);
-float displacement = (wave * uPrimaryScale + choppyWave + crest) * depthFactor + waterfallBoost * uSecondaryScale;
-transformed.y += displacement;
-transformed.xz += flowDirection * (flowStrength * uFlowScale) * (0.6 + shoreline * 0.4) * sin(uTime * 0.8 + displacement);
-vSurfaceType = surfaceMask;
-vFlow = flowDirection * flowStrength;
-vFoamEdge = edgeFoam;
-vDepth = depth;
-vShore = shoreline;
-vec4 worldPosition = modelMatrix * vec4(transformed, 1.0);
-vWorldPosition = worldPosition.xyz;
+    varying vec3 vColor;
+    varying vec3 vWorldPosition;
+    varying vec3 vNormal;
+    varying vec2 vFlow;
+    varying float vFoamEdge;
+    varying float vDepth;
+    varying float vShore;
+    varying float vSurfaceType;
+    varying vec2 vWorldXZ;
+    varying float vWaveHeight;
+    varying float vCrest;
 
+    void main() {
+      vec3 normal = normalize(vNormal);
+      float depthMix = clamp(vDepth / max(uFadeDepth, 0.0001), 0.0, 1.0);
+      float shoreMix = clamp(vShore, 0.0, 1.0);
 
-        `,
-      );
+      float waterfallMask = smoothstep(0.35, 1.0, clamp(vSurfaceType, 0.0, 1.0));
 
-    shader.fragmentShader = shader.fragmentShader
-      .replace(
-        '#include <common>',
-        `#include <common>
+      vec3 shallowTint = mix(vColor, uShallowTint, 0.5);
+      vec3 deepTint = mix(vColor, uDeepTint, 0.8);
+      vec3 scatterTint = mix(shallowTint, deepTint, depthMix);
+      scatterTint = mix(scatterTint, uUnderwaterColor, depthMix * 0.25);
+      float horizonInfluence = (1.0 - depthMix) * 0.4;
+      scatterTint = mix(scatterTint, uHorizonTint, horizonInfluence * 0.5);
 
-uniform float uTime;
-uniform float uFadeDepth;
-uniform float uRefractionStrength;
-uniform float uFoamSpeed;
-uniform float uEdgeFoamBoost;
-uniform vec3 uShallowTint;
-uniform vec3 uDeepTint;
-uniform vec3 uFoamColor;
-uniform vec3 uHorizonTint;
-uniform vec3 uUnderwaterColor;
-uniform vec3 uSurfaceGlintColor;
+      vec3 lightDir = normalize(uLightDirection);
+      float lambert = max(dot(normal, lightDir), 0.0);
+      vec3 lighting = uAmbientColor + uLightColor * lambert;
 
-varying float vSurfaceType;
-varying vec2 vFlow;
-varying float vFoamEdge;
-varying float vDepth;
-varying float vShore;
-varying vec3 vDisplacedNormal;
-varying vec3 vWorldPosition;
+      vec3 viewDir = normalize(cameraPosition - vWorldPosition);
+      float fresnel = pow(1.0 - max(dot(normal, viewDir), 0.0), 5.0);
+      vec3 reflection = mix(uHorizonTint, uSurfaceGlintColor, clamp(fresnel * 1.2, 0.0, 1.0));
+      vec3 base = mix(scatterTint, reflection, clamp(fresnel * 0.75 + 0.15, 0.0, 1.0));
+      base *= lighting;
 
-vec3 gHydraTint;
-vec3 gFoamColor;
-float gHydraDepthMix;
-float gHydraShoreMix;
+      vec2 foamUv = vWorldXZ * 1.2;
+      float foamNoiseA = sin(dot(foamUv, vec2(0.82, 1.73)) + uTime * (uFoamSpeed * 0.8 + length(vFlow))) * 0.5 + 0.5;
+      float foamNoiseB = sin(foamUv.x * 2.1 - foamUv.y * 2.4 + uTime * 1.1) * 0.5 + 0.5;
+      float crestFoam = smoothstep(0.18, 0.85, vCrest * (1.1 + shoreMix * 0.5));
+      float flowFoam = smoothstep(0.1, 0.8, length(vFlow) * 1.4 + vFoamEdge * uEdgeFoamBoost + shoreMix * 0.9);
+      float foamMask = clamp(max(crestFoam, flowFoam), 0.0, 1.0);
+      foamMask = mix(foamMask, foamMask * foamNoiseA, 0.55);
+      foamMask = mix(foamMask, foamMask * foamNoiseB, 0.45);
+      foamMask += waterfallMask * 0.35;
+      foamMask = clamp(foamMask, 0.0, 1.2);
 
-        `,
-      )
-      .replace(
-        '#include <normal_fragment_begin>',
-        `#include <normal_fragment_begin>
-normal = normalize(vDisplacedNormal);
-geometryNormal = normal;
+      vec3 foamColor = uFoamColor * foamMask;
 
+      float waveHighlight = smoothstep(-0.6, 0.9, vWaveHeight);
+      base = mix(base, mix(uFoamColor, uHorizonTint, 0.5), waveHighlight * (1.0 - depthMix) * 0.25);
+      base = mix(base, uShallowTint, (1.0 - depthMix) * 0.15 + shoreMix * 0.2);
+      base += foamColor;
+      base += uFoamColor * fresnel * (0.08 + shoreMix * 0.2);
 
-        `,
-      )
-      .replace(
-        '#include <color_fragment>',
-        `#include <color_fragment>
+      float alphaBase = clamp(0.6 + depthMix * 0.25, 0.0, 1.0);
+      float alpha = clamp(alphaBase + foamMask * 0.25 + waterfallMask * 0.15, 0.0, 1.0);
+      gl_FragColor = vec4(base, alpha);
 
-#ifdef USE_COLOR_ALPHA
-diffuseColor *= vColor;
-#elif defined( USE_COLOR )
-diffuseColor.rgb *= vColor;
-#endif
-float depthMix = clamp(vDepth / max(uFadeDepth, 0.0001), 0.0, 1.0);
-float shoreMix = clamp(vShore, 0.0, 1.0);
-vec3 shallowTint = mix(diffuseColor.rgb, uShallowTint, 0.6);
-vec3 deepTint = mix(diffuseColor.rgb, uDeepTint, 0.85);
-vec3 tint = mix(shallowTint, deepTint, depthMix);
-float waterfallMask = smoothstep(0.35, 1.0, vSurfaceType);
-vec3 horizonBlend = mix(tint, uHorizonTint, 0.35 * (1.0 - depthMix));
-diffuseColor.rgb = mix(horizonBlend, tint, depthMix * 0.7);
-float altitudeMix = clamp(vWorldPosition.y * 0.02 + 0.5, 0.0, 1.0);
-diffuseColor.rgb = mix(
-  diffuseColor.rgb,
-  mix(uHorizonTint, uShallowTint, altitudeMix),
-  0.08 * (1.0 - depthMix),
-);
-float glint = clamp(length(vFlow) * 0.45 + shoreMix * 0.2 + waterfallMask * 0.2, 0.0, 1.0);
-diffuseColor.rgb = mix(diffuseColor.rgb, uSurfaceGlintColor, glint * 0.25);
-float foamNoise = sin(uTime * (uFoamSpeed + length(vFlow) * 0.6) + dot(vFlow, vec2(7.3, -3.1))) * 0.5 + 0.5;
-float foamMask = smoothstep(0.15, 0.9, vFoamEdge * uEdgeFoamBoost + shoreMix * 1.35 + waterfallMask * 0.25);
-vec3 foamColor = uFoamColor * foamMask * (0.65 + foamNoise * 0.4);
-float minAlpha = 0.45;
-float maxAlpha = 0.95;
-diffuseColor.a = mix(minAlpha, maxAlpha, clamp(depthMix * 0.85 + shoreMix * 0.35, 0.0, 1.0));
-gHydraTint = tint;
-gFoamColor = foamColor;
-gHydraDepthMix = depthMix;
-gHydraShoreMix = shoreMix;
+      #include <tonemapping_fragment>
+      #include <colorspace_fragment>
+      #include <fog_fragment>
+    }
+  `;
 
-
-        `,
-      )
-      .replace(
-        'vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;',
-        `vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;
-
-outgoingLight += gFoamColor;
-vec3 viewDir = normalize(-vViewPosition);
-float fresnel = pow(1.0 - max(dot(normalize(vDisplacedNormal), viewDir), 0.0), 3.0);
-vec3 refractionTint = mix(uUnderwaterColor, gHydraTint, clamp(0.25 + gHydraDepthMix * 0.75, 0.0, 1.0));
-outgoingLight = mix(outgoingLight, refractionTint, uRefractionStrength * (1.0 - gHydraDepthMix));
-outgoingLight += uFoamColor * fresnel * (0.08 + gHydraShoreMix * 0.25);
-
-        `,
-      );
-
-    shader.fragmentShader = shader.fragmentShader.replace(
-      'totalDiffuse = mix( totalDiffuse, transmitted.rgb, material.transmission );',
-      `vec3 refractedTint = mix(transmitted.rgb, gHydraTint, 0.7);
-vec3 abyss = mix(uUnderwaterColor, gHydraTint, clamp(gHydraDepthMix * 0.85 + 0.1, 0.0, 1.0));
-totalDiffuse = mix(totalDiffuse, refractedTint, material.transmission);
-totalDiffuse += abyss * (0.2 + (1.0 - material.transmission) * 0.4);
-
-`,
-    );
-  };
-
-  material.customProgramCacheKey = () => 'HydraWaterMaterial_v1';
+  const material = new THREE.ShaderMaterial({
+    name: 'HydraWaterMaterial',
+    uniforms,
+    vertexShader,
+    fragmentShader,
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    fog: true,
+  });
 
   const update = (delta) => {
     uniforms.uTime.value += delta;
     if (uniforms.uTime.value > 10000) {
-
       uniforms.uTime.value = 0;
     }
   };


### PR DESCRIPTION
## Summary
- rebuild the water vertex shader around layered wave sampling so surfaces receive consistent displacement and normals
- compute crest and wave height masks to drive foam, fresnel, and tint blending for a brighter, more visible surface
- lean on built-in cameraPosition uniform to avoid stale view vectors while keeping the shader material update loop intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d373708030832a951655ee027d20ab