### PR TITLE
Add voxel object smoothing and visual offsets

### DIFF
--- a/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
+++ b/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
@@ -19,6 +19,12 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.4,
+      "smoothing": {
+        "segmentOverlap": 0.5,
+        "segmentEndPadding": 0.45,
+        "segmentSubdivisions": 2,
+        "nodeInflate": 0.22
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#6a4d84" },
       "nodes": [
         {

--- a/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
+++ b/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
@@ -20,6 +20,12 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.38,
+      "smoothing": {
+        "segmentOverlap": 0.45,
+        "segmentEndPadding": 0.4,
+        "segmentSubdivisions": 2,
+        "nodeInflate": 0.2
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#37b47a" },
       "nodes": [
         {

--- a/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
+++ b/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
@@ -19,6 +19,12 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.42,
+      "smoothing": {
+        "segmentOverlap": 0.4,
+        "segmentEndPadding": 0.35,
+        "segmentSubdivisions": 2,
+        "nodeInflate": 0.18
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#f8a7ff" },
       "nodes": [
         {


### PR DESCRIPTION
## Summary
- add configurable smoothing metadata to the node-growth generator for procedural voxel objects
- render smoothed voxel segments by applying visual-only scale and offset adjustments during placement and chunk instancing
- enable smoothing presets on large plant definitions to tighten visuals around their node-based segments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bb146ab4832aa2af5e3e0bd74660