### PR TITLE
Enhance voxel smoothing and decorative layering

### DIFF
--- a/three-demo/src/world/procedural/node-growth-generator.js
+++ b/three-demo/src/world/procedural/node-growth-generator.js
@@ -1,8 +1,156 @@
 const DEFAULT_STEP = 0.5;
 const MIN_STEP = 0.05;
 
+const DEFAULT_SMOOTHING = {
+  nodeInflate: 0,
+  segmentOverlap: 0,
+  segmentEndPadding: 0,
+  segmentSubdivisions: 1,
+  embed: 0,
+  featherLayers: 0,
+  featherRadius: 0,
+  featherSpacing: 0.25,
+  featherScale: 0.15,
+  featherTint: null,
+  microJitter: 0,
+};
+
 function lerp(a, b, t) {
   return a + (b - a) * t;
+}
+
+function normalizeSmoothingConfig(value, fallback = DEFAULT_SMOOTHING) {
+  const base = {
+    nodeInflate:
+      typeof fallback?.nodeInflate === 'number'
+        ? fallback.nodeInflate
+        : DEFAULT_SMOOTHING.nodeInflate,
+    segmentOverlap:
+      typeof fallback?.segmentOverlap === 'number'
+        ? fallback.segmentOverlap
+        : DEFAULT_SMOOTHING.segmentOverlap,
+    segmentEndPadding:
+      typeof fallback?.segmentEndPadding === 'number'
+        ? fallback.segmentEndPadding
+        : DEFAULT_SMOOTHING.segmentEndPadding,
+    segmentSubdivisions:
+      typeof fallback?.segmentSubdivisions === 'number'
+        ? fallback.segmentSubdivisions
+        : DEFAULT_SMOOTHING.segmentSubdivisions,
+    embed:
+      typeof fallback?.embed === 'number'
+        ? fallback.embed
+        : DEFAULT_SMOOTHING.embed,
+    featherLayers:
+      typeof fallback?.featherLayers === 'number'
+        ? fallback.featherLayers
+        : DEFAULT_SMOOTHING.featherLayers,
+    featherRadius:
+      typeof fallback?.featherRadius === 'number'
+        ? fallback.featherRadius
+        : DEFAULT_SMOOTHING.featherRadius,
+    featherSpacing:
+      typeof fallback?.featherSpacing === 'number'
+        ? fallback.featherSpacing
+        : DEFAULT_SMOOTHING.featherSpacing,
+    featherScale:
+      typeof fallback?.featherScale === 'number'
+        ? fallback.featherScale
+        : DEFAULT_SMOOTHING.featherScale,
+    featherTint:
+      typeof fallback?.featherTint === 'string'
+        ? fallback.featherTint
+        : DEFAULT_SMOOTHING.featherTint,
+    microJitter:
+      typeof fallback?.microJitter === 'number'
+        ? fallback.microJitter
+        : DEFAULT_SMOOTHING.microJitter,
+  };
+
+  if (!value || typeof value !== 'object') {
+    return { ...base };
+  }
+
+  const numeric = (candidate) =>
+    typeof candidate === 'number' && !Number.isNaN(candidate) ? candidate : null;
+
+  const stringValue = (candidate) =>
+    typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+
+  const nodeInflate = numeric(value.nodeInflate ?? value.nodePadding);
+  if (nodeInflate !== null) {
+    base.nodeInflate = Math.max(0, nodeInflate);
+  }
+
+  const segmentOverlap = numeric(
+    value.segmentOverlap ?? value.overlap ?? value.segmentVisualOverlap,
+  );
+  if (segmentOverlap !== null) {
+    base.segmentOverlap = Math.max(0, segmentOverlap);
+  }
+
+  const segmentEndPadding = numeric(
+    value.segmentEndPadding ?? value.endPadding ?? value.padding ?? value.nodeBlendPadding,
+  );
+  if (segmentEndPadding !== null) {
+    base.segmentEndPadding = Math.max(0, segmentEndPadding);
+  }
+
+  const segmentSubdivisions = numeric(
+    value.segmentSubdivisions ?? value.subdivisions ?? value.segmentLerpSteps,
+  );
+  if (segmentSubdivisions !== null) {
+    base.segmentSubdivisions = Math.max(1, Math.floor(segmentSubdivisions));
+  }
+
+  const embed = numeric(value.embed ?? value.segmentEmbed ?? value.segmentInset);
+  if (embed !== null) {
+    base.embed = Math.max(0, embed);
+  }
+
+  const featherLayers = numeric(
+    value.featherLayers ?? value.layers ?? value.feather ?? value.featherCount,
+  );
+  if (featherLayers !== null) {
+    base.featherLayers = Math.max(0, Math.floor(featherLayers));
+  }
+
+  const featherRadius = numeric(
+    value.featherRadius ?? value.featherSpread ?? value.ribbonRadius,
+  );
+  if (featherRadius !== null) {
+    base.featherRadius = Math.max(0, featherRadius);
+  }
+
+  const featherSpacing = numeric(
+    value.featherSpacing ?? value.featherStep ?? value.ribbonSpacing,
+  );
+  if (featherSpacing !== null) {
+    base.featherSpacing = Math.max(0, featherSpacing);
+  }
+
+  const featherScale = numeric(
+    value.featherScale ?? value.featherGrowth ?? value.ribbonScale,
+  );
+  if (featherScale !== null) {
+    base.featherScale = Math.max(0, featherScale);
+  }
+
+  const microJitter = numeric(
+    value.microJitter ?? value.jitter ?? value.wobble ?? value.sparkle,
+  );
+  if (microJitter !== null) {
+    base.microJitter = Math.max(0, microJitter);
+  }
+
+  const featherTint = stringValue(
+    value.featherTint ?? value.accentTint ?? value.ribbonTint ?? value.tint,
+  );
+  if (featherTint !== null) {
+    base.featherTint = featherTint;
+  }
+
+  return { ...base };
 }
 
 function clampStep(step) {
@@ -158,21 +306,49 @@ export function generateNodeGrowthVoxels(object, config) {
     config.defaultVoxel,
   );
 
+  const baseSmoothing = normalizeSmoothingConfig(
+    config.smoothing ?? config.visual?.smoothing ?? null,
+  );
+
   (config.nodes || []).forEach((node) => {
     if (!node || typeof node.id !== 'string') {
       return;
     }
     const position = toVector3(node.position);
-    nodes.set(node.id, { ...node, position });
+    const nodeSmoothing = normalizeSmoothingConfig(node.smoothing, baseSmoothing);
+    nodes.set(node.id, { ...node, position, smoothing: nodeSmoothing });
     const nodeVoxelConfig = normalizeVoxelConfig(node.voxel, defaultNodeVoxel);
     if (nodeVoxelConfig) {
       const size = toSize(
         node.voxel?.size ?? config.nodeSize ?? config.segmentSize ?? 1,
       );
+      let metadata = nodeVoxelConfig.metadata ? { ...nodeVoxelConfig.metadata } : null;
+      const nodeSmoothingActive =
+        nodeSmoothing.nodeInflate > 0 ||
+        nodeSmoothing.embed > 0 ||
+        nodeSmoothing.featherLayers > 0 ||
+        nodeSmoothing.microJitter > 0;
+      if (nodeSmoothingActive) {
+        const visual = { ...(metadata?.visual ?? {}) };
+        visual.smoothing = {
+          ...(visual.smoothing ?? {}),
+          type: 'node',
+          inflate: nodeSmoothing.nodeInflate,
+          embed: nodeSmoothing.embed,
+          featherLayers: nodeSmoothing.featherLayers,
+          featherRadius: nodeSmoothing.featherRadius,
+          featherSpacing: nodeSmoothing.featherSpacing,
+          featherScale: nodeSmoothing.featherScale,
+          featherTint: nodeSmoothing.featherTint,
+          microJitter: nodeSmoothing.microJitter,
+        };
+        metadata = { ...(metadata ?? {}), visual };
+      }
       addVoxel(voxels, usedKeys, {
         ...nodeVoxelConfig,
         position,
         size,
+        metadata,
       });
     }
   });
@@ -205,9 +381,12 @@ export function generateNodeGrowthVoxels(object, config) {
     }
 
     const stepSize = clampStep(segment.step ?? config.step ?? DEFAULT_STEP);
-    const steps = segment.steps
+    const segmentSmoothing = normalizeSmoothingConfig(segment.smoothing, baseSmoothing);
+    const subdivisions = Math.max(1, segmentSmoothing.segmentSubdivisions);
+    const steps = (segment.steps
       ? Math.max(1, Math.floor(segment.steps))
-      : Math.max(1, Math.ceil(length / stepSize));
+      : Math.max(1, Math.ceil(length / stepSize))) * subdivisions;
+    const stepLength = length / steps;
 
     const startSize = toSize(
       segment.startSize ?? segment.size ?? config.segmentSize ?? 1,
@@ -226,6 +405,28 @@ export function generateNodeGrowthVoxels(object, config) {
 
     const includeStart = segment.includeStart ?? false;
     const includeEnd = segment.includeEnd ?? true;
+
+    const direction = {
+      x: delta.x / length,
+      y: delta.y / length,
+      z: delta.z / length,
+    };
+    const startPaddingValue = Math.max(
+      segmentSmoothing.segmentEndPadding,
+      fromNode.smoothing?.nodeInflate ?? 0,
+    );
+    const endPaddingValue = Math.max(
+      segmentSmoothing.segmentEndPadding,
+      toNode.smoothing?.nodeInflate ?? 0,
+    );
+
+    const smoothingActive =
+      segmentSmoothing.segmentOverlap > 0 ||
+      startPaddingValue > 0 ||
+      endPaddingValue > 0 ||
+      segmentSmoothing.embed > 0 ||
+      segmentSmoothing.featherLayers > 0 ||
+      segmentSmoothing.microJitter > 0;
 
     for (let i = 0; i <= steps; i += 1) {
       if (i === 0 && !includeStart) {
@@ -252,11 +453,38 @@ export function generateNodeGrowthVoxels(object, config) {
         tint = mixed ? tintToHex(mixed) : tint;
       }
 
+      let metadata = segmentVoxel.metadata ? { ...segmentVoxel.metadata } : null;
+      if (smoothingActive) {
+        const visual = { ...(metadata?.visual ?? {}) };
+        visual.smoothing = {
+          ...(visual.smoothing ?? {}),
+          type: 'segment',
+          overlap: segmentSmoothing.segmentOverlap,
+          stepLength,
+          direction: { ...direction },
+          distanceFromStart: length * t,
+          distanceFromEnd: length * (1 - t),
+          startPadding: startPaddingValue,
+          endPadding: endPaddingValue,
+          embed: segmentSmoothing.embed,
+          featherLayers: segmentSmoothing.featherLayers,
+          featherRadius: segmentSmoothing.featherRadius,
+          featherSpacing: segmentSmoothing.featherSpacing,
+          featherScale: segmentSmoothing.featherScale,
+          featherTint: segmentSmoothing.featherTint,
+          microJitter: segmentSmoothing.microJitter,
+          progress: t,
+          steps,
+        };
+        metadata = { ...(metadata ?? {}), visual };
+      }
+
       addVoxel(voxels, usedKeys, {
         ...segmentVoxel,
         position,
         size,
         tint,
+        metadata,
       });
     }
   });

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -27,6 +27,268 @@ function resolveScaleVector({ size }, voxelScale) {
 }
 
 
+const ZERO_OFFSET = { x: 0, y: 0, z: 0 };
+
+function cloneScale(scale) {
+  return { x: scale.x, y: scale.y, z: scale.z };
+}
+
+function cloneOffset(offset) {
+  return { x: offset.x, y: offset.y, z: offset.z };
+}
+
+function seededRandom(...components) {
+  let hash = 2166136261;
+  components.forEach((component) => {
+    const str = String(component);
+    for (let i = 0; i < str.length; i += 1) {
+      hash ^= str.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+  });
+  return (hash >>> 0) / 4294967296;
+}
+
+function seededRandomCentered(...components) {
+  return seededRandom(...components) * 2 - 1;
+}
+
+function normalizeVector(vector) {
+  const length = Math.hypot(vector.x, vector.y, vector.z);
+  if (length === 0) {
+    return null;
+  }
+  return { x: vector.x / length, y: vector.y / length, z: vector.z / length };
+}
+
+function crossVectors(a, b) {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function scaleVector(vector, amount) {
+  return { x: vector.x * amount, y: vector.y * amount, z: vector.z * amount };
+}
+
+function addVectors(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function createLocalFrame(direction) {
+  const forward = normalizeVector(direction);
+  if (!forward) {
+    return null;
+  }
+  const upHint = Math.abs(forward.y) < 0.999 ? { x: 0, y: 1, z: 0 } : { x: 1, y: 0, z: 0 };
+  let right = normalizeVector(crossVectors(upHint, forward));
+  if (!right) {
+    right = { x: 1, y: 0, z: 0 };
+  }
+  let up = normalizeVector(crossVectors(forward, right));
+  if (!up) {
+    up = { x: 0, y: 1, z: 0 };
+  }
+  return { forward, right, up };
+}
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function parseHexColor(hex) {
+  if (typeof hex !== 'string') {
+    return null;
+  }
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!match) {
+    return null;
+  }
+  const int = parseInt(match[1], 16);
+  return {
+    r: (int >> 16) & 0xff,
+    g: (int >> 8) & 0xff,
+    b: int & 0xff,
+  };
+}
+
+function colorToHex({ r, g, b }) {
+  const clamp = (component) =>
+    Math.max(0, Math.min(255, Math.round(component))).toString(16).padStart(2, '0');
+  return `#${clamp(r)}${clamp(g)}${clamp(b)}`;
+}
+
+function blendTint(baseHex, accentHex, mix) {
+  const mixValue = clamp01(mix);
+  const base = parseHexColor(baseHex) ?? { r: 255, g: 255, b: 255 };
+  const accent = parseHexColor(accentHex) ?? { r: 255, g: 255, b: 255 };
+  return colorToHex({
+    r: base.r + (accent.r - base.r) * mixValue,
+    g: base.g + (accent.g - base.g) * mixValue,
+    b: base.b + (accent.b - base.b) * mixValue,
+  });
+}
+
+function computeSegmentVisualAdjustments(voxel, smoothing, scale, object) {
+  const direction = smoothing.direction ?? ZERO_OFFSET;
+  const length = Math.hypot(direction.x, direction.y, direction.z);
+  if (length === 0) {
+    return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+  }
+
+  const unit = {
+    x: direction.x / length,
+    y: direction.y / length,
+    z: direction.z / length,
+  };
+
+  const stepLength = Math.max(0, smoothing.stepLength ?? 0) * object.voxelScale;
+  const overlapRatio = Math.max(0, smoothing.overlap ?? 0);
+  const extendWorld = stepLength * overlapRatio;
+
+  const startPadding = Math.max(0, smoothing.startPadding ?? 0) * object.voxelScale;
+  const endPadding = Math.max(0, smoothing.endPadding ?? 0) * object.voxelScale;
+  const distanceFromStart =
+    Math.max(0, smoothing.distanceFromStart ?? 0) * object.voxelScale;
+  const distanceFromEnd =
+    Math.max(0, smoothing.distanceFromEnd ?? 0) * object.voxelScale;
+
+  const startAllowance = distanceFromStart + startPadding;
+  const endAllowance = distanceFromEnd + endPadding;
+  const startBias = Math.max(0, startPadding - distanceFromStart);
+  const endBias = Math.max(0, endPadding - distanceFromEnd);
+  const halfExtend = extendWorld / 2;
+
+  const computeExtend = (allowance, bias) => {
+    if (allowance <= 0 && bias <= 0 && halfExtend <= 0) {
+      return 0;
+    }
+    const desired = halfExtend + bias;
+    if (desired <= 0) {
+      return 0;
+    }
+    return Math.min(allowance, desired);
+  };
+
+  const backExtend = computeExtend(startAllowance, startBias);
+  const forwardExtend = computeExtend(endAllowance, endBias);
+  const actualExtend = backExtend + forwardExtend;
+
+  const visualScale = cloneScale(scale);
+  if (actualExtend > 0) {
+    visualScale.x += Math.abs(unit.x) * actualExtend;
+    visualScale.y += Math.abs(unit.y) * actualExtend;
+    visualScale.z += Math.abs(unit.z) * actualExtend;
+  }
+
+  let visualOffset = ZERO_OFFSET;
+  const offsetAlong = (forwardExtend - backExtend) / 2;
+  if (offsetAlong !== 0) {
+    visualOffset = {
+      x: unit.x * offsetAlong,
+      y: unit.y * offsetAlong,
+      z: unit.z * offsetAlong,
+    };
+  }
+
+  const embed = Math.max(0, smoothing.embed ?? 0) * object.voxelScale;
+  if (embed > 0) {
+    const startSpan = Math.max(stepLength + startPadding, stepLength || 1);
+    const endSpan = Math.max(stepLength + endPadding, stepLength || 1);
+    const startInfluence = clamp01(1 - distanceFromStart / startSpan);
+    const endInfluence = clamp01(1 - distanceFromEnd / endSpan);
+    const embedStrength = Math.max(startInfluence, endInfluence);
+    if (embedStrength > 0) {
+      const shrink = embed * embedStrength;
+      visualScale.x = Math.max(0.01, visualScale.x - shrink);
+      visualScale.y = Math.max(0.01, visualScale.y - shrink);
+      visualScale.z = Math.max(0.01, visualScale.z - shrink);
+      const embedBias = endInfluence - startInfluence;
+      const embedOffset = embed * embedBias * 0.5;
+      if (embedOffset !== 0) {
+        const offsetDelta = {
+          x: unit.x * embedOffset,
+          y: unit.y * embedOffset,
+          z: unit.z * embedOffset,
+        };
+        visualOffset = visualOffset === ZERO_OFFSET ? offsetDelta : addVectors(visualOffset, offsetDelta);
+      }
+    }
+  }
+
+  const decorativeLayers = Math.max(0, smoothing.featherLayers ?? 0);
+  if (decorativeLayers > 0) {
+    const shrinkFactor = Math.max(0.55, 1 - decorativeLayers * 0.08);
+    visualScale.x *= shrinkFactor;
+    visualScale.y *= shrinkFactor;
+    visualScale.z *= shrinkFactor;
+  }
+
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0);
+  if (jitterStrength > 0) {
+    const amplitude = jitterStrength * object.voxelScale * 0.35;
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jx') * amplitude,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jy') * amplitude,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jz') * amplitude,
+    };
+    visualOffset = visualOffset === ZERO_OFFSET ? jitter : addVectors(visualOffset, jitter);
+  }
+
+  return { visualScale, visualOffset };
+}
+
+function computeVisualAdjustments(voxel, scale, object) {
+  const smoothing = voxel?.metadata?.visual?.smoothing;
+  if (!smoothing) {
+    return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+  }
+
+  if (smoothing.type === 'node') {
+    const inflate = Math.max(0, smoothing.inflate ?? 0) * object.voxelScale;
+    const visualScale = cloneScale(scale);
+    if (inflate > 0) {
+      visualScale.x += inflate;
+      visualScale.y += inflate;
+      visualScale.z += inflate;
+    }
+    const embed = Math.max(0, smoothing.embed ?? 0) * object.voxelScale;
+    if (embed > 0) {
+      visualScale.x = Math.max(0.01, visualScale.x - embed);
+      visualScale.y = Math.max(0.01, visualScale.y - embed);
+      visualScale.z = Math.max(0.01, visualScale.z - embed);
+    }
+    const decorativeLayers = Math.max(0, smoothing.featherLayers ?? 0);
+    if (decorativeLayers > 0) {
+      const shrinkFactor = Math.max(0.5, 1 - decorativeLayers * 0.12);
+      visualScale.x *= shrinkFactor;
+      visualScale.y *= shrinkFactor;
+      visualScale.z *= shrinkFactor;
+    }
+    let visualOffset = ZERO_OFFSET;
+    const jitterStrength = Math.max(0, smoothing.microJitter ?? 0);
+    if (jitterStrength > 0) {
+      const amplitude = jitterStrength * object.voxelScale * 0.35;
+      const jitter = {
+        x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jx') * amplitude,
+        y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jy') * amplitude,
+        z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jz') * amplitude,
+      };
+      visualOffset = jitter;
+    }
+    return { visualScale, visualOffset };
+  }
+
+  if (smoothing.type === 'segment') {
+    return computeSegmentVisualAdjustments(voxel, smoothing, scale, object);
+  }
+
+  return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+}
+
+
 function resolveCollisionMode(voxel, object) {
   if (voxel?.collisionMode) {
     return voxel.collisionMode;
@@ -41,6 +303,175 @@ function resolveCollisionMode(voxel, object) {
   return object.voxelScale < 1 ? 'none' : 'solid';
 }
 
+function computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing) {
+  const layerCount = Math.max(0, smoothing.featherLayers ?? 0);
+  if (layerCount === 0) {
+    return [];
+  }
+  const frame = createLocalFrame(smoothing.direction ?? ZERO_OFFSET);
+  if (!frame) {
+    return [];
+  }
+
+  const baseOffset =
+    basePlacement.visualOffset === ZERO_OFFSET
+      ? ZERO_OFFSET
+      : cloneOffset(basePlacement.visualOffset);
+  const spacing = Math.max(0, smoothing.featherSpacing ?? 0.2) * object.voxelScale;
+  const radius = Math.max(0, smoothing.featherRadius ?? 0.25) * object.voxelScale;
+  const scaleFactor = Math.max(0, smoothing.featherScale ?? 0.1);
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0) * object.voxelScale * 0.45;
+  const baseTint = basePlacement.tint;
+  const accentTint = smoothing.featherTint ?? baseTint;
+
+  const placements = [];
+  for (let i = 1; i <= layerCount; i += 1) {
+    const layerRatio = i / (layerCount + 1);
+    const alongOffset = (i - (layerCount + 1) / 2) * spacing * 0.6;
+    const swirlSeed = seededRandom(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer');
+    const swirlAngle = (smoothing.progress ?? 0) * Math.PI * 2 + swirlSeed * Math.PI * 2;
+    const radialAmount = radius * (0.65 + 0.35 * (1 - layerRatio));
+    const radialOffset = addVectors(
+      scaleVector(frame.right, Math.cos(swirlAngle) * radialAmount),
+      scaleVector(frame.up, Math.sin(swirlAngle) * radialAmount),
+    );
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jx') *
+        jitterStrength,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jy') *
+        jitterStrength,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jz') *
+        jitterStrength,
+    };
+    const offset = addVectors(
+      baseOffset,
+      addVectors(scaleVector(frame.forward, alongOffset), addVectors(radialOffset, jitter)),
+    );
+
+    const scaleMultiplier = 1 + scaleFactor * (1 - layerRatio * 0.75);
+    const visualScale = {
+      x: basePlacement.visualScale.x * scaleMultiplier,
+      y: basePlacement.visualScale.y * (1 + scaleFactor * (1 - layerRatio) * 0.5),
+      z: basePlacement.visualScale.z * scaleMultiplier,
+    };
+
+    const tintMix = 0.35 + layerRatio * 0.35;
+    const tint = blendTint(baseTint, accentTint, tintMix);
+
+    placements.push({
+      type: voxel.type,
+      worldX: basePlacement.worldX,
+      worldY: basePlacement.worldY,
+      worldZ: basePlacement.worldZ,
+      options: {
+        scale: basePlacement.scale,
+        visualScale,
+        visualOffset: offset,
+        tint,
+        collisionMode: 'none',
+        isSolid: false,
+        destructible: basePlacement.destructible,
+        sourceObjectId: object.id,
+        voxelIndex: voxel.index,
+        metadata: basePlacement.metadata,
+        key: `${basePlacement.key}|layer-${i}`,
+      },
+    });
+  }
+
+  return placements;
+}
+
+function computeNodeFeatherPlacements(voxel, basePlacement, object, smoothing) {
+  const layerCount = Math.max(0, smoothing.featherLayers ?? 0);
+  if (layerCount === 0) {
+    return [];
+  }
+
+  const baseOffset =
+    basePlacement.visualOffset === ZERO_OFFSET
+      ? ZERO_OFFSET
+      : cloneOffset(basePlacement.visualOffset);
+  const radius = Math.max(0, smoothing.featherRadius ?? 0.35) * object.voxelScale;
+  const scaleFactor = Math.max(0, smoothing.featherScale ?? 0.2);
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0) * object.voxelScale * 0.5;
+  const baseTint = basePlacement.tint;
+  const accentTint = smoothing.featherTint ?? baseTint;
+
+  const placements = [];
+  for (let i = 1; i <= layerCount; i += 1) {
+    const layerRatio = i / (layerCount + 1);
+    const angle = seededRandom(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-angle') *
+      Math.PI * 2;
+    const verticalSwing = seededRandomCentered(
+      object.id ?? 'object',
+      voxel.index ?? 0,
+      i,
+      'node-layer-vertical',
+    );
+    const radialAmount = radius * layerRatio;
+    const offset = {
+      x: Math.cos(angle) * radialAmount,
+      y: verticalSwing * radius * 0.4,
+      z: Math.sin(angle) * radialAmount,
+    };
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jx') *
+        jitterStrength,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jy') *
+        jitterStrength,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jz') *
+        jitterStrength,
+    };
+    const finalOffset = addVectors(baseOffset, addVectors(offset, jitter));
+
+    const scaleMultiplier = 1 + scaleFactor * layerRatio;
+    const visualScale = {
+      x: basePlacement.visualScale.x * scaleMultiplier,
+      y: basePlacement.visualScale.y * (1 + scaleFactor * layerRatio * 0.65),
+      z: basePlacement.visualScale.z * scaleMultiplier,
+    };
+
+    const tintMix = 0.4 + layerRatio * 0.4;
+    const tint = blendTint(baseTint, accentTint, tintMix);
+
+    placements.push({
+      type: voxel.type,
+      worldX: basePlacement.worldX,
+      worldY: basePlacement.worldY,
+      worldZ: basePlacement.worldZ,
+      options: {
+        scale: basePlacement.scale,
+        visualScale,
+        visualOffset: finalOffset,
+        tint,
+        collisionMode: 'none',
+        isSolid: false,
+        destructible: basePlacement.destructible,
+        sourceObjectId: object.id,
+        voxelIndex: voxel.index,
+        metadata: basePlacement.metadata,
+        key: `${basePlacement.key}|petal-${i}`,
+      },
+    });
+  }
+
+  return placements;
+}
+
+function computeDecorativePlacements(voxel, basePlacement, object) {
+  const smoothing = voxel?.metadata?.visual?.smoothing;
+  if (!smoothing) {
+    return [];
+  }
+  if (smoothing.type === 'segment') {
+    return computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing);
+  }
+  if (smoothing.type === 'node') {
+    return computeNodeFeatherPlacements(voxel, basePlacement, object, smoothing);
+  }
+  return [];
+}
 
 export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
   if (!object || typeof addBlock !== 'function') {
@@ -54,21 +485,40 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
     z: base.z,
   };
 
-  const defaultSolidOverride = object.voxelScale < 1;
-
-
   const voxels = resolveVoxelObjectVoxels(object);
 
   voxels.forEach((voxel) => {
     const scale = resolveScaleVector(voxel, object.voxelScale);
+    const { visualScale, visualOffset } = computeVisualAdjustments(
+      voxel,
+      scale,
+      object,
+    );
     const worldX = anchor.x + voxel.position.x * object.voxelScale;
     const worldY = anchor.y + voxel.position.y * object.voxelScale + scale.y / 2;
     const worldZ = anchor.z + voxel.position.z * object.voxelScale;
 
     const collisionMode = resolveCollisionMode(voxel, object);
+    const baseKey = `${object.id}|${voxel.index}|${worldX}|${worldY}|${worldZ}`;
+    const basePlacement = {
+      type: voxel.type,
+      worldX,
+      worldY,
+      worldZ,
+      scale,
+      visualScale,
+      visualOffset,
+      tint: voxel.tint,
+      destructible: voxel.destructible,
+      metadata: voxel.metadata,
+      collisionMode,
+      key: baseKey,
+    };
 
     addBlock(voxel.type, worldX, worldY, worldZ, biome, {
       scale,
+      visualScale,
+      visualOffset,
       collisionMode,
       isSolid: collisionMode === 'solid',
 
@@ -77,7 +527,19 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
       sourceObjectId: object.id,
       voxelIndex: voxel.index,
       metadata: voxel.metadata,
-      key: `${object.id}|${voxel.index}|${worldX}|${worldY}|${worldZ}`,
+      key: baseKey,
+    });
+
+    const decorativePlacements = computeDecorativePlacements(voxel, basePlacement, object);
+    decorativePlacements.forEach((placement) => {
+      addBlock(
+        placement.type,
+        placement.worldX,
+        placement.worldY,
+        placement.worldZ,
+        biome,
+        placement.options,
+      );
     });
   });
 }

--- a/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
+++ b/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
@@ -19,17 +19,49 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.4,
+      "smoothing": {
+        "segmentOverlap": 0.5,
+        "segmentEndPadding": 0.45,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.22,
+        "embed": 0.12,
+        "featherLayers": 3,
+        "featherRadius": 0.45,
+        "featherSpacing": 0.28,
+        "featherScale": 0.22,
+        "microJitter": 0.18,
+        "featherTint": "#bdfbff"
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#6a4d84" },
       "nodes": [
         {
           "id": "base",
           "position": [0, 0, 0],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.32,
+            "microJitter": 0.14,
+            "embed": 0.08,
+            "featherTint": "#86d0ff"
+          },
           "voxel": { "type": "log", "size": [1.3, 0.6, 1.3], "tint": "#6a4d84", "isSolid": true }
         },
-        { "id": "mid", "position": [0.18, 2.8, -0.1] },
+        {
+          "id": "mid",
+          "position": [0.18, 2.8, -0.1],
+          "smoothing": { "featherLayers": 1, "featherRadius": 0.26, "microJitter": 0.12 }
+        },
         {
           "id": "crown",
           "position": [-0.12, 5.8, 0.16],
+          "smoothing": {
+            "featherLayers": 4,
+            "featherRadius": 0.5,
+            "featherScale": 0.3,
+            "microJitter": 0.24,
+            "embed": 0.1,
+            "featherTint": "#d6f8ff"
+          },
           "voxel": { "type": "log", "size": [1.0, 0.8, 1.0], "tint": "#735694", "isSolid": true }
         }
       ],
@@ -39,14 +71,36 @@
           "to": "mid",
           "voxel": { "type": "log", "tint": "#6f558d", "isSolid": true },
           "startSize": [1.25, 1.2, 1.25],
-          "endSize": [1.1, 1.1, 1.1]
+          "endSize": [1.1, 1.1, 1.1],
+          "smoothing": {
+            "segmentOverlap": 0.6,
+            "segmentEndPadding": 0.52,
+            "featherLayers": 2,
+            "featherRadius": 0.32,
+            "featherSpacing": 0.22,
+            "featherScale": 0.18,
+            "microJitter": 0.16,
+            "featherTint": "#8ad8ff",
+            "embed": 0.12
+          }
         },
         {
           "from": "mid",
           "to": "crown",
           "voxel": { "type": "log", "tint": "#735694", "isSolid": true },
           "startSize": [1.1, 1.05, 1.1],
-          "endSize": [0.95, 0.95, 0.95]
+          "endSize": [0.95, 0.95, 0.95],
+          "smoothing": {
+            "segmentOverlap": 0.65,
+            "segmentEndPadding": 0.6,
+            "featherLayers": 4,
+            "featherRadius": 0.42,
+            "featherSpacing": 0.3,
+            "featherScale": 0.24,
+            "microJitter": 0.2,
+            "featherTint": "#c7f6ff",
+            "embed": 0.14
+          }
         }
       ]
     }

--- a/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
+++ b/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
@@ -20,17 +20,54 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.38,
+      "smoothing": {
+        "segmentOverlap": 0.45,
+        "segmentEndPadding": 0.4,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.2,
+        "embed": 0.1,
+        "featherLayers": 2,
+        "featherRadius": 0.4,
+        "featherSpacing": 0.24,
+        "featherScale": 0.2,
+        "microJitter": 0.16,
+        "featherTint": "#f4f0a6"
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#37b47a" },
       "nodes": [
         {
           "id": "base",
           "position": [0, 0, 0],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.28,
+            "microJitter": 0.1,
+            "embed": 0.08,
+            "featherTint": "#f2d384"
+          },
           "voxel": { "type": "log", "size": [1.25, 0.6, 1.25], "tint": "#2f9f6f", "isSolid": true }
         },
-        { "id": "mid", "position": [0, 3.2, 0] },
+        {
+          "id": "mid",
+          "position": [0, 3.2, 0],
+          "smoothing": {
+            "featherLayers": 1,
+            "featherRadius": 0.22,
+            "microJitter": 0.12,
+            "featherTint": "#f8e49b"
+          }
+        },
         {
           "id": "upper",
           "position": [0, 6.4, 0],
+          "smoothing": {
+            "featherLayers": 3,
+            "featherRadius": 0.36,
+            "featherScale": 0.22,
+            "microJitter": 0.18,
+            "embed": 0.1,
+            "featherTint": "#ffe7a8"
+          },
           "voxel": { "type": "log", "size": [0.9, 0.6, 0.9], "tint": "#3fc488", "isSolid": true }
         }
       ],
@@ -40,14 +77,36 @@
           "to": "mid",
           "voxel": { "type": "log", "tint": "#37b47a", "isSolid": true },
           "startSize": [1.2, 1.1, 1.2],
-          "endSize": [1.05, 1.05, 1.05]
+          "endSize": [1.05, 1.05, 1.05],
+          "smoothing": {
+            "segmentOverlap": 0.5,
+            "segmentEndPadding": 0.48,
+            "featherLayers": 2,
+            "featherRadius": 0.26,
+            "featherSpacing": 0.2,
+            "featherScale": 0.18,
+            "microJitter": 0.18,
+            "featherTint": "#f6db8d",
+            "embed": 0.1
+          }
         },
         {
           "from": "mid",
           "to": "upper",
           "voxel": { "type": "log", "tint": "#3fc488", "isSolid": true },
           "startSize": [1.05, 1.0, 1.05],
-          "endSize": [0.9, 0.9, 0.9]
+          "endSize": [0.9, 0.9, 0.9],
+          "smoothing": {
+            "segmentOverlap": 0.52,
+            "segmentEndPadding": 0.55,
+            "featherLayers": 3,
+            "featherRadius": 0.34,
+            "featherSpacing": 0.26,
+            "featherScale": 0.24,
+            "microJitter": 0.2,
+            "featherTint": "#ffe0a1",
+            "embed": 0.12
+          }
         }
       ]
     }

--- a/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
+++ b/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
@@ -19,17 +19,54 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.42,
+      "smoothing": {
+        "segmentOverlap": 0.4,
+        "segmentEndPadding": 0.35,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.18,
+        "embed": 0.1,
+        "featherLayers": 4,
+        "featherRadius": 0.5,
+        "featherSpacing": 0.3,
+        "featherScale": 0.25,
+        "microJitter": 0.22,
+        "featherTint": "#ffd6ff"
+      },
       "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#f8a7ff" },
       "nodes": [
         {
           "id": "base",
           "position": [0, 0, 0],
+          "smoothing": {
+            "featherLayers": 3,
+            "featherRadius": 0.35,
+            "microJitter": 0.18,
+            "embed": 0.08,
+            "featherTint": "#ffb0ff"
+          },
           "voxel": { "type": "log", "size": [1.15, 0.6, 1.15], "tint": "#f38ff9", "isSolid": true }
         },
-        { "id": "mid", "position": [0.25, 2.4, -0.15] },
+        {
+          "id": "mid",
+          "position": [0.25, 2.4, -0.15],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.28,
+            "microJitter": 0.2,
+            "featherTint": "#ffc3ff"
+          }
+        },
         {
           "id": "crown",
           "position": [0.05, 4.5, 0.2],
+          "smoothing": {
+            "featherLayers": 5,
+            "featherRadius": 0.55,
+            "featherScale": 0.32,
+            "microJitter": 0.28,
+            "embed": 0.12,
+            "featherTint": "#fff0ff"
+          },
           "voxel": { "type": "log", "size": [0.8, 0.6, 0.8], "tint": "#ffbffb", "isSolid": true }
         }
       ],
@@ -39,14 +76,36 @@
           "to": "mid",
           "voxel": { "type": "log", "tint": "#f8a7ff", "isSolid": true },
           "startSize": [1.05, 0.9, 1.05],
-          "endSize": [0.9, 0.85, 0.9]
+          "endSize": [0.9, 0.85, 0.9],
+          "smoothing": {
+            "segmentOverlap": 0.48,
+            "segmentEndPadding": 0.42,
+            "featherLayers": 3,
+            "featherRadius": 0.36,
+            "featherSpacing": 0.26,
+            "featherScale": 0.22,
+            "microJitter": 0.24,
+            "featherTint": "#ffd9ff",
+            "embed": 0.12
+          }
         },
         {
           "from": "mid",
           "to": "crown",
           "voxel": { "type": "log", "tint": "#ffbdfc", "isSolid": true },
           "startSize": [0.9, 0.8, 0.9],
-          "endSize": [0.7, 0.7, 0.7]
+          "endSize": [0.7, 0.7, 0.7],
+          "smoothing": {
+            "segmentOverlap": 0.55,
+            "segmentEndPadding": 0.5,
+            "featherLayers": 5,
+            "featherRadius": 0.48,
+            "featherSpacing": 0.32,
+            "featherScale": 0.3,
+            "microJitter": 0.3,
+            "featherTint": "#fff4ff",
+            "embed": 0.16
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
- expand node-growth smoothing metadata with feathering, jitter, and tint controls and propagate them onto generated voxels
- render feathered decorative layers during voxel placement to add jittered halos and reduce z-fighting while keeping collisions intact
- tune noctilucent pillarcap, sunset cactus, and vaporwave palm definitions to use the new smoothing presets for richer silhouettes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bb146ab4832aa2af5e3e0bd74660