### PR TITLE
Add mesh morphing waves to water surfaces

### DIFF
--- a/three-demo/src/rendering/mesh-morpher.js
+++ b/three-demo/src/rendering/mesh-morpher.js
@@ -1,0 +1,135 @@
+export function createMeshMorpher({ THREE }) {
+  if (!THREE) {
+    throw new Error('createMeshMorpher requires a valid THREE namespace');
+  }
+
+  const registry = new Map();
+
+  function registerMesh(mesh, { attributes = ['position'], resetOnUpdate = true } = {}) {
+    if (!mesh || !mesh.geometry) {
+      throw new Error('Mesh morphing requires a mesh with geometry');
+    }
+
+    if (registry.has(mesh)) {
+      return registry.get(mesh);
+    }
+
+    if (!Array.isArray(attributes) || attributes.length === 0) {
+      throw new Error('Mesh morphing requires at least one attribute to track');
+    }
+
+    const trackedAttributes = attributes.map((name) => {
+      const attribute = mesh.geometry.getAttribute(name);
+      if (!attribute) {
+        throw new Error(`Mesh geometry is missing attribute "${name}" required for morphing`);
+      }
+
+      if (typeof attribute.setUsage === 'function') {
+        attribute.setUsage(THREE.DynamicDrawUsage);
+      }
+
+      return {
+        name,
+        attribute,
+        base: attribute.array.slice(0),
+      };
+    });
+
+    const record = {
+      mesh,
+      attributes: trackedAttributes,
+      effects: new Set(),
+      resetOnUpdate,
+    };
+
+    registry.set(mesh, record);
+    return record;
+  }
+
+  function unregisterMesh(mesh) {
+    const record = registry.get(mesh);
+    if (!record) {
+      return;
+    }
+
+    record.attributes.forEach(({ attribute, base }) => {
+      attribute.array.set(base);
+      attribute.needsUpdate = true;
+    });
+
+    registry.delete(mesh);
+  }
+
+  function addEffect(mesh, effect) {
+    if (typeof effect !== 'function') {
+      throw new Error('Morph effects must be provided as functions');
+    }
+
+    const record = registry.get(mesh);
+    if (!record) {
+      throw new Error('Mesh must be registered with the morph system before adding effects');
+    }
+
+    record.effects.add(effect);
+    return () => {
+      record.effects.delete(effect);
+    };
+  }
+
+  function hasMesh(mesh) {
+    return registry.has(mesh);
+  }
+
+  function update(delta, context = {}) {
+    if (!delta || delta <= 0) {
+      return;
+    }
+
+    registry.forEach((record, mesh) => {
+      if (!mesh || !mesh.geometry) {
+        registry.delete(mesh);
+        return;
+      }
+
+      if (record.resetOnUpdate) {
+        record.attributes.forEach(({ attribute, base }) => {
+          attribute.array.set(base);
+        });
+      }
+
+      if (record.effects.size === 0) {
+        return;
+      }
+
+      const effectContext = {
+        ...context,
+        delta,
+        mesh,
+        attributes: record.attributes,
+        getAttribute: (name) => {
+          const entry = record.attributes.find((item) => item.name === name);
+          return entry ? entry.attribute : null;
+        },
+        getAttributeData: (name) => {
+          return record.attributes.find((item) => item.name === name) ?? null;
+        },
+      };
+
+      record.effects.forEach((effect) => {
+        effect(effectContext);
+      });
+
+      record.attributes.forEach(({ attribute }) => {
+        attribute.needsUpdate = true;
+      });
+    });
+  }
+
+  return {
+    registerMesh,
+    unregisterMesh,
+    addEffect,
+    hasMesh,
+    update,
+  };
+}

--- a/three-demo/src/world/fluids/water-material.js
+++ b/three-demo/src/world/fluids/water-material.js
@@ -1,3 +1,60 @@
+import { createMeshMorpher } from '../../rendering/mesh-morpher.js';
+
+const WAVE_SETTINGS = {
+  amplitude: 0.18,
+  baseFrequency: 0.45,
+  baseSpeed: 0.9,
+  crossFrequency: 0.16,
+  crossSpeed: 1.35,
+  flowFrequency: 0.52,
+  flowSpeed: 1.4,
+};
+
+function sampleWave({ x, z, time, flowX, flowZ, flowStrength }) {
+  const {
+    amplitude,
+    baseFrequency,
+    baseSpeed,
+    crossFrequency,
+    crossSpeed,
+    flowFrequency,
+    flowSpeed,
+  } = WAVE_SETTINGS;
+
+  const primaryPhase = x * baseFrequency + time * baseSpeed;
+  const secondaryPhase = z * (baseFrequency * 0.85) + time * (baseSpeed * 0.92);
+  const crossPhase = (x + z) * crossFrequency + time * crossSpeed;
+
+  let value = 0;
+  let derivativeX = 0;
+  let derivativeZ = 0;
+
+  value += 0.6 * Math.sin(primaryPhase);
+  derivativeX += 0.6 * Math.cos(primaryPhase) * baseFrequency;
+
+  value += 0.4 * Math.cos(secondaryPhase);
+  derivativeZ += -0.4 * Math.sin(secondaryPhase) * (baseFrequency * 0.85);
+
+  value += 0.35 * Math.sin(crossPhase);
+  const crossDerivative = Math.cos(crossPhase) * crossFrequency * 0.35;
+  derivativeX += crossDerivative;
+  derivativeZ += crossDerivative;
+
+  if (flowStrength > 0.001) {
+    const flowPhase = (flowX * x + flowZ * z) * flowFrequency + time * flowSpeed;
+    value += flowStrength * 0.5 * Math.sin(flowPhase);
+    const flowDerivative = Math.cos(flowPhase) * flowFrequency * 0.5 * flowStrength;
+    derivativeX += flowDerivative * flowX;
+    derivativeZ += flowDerivative * flowZ;
+  }
+
+  return {
+    value: value * amplitude,
+    derivativeX: derivativeX * amplitude,
+    derivativeZ: derivativeZ * amplitude,
+  };
+}
+
 export function createHydraWaterMaterial({ THREE }) {
   const material = new THREE.MeshPhysicalMaterial({
     color: new THREE.Color('#1f5fbf'),
@@ -19,9 +76,118 @@ export function createHydraWaterMaterial({ THREE }) {
   material.side = THREE.DoubleSide;
   material.depthWrite = false;
 
+  const morpher = createMeshMorpher({ THREE });
+  const cleanupHandlers = new Map();
+  let elapsedTime = 0;
 
-  material.userData.hydraWaterVersion = 'simple-blue-v1';
+  const ensureSurfaceBounds = (mesh) => {
+    const geometry = mesh.geometry;
+    if (!geometry) {
+      return;
+    }
+    if (!geometry.boundingBox) {
+      geometry.computeBoundingBox();
+    }
+    if (!geometry.boundingSphere) {
+      geometry.computeBoundingSphere();
+    }
+    if (geometry.boundingBox) {
+      const padding = WAVE_SETTINGS.amplitude * 1.2;
+      geometry.boundingBox.max.y += padding;
+      geometry.boundingBox.min.y -= padding;
+    }
+    if (geometry.boundingSphere) {
+      geometry.boundingSphere.radius += WAVE_SETTINGS.amplitude * 1.2;
+    }
+  };
 
+  const registerSurface = (mesh) => {
+    if (morpher.hasMesh(mesh)) {
+      return;
+    }
 
-  return { material, update: null };
+    morpher.registerMesh(mesh, { attributes: ['position', 'normal'] });
+
+    const effect = ({ mesh: effectMesh, attributes, elapsedTime: time }) => {
+      const positionData = attributes.find((entry) => entry.name === 'position');
+      const normalData = attributes.find((entry) => entry.name === 'normal');
+      if (!positionData || !normalData) {
+        return;
+      }
+
+      const positionAttribute = positionData.attribute;
+      const normalAttribute = normalData.attribute;
+      const basePositions = positionData.base;
+      const baseNormals = normalData.base;
+      const flowDir = effectMesh.geometry.getAttribute('flowDirection');
+      const flowStrength = effectMesh.geometry.getAttribute('flowStrength');
+
+      const vertexCount = positionAttribute.count;
+      for (let index = 0; index < vertexCount; index += 1) {
+        const baseOffset = index * 3;
+        const baseNormalY = baseNormals[baseOffset + 1];
+        if (baseNormalY < 0.5) {
+          continue;
+        }
+
+        const x = basePositions[baseOffset];
+        const y = basePositions[baseOffset + 1];
+        const z = basePositions[baseOffset + 2];
+
+        const flowX = flowDir ? flowDir.array[index * 2] : 0;
+        const flowZ = flowDir ? flowDir.array[index * 2 + 1] : 0;
+        const flowAmount = flowStrength ? flowStrength.array[index] : 0;
+
+        const { value, derivativeX, derivativeZ } = sampleWave({
+          x,
+          z,
+          time,
+          flowX,
+          flowZ,
+          flowStrength: flowAmount,
+        });
+
+        positionAttribute.array[baseOffset + 1] = y + value;
+
+        const normalX = -derivativeX;
+        const normalY = 1;
+        const normalZ = -derivativeZ;
+        const normalization = 1 / Math.hypot(normalX, normalY, normalZ);
+        normalAttribute.array[baseOffset] = normalX * normalization;
+        normalAttribute.array[baseOffset + 1] = normalY * normalization;
+        normalAttribute.array[baseOffset + 2] = normalZ * normalization;
+      }
+    };
+
+    const removeEffect = morpher.addEffect(mesh, (context) => {
+      effect({ ...context, elapsedTime });
+    });
+
+    cleanupHandlers.set(mesh, () => {
+      removeEffect();
+      morpher.unregisterMesh(mesh);
+    });
+
+    ensureSurfaceBounds(mesh);
+  };
+
+  const disposeSurface = (mesh) => {
+    const cleanup = cleanupHandlers.get(mesh);
+    if (cleanup) {
+      cleanup();
+      cleanupHandlers.delete(mesh);
+    }
+  };
+
+  material.userData.hydraWaterVersion = 'simple-blue-waves-v1';
+
+  return {
+    material,
+    update: (delta) => {
+      elapsedTime += delta;
+      morpher.update(delta, { elapsedTime });
+    },
+    onSurfaceCreated: registerSurface,
+    onSurfaceDisposed: disposeSurface,
+  };
 }


### PR DESCRIPTION
## Summary
- add a reusable mesh morphing helper for dynamically adjusting buffer attributes
- extend the fluid registry to let materials react to surface creation and disposal events
- update the water material to drive a sine-based wave effect and refreshed normals for each surface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d48eaa17b0832a973a8f89fc55500f