### PR TITLE
Normalize large plant JSON formatting

### DIFF
--- a/three-demo/src/world/procedural/nanovoxel-palette.js
+++ b/three-demo/src/world/procedural/nanovoxel-palette.js
@@ -1,0 +1,132 @@
+const NANOVOXEL_DEFINITIONS = [
+  {
+    id: 'feather-frond',
+    baseType: 'leaf',
+    baseScale: { x: 0.22, y: 0.05, z: 0.28 },
+    defaultTint: '#aef2ff',
+    accentTint: '#f0ffff',
+    accentStrength: 0.32,
+    inheritTintStrength: 0.4,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1.1 },
+        accentStrength: 0.18,
+      },
+      {
+        offset: { right: 0.2, up: 0.12, forward: 0.26 },
+        scale: { right: 0.82, up: 1, forward: 0.85 },
+        accentStrength: 0.35,
+      },
+      {
+        offset: { right: -0.18, up: 0.18, forward: 0.34 },
+        scale: { right: 0.7, up: 0.92, forward: 0.78 },
+        accentStrength: 0.42,
+      },
+    ],
+  },
+  {
+    id: 'cactus-needle-bundle',
+    baseType: 'log',
+    baseScale: { x: 0.05, y: 0.26, z: 0.05 },
+    defaultTint: '#ffe2c0',
+    accentTint: '#ffd2a8',
+    accentStrength: 0.28,
+    inheritTintStrength: 0.25,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+      },
+      {
+        offset: { right: 0.02, up: 0.22, forward: 0.02 },
+        scale: { right: 0.65, up: 0.55, forward: 0.65 },
+        type: 'leaf',
+        accentStrength: 0.4,
+      },
+    ],
+  },
+  {
+    id: 'coral-frill',
+    baseType: 'leaf',
+    baseScale: { x: 0.18, y: 0.06, z: 0.18 },
+    defaultTint: '#ffb1f0',
+    accentTint: '#ffe8ff',
+    accentStrength: 0.36,
+    inheritTintStrength: 0.3,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1.25, up: 0.85, forward: 1.2 },
+        accentStrength: 0.25,
+      },
+      {
+        offset: { right: 0.24, up: 0.12, forward: 0.22 },
+        scale: { right: 0.78, up: 0.65, forward: 0.8 },
+        accentStrength: 0.4,
+      },
+      {
+        offset: { right: -0.24, up: 0.14, forward: 0.2 },
+        scale: { right: 0.78, up: 0.62, forward: 0.8 },
+        accentStrength: 0.38,
+      },
+    ],
+  },
+  {
+    id: 'petal-cluster',
+    baseType: 'leaf',
+    baseScale: { x: 0.26, y: 0.05, z: 0.2 },
+    defaultTint: '#ffd0f6',
+    accentTint: '#ffe6ff',
+    accentStrength: 0.35,
+    inheritTintStrength: 0.28,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.25,
+      },
+      {
+        offset: { right: 0.18, up: 0.06, forward: 0.22 },
+        scale: { right: 0.75, up: 1, forward: 0.82 },
+        accentStrength: 0.4,
+      },
+      {
+        offset: { right: -0.18, up: 0.06, forward: 0.22 },
+        scale: { right: 0.75, up: 1, forward: 0.82 },
+        accentStrength: 0.4,
+      },
+    ],
+  },
+  {
+    id: 'halo-spark',
+    baseType: 'leaf',
+    baseScale: { x: 0.12, y: 0.12, z: 0.12 },
+    defaultTint: '#98f8ff',
+    accentTint: '#ffffff',
+    accentStrength: 0.55,
+    inheritTintStrength: 0.2,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.6,
+      },
+    ],
+  },
+];
+
+const NANOVOXEL_MAP = new Map(NANOVOXEL_DEFINITIONS.map((definition) => [definition.id, definition]));
+
+export function getNanovoxelDefinition(id) {
+  if (typeof id !== 'string') {
+    return null;
+  }
+  return NANOVOXEL_MAP.get(id) ?? null;
+}
+
+export function listNanovoxelDefinitions() {
+  return Array.from(NANOVOXEL_MAP.keys());
+}
+
+export default getNanovoxelDefinition;

--- a/three-demo/src/world/procedural/node-growth-generator.js
+++ b/three-demo/src/world/procedural/node-growth-generator.js
@@ -1,8 +1,156 @@
 const DEFAULT_STEP = 0.5;
 const MIN_STEP = 0.05;
 
+const DEFAULT_SMOOTHING = {
+  nodeInflate: 0,
+  segmentOverlap: 0,
+  segmentEndPadding: 0,
+  segmentSubdivisions: 1,
+  embed: 0,
+  featherLayers: 0,
+  featherRadius: 0,
+  featherSpacing: 0.25,
+  featherScale: 0.15,
+  featherTint: null,
+  microJitter: 0,
+};
+
 function lerp(a, b, t) {
   return a + (b - a) * t;
+}
+
+function normalizeSmoothingConfig(value, fallback = DEFAULT_SMOOTHING) {
+  const base = {
+    nodeInflate:
+      typeof fallback?.nodeInflate === 'number'
+        ? fallback.nodeInflate
+        : DEFAULT_SMOOTHING.nodeInflate,
+    segmentOverlap:
+      typeof fallback?.segmentOverlap === 'number'
+        ? fallback.segmentOverlap
+        : DEFAULT_SMOOTHING.segmentOverlap,
+    segmentEndPadding:
+      typeof fallback?.segmentEndPadding === 'number'
+        ? fallback.segmentEndPadding
+        : DEFAULT_SMOOTHING.segmentEndPadding,
+    segmentSubdivisions:
+      typeof fallback?.segmentSubdivisions === 'number'
+        ? fallback.segmentSubdivisions
+        : DEFAULT_SMOOTHING.segmentSubdivisions,
+    embed:
+      typeof fallback?.embed === 'number'
+        ? fallback.embed
+        : DEFAULT_SMOOTHING.embed,
+    featherLayers:
+      typeof fallback?.featherLayers === 'number'
+        ? fallback.featherLayers
+        : DEFAULT_SMOOTHING.featherLayers,
+    featherRadius:
+      typeof fallback?.featherRadius === 'number'
+        ? fallback.featherRadius
+        : DEFAULT_SMOOTHING.featherRadius,
+    featherSpacing:
+      typeof fallback?.featherSpacing === 'number'
+        ? fallback.featherSpacing
+        : DEFAULT_SMOOTHING.featherSpacing,
+    featherScale:
+      typeof fallback?.featherScale === 'number'
+        ? fallback.featherScale
+        : DEFAULT_SMOOTHING.featherScale,
+    featherTint:
+      typeof fallback?.featherTint === 'string'
+        ? fallback.featherTint
+        : DEFAULT_SMOOTHING.featherTint,
+    microJitter:
+      typeof fallback?.microJitter === 'number'
+        ? fallback.microJitter
+        : DEFAULT_SMOOTHING.microJitter,
+  };
+
+  if (!value || typeof value !== 'object') {
+    return { ...base };
+  }
+
+  const numeric = (candidate) =>
+    typeof candidate === 'number' && !Number.isNaN(candidate) ? candidate : null;
+
+  const stringValue = (candidate) =>
+    typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+
+  const nodeInflate = numeric(value.nodeInflate ?? value.nodePadding);
+  if (nodeInflate !== null) {
+    base.nodeInflate = Math.max(0, nodeInflate);
+  }
+
+  const segmentOverlap = numeric(
+    value.segmentOverlap ?? value.overlap ?? value.segmentVisualOverlap,
+  );
+  if (segmentOverlap !== null) {
+    base.segmentOverlap = Math.max(0, segmentOverlap);
+  }
+
+  const segmentEndPadding = numeric(
+    value.segmentEndPadding ?? value.endPadding ?? value.padding ?? value.nodeBlendPadding,
+  );
+  if (segmentEndPadding !== null) {
+    base.segmentEndPadding = Math.max(0, segmentEndPadding);
+  }
+
+  const segmentSubdivisions = numeric(
+    value.segmentSubdivisions ?? value.subdivisions ?? value.segmentLerpSteps,
+  );
+  if (segmentSubdivisions !== null) {
+    base.segmentSubdivisions = Math.max(1, Math.floor(segmentSubdivisions));
+  }
+
+  const embed = numeric(value.embed ?? value.segmentEmbed ?? value.segmentInset);
+  if (embed !== null) {
+    base.embed = Math.max(0, embed);
+  }
+
+  const featherLayers = numeric(
+    value.featherLayers ?? value.layers ?? value.feather ?? value.featherCount,
+  );
+  if (featherLayers !== null) {
+    base.featherLayers = Math.max(0, Math.floor(featherLayers));
+  }
+
+  const featherRadius = numeric(
+    value.featherRadius ?? value.featherSpread ?? value.ribbonRadius,
+  );
+  if (featherRadius !== null) {
+    base.featherRadius = Math.max(0, featherRadius);
+  }
+
+  const featherSpacing = numeric(
+    value.featherSpacing ?? value.featherStep ?? value.ribbonSpacing,
+  );
+  if (featherSpacing !== null) {
+    base.featherSpacing = Math.max(0, featherSpacing);
+  }
+
+  const featherScale = numeric(
+    value.featherScale ?? value.featherGrowth ?? value.ribbonScale,
+  );
+  if (featherScale !== null) {
+    base.featherScale = Math.max(0, featherScale);
+  }
+
+  const microJitter = numeric(
+    value.microJitter ?? value.jitter ?? value.wobble ?? value.sparkle,
+  );
+  if (microJitter !== null) {
+    base.microJitter = Math.max(0, microJitter);
+  }
+
+  const featherTint = stringValue(
+    value.featherTint ?? value.accentTint ?? value.ribbonTint ?? value.tint,
+  );
+  if (featherTint !== null) {
+    base.featherTint = featherTint;
+  }
+
+  return { ...base };
 }
 
 function clampStep(step) {
@@ -41,6 +189,201 @@ function toSize(value, fallback = { x: 1, y: 1, z: 1 }) {
     return { x, y, z };
   }
   return { ...fallback };
+}
+
+function toLocalVector(value, fallback = { right: 0, up: 0, forward: 0 }) {
+  if (typeof value === 'number') {
+    return { right: value, up: value, forward: value };
+  }
+  if (Array.isArray(value)) {
+    const [right = fallback.right, up = fallback.up, forward = fallback.forward] = value;
+    return { right, up, forward };
+  }
+  if (value && typeof value === 'object') {
+    const numeric = (candidate, fallbackValue) =>
+      typeof candidate === 'number' && !Number.isNaN(candidate) ? candidate : fallbackValue;
+    const right = numeric(value.right ?? value.x, fallback.right);
+    const up = numeric(value.up ?? value.y, fallback.up);
+    const forward = numeric(value.forward ?? value.z, fallback.forward);
+    return { right, up, forward };
+  }
+  return { ...fallback };
+}
+
+function resolveAngle(primary, turns, degrees, fallback) {
+  const numeric = (candidate) =>
+    typeof candidate === 'number' && !Number.isNaN(candidate) ? candidate : null;
+  const primaryValue = numeric(primary);
+  if (primaryValue !== null) {
+    return primaryValue;
+  }
+  const degreeValue = numeric(degrees);
+  if (degreeValue !== null) {
+    return (degreeValue * Math.PI) / 180;
+  }
+  const turnValue = numeric(turns);
+  if (turnValue !== null) {
+    return turnValue * Math.PI * 2;
+  }
+  return fallback;
+}
+
+function normalizeNanovoxelEntry(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  if (value.enabled === false) {
+    return null;
+  }
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    return null;
+  }
+
+  const numeric = (candidate, fallbackValue = null) =>
+    typeof candidate === 'number' && !Number.isNaN(candidate) ? candidate : fallbackValue;
+
+  const count = Math.max(1, Math.min(64, Math.round(numeric(value.count, 1) ?? 1)));
+  const radius = Math.max(0, numeric(value.radius, 0) ?? 0);
+  const radiusRight = Math.max(
+    0,
+    numeric(value.radiusRight ?? value.radiusX, null) ?? radius,
+  );
+  const radiusUp = Math.max(0, numeric(value.radiusUp ?? value.radiusY, null) ?? radius);
+  const arc = resolveAngle(
+    value.arc ?? value.spread,
+    value.arcTurns ?? value.spreadTurns,
+    value.arcDegrees ?? value.spreadDegrees,
+    Math.PI * 2,
+  );
+  const phase = resolveAngle(
+    value.phase ?? value.rotation,
+    value.phaseTurns ?? value.rotationTurns,
+    value.phaseDegrees ?? value.rotationDegrees,
+    0,
+  );
+  const offset = toLocalVector(value.offset ?? value.anchor ?? 0, {
+    right: 0,
+    up: 0,
+    forward: 0,
+  });
+  offset.right += numeric(value.offsetRight ?? value.anchorRight, 0) ?? 0;
+  offset.up += numeric(value.offsetUp ?? value.anchorUp, 0) ?? 0;
+  offset.forward += numeric(value.offsetForward ?? value.anchorForward, 0) ?? 0;
+
+  const baseScale = toLocalVector(value.scale ?? value.scaling ?? 1, {
+    right: 1,
+    up: 1,
+    forward: 1,
+  });
+  const scaleMultiplier = numeric(value.scaleMultiplier ?? value.scaleAll, 1) ?? 1;
+  const scaleRight = numeric(value.scaleRight ?? value.scaleX, null);
+  const scaleUp = numeric(value.scaleUp ?? value.scaleY, null);
+  const scaleForward = numeric(value.scaleForward ?? value.scaleZ, null);
+  const scale = {
+    right: (scaleRight ?? baseScale.right) * scaleMultiplier,
+    up: (scaleUp ?? baseScale.up) * scaleMultiplier,
+    forward: (scaleForward ?? baseScale.forward) * scaleMultiplier,
+  };
+
+  const jitter = Math.max(0, numeric(value.jitter ?? value.noise ?? value.wobble, 0) ?? 0);
+  const length = Math.max(0, numeric(value.length ?? value.span ?? value.forwardLength, 0) ?? 0);
+  const distribution =
+    typeof value.distribution === 'string' ? value.distribution.toLowerCase() : 'auto';
+  const axis = value.axis || value.direction ? toVector3(value.axis ?? value.direction, null) : null;
+  const up = value.up || value.upHint ? toVector3(value.up ?? value.upHint, null) : null;
+  const tint = typeof value.tint === 'string' ? value.tint : null;
+  const accentTint = typeof value.accentTint === 'string' ? value.accentTint : null;
+  const accentStrength = numeric(value.accentStrength ?? value.accentMix, null);
+  const inheritTint = value.inheritTint === false ? false : true;
+  const inheritTintStrength = numeric(value.inheritTintStrength, null);
+  let minProgress = numeric(value.minProgress ?? value.progressMin, null);
+  let maxProgress = numeric(value.maxProgress ?? value.progressMax, null);
+  if (minProgress !== null) {
+    minProgress = Math.max(0, Math.min(1, minProgress));
+  }
+  if (maxProgress !== null) {
+    maxProgress = Math.max(0, Math.min(1, maxProgress));
+  }
+  if (minProgress !== null && maxProgress !== null && minProgress > maxProgress) {
+    const temp = minProgress;
+    minProgress = maxProgress;
+    maxProgress = temp;
+  }
+  const seed =
+    typeof value.seed === 'string'
+      ? value.seed
+      : typeof value.seed === 'number'
+      ? String(value.seed)
+      : null;
+  const scaleJitter = Math.max(0, numeric(value.scaleJitter ?? value.scaleNoise, 0) ?? 0);
+  const type = typeof value.type === 'string' ? value.type : null;
+  const scatter = Math.max(0, numeric(value.scatter ?? value.cluster, 0) ?? 0);
+  const growth = Math.max(0, numeric(value.growth, 0) ?? 0);
+  const progressMode =
+    typeof value.progressMode === 'string' ? value.progressMode.toLowerCase() : null;
+
+  return {
+    id: value.id,
+    count,
+    radiusRight,
+    radiusUp,
+    arc,
+    phase,
+    offset,
+    scale,
+    jitter,
+    length,
+    distribution,
+    axis,
+    up,
+    tint,
+    accentTint,
+    accentStrength:
+      accentStrength !== null ? Math.max(0, Math.min(1, accentStrength)) : null,
+    inheritTint,
+    inheritTintStrength:
+      inheritTintStrength !== null
+        ? Math.max(0, Math.min(1, inheritTintStrength))
+        : null,
+    minProgress: minProgress !== null ? minProgress : 0,
+    maxProgress: maxProgress !== null ? maxProgress : 1,
+    seed,
+    scaleJitter,
+    type,
+    scatter,
+    growth,
+    progressMode,
+  };
+}
+
+function normalizeNanovoxelList(source) {
+  if (!source) {
+    return [];
+  }
+  const list = Array.isArray(source) ? source : [source];
+  const result = [];
+  list.forEach((item) => {
+    const normalized = normalizeNanovoxelEntry(item);
+    if (normalized) {
+      result.push(normalized);
+    }
+  });
+  return result;
+}
+
+function appendNanovoxelDescriptor(metadata, descriptor) {
+  if (!descriptor) {
+    return metadata;
+  }
+  const visual = { ...(metadata?.visual ?? {}) };
+  const existing = Array.isArray(visual.nanovoxels)
+    ? [...visual.nanovoxels]
+    : visual.nanovoxels
+    ? [visual.nanovoxels]
+    : [];
+  existing.push(descriptor);
+  visual.nanovoxels = existing;
+  return { ...(metadata ?? {}), visual };
 }
 
 function normalizeVoxelConfig(voxel, fallback = null) {
@@ -158,21 +501,69 @@ export function generateNodeGrowthVoxels(object, config) {
     config.defaultVoxel,
   );
 
+  const baseSmoothing = normalizeSmoothingConfig(
+    config.smoothing ?? config.visual?.smoothing ?? null,
+  );
+
+  const baseNodeNanovoxels = normalizeNanovoxelList(
+    config.nodeNanovoxels ?? config.nanovoxels ?? null,
+  );
+  const baseSegmentNanovoxels = normalizeNanovoxelList(config.segmentNanovoxels ?? null);
+
   (config.nodes || []).forEach((node) => {
     if (!node || typeof node.id !== 'string') {
       return;
     }
     const position = toVector3(node.position);
-    nodes.set(node.id, { ...node, position });
+    const nodeSmoothing = normalizeSmoothingConfig(node.smoothing, baseSmoothing);
+    nodes.set(node.id, { ...node, position, smoothing: nodeSmoothing });
     const nodeVoxelConfig = normalizeVoxelConfig(node.voxel, defaultNodeVoxel);
     if (nodeVoxelConfig) {
       const size = toSize(
         node.voxel?.size ?? config.nodeSize ?? config.segmentSize ?? 1,
       );
+      let metadata = nodeVoxelConfig.metadata ? { ...nodeVoxelConfig.metadata } : null;
+      const nodeSmoothingActive =
+        nodeSmoothing.nodeInflate > 0 ||
+        nodeSmoothing.embed > 0 ||
+        nodeSmoothing.featherLayers > 0 ||
+        nodeSmoothing.microJitter > 0;
+      if (nodeSmoothingActive) {
+        const visual = { ...(metadata?.visual ?? {}) };
+        visual.smoothing = {
+          ...(visual.smoothing ?? {}),
+          type: 'node',
+          inflate: nodeSmoothing.nodeInflate,
+          embed: nodeSmoothing.embed,
+          featherLayers: nodeSmoothing.featherLayers,
+          featherRadius: nodeSmoothing.featherRadius,
+          featherSpacing: nodeSmoothing.featherSpacing,
+          featherScale: nodeSmoothing.featherScale,
+          featherTint: nodeSmoothing.featherTint,
+          microJitter: nodeSmoothing.microJitter,
+        };
+        metadata = { ...(metadata ?? {}), visual };
+      }
+
+      const nodeNanovoxels = [
+        ...baseNodeNanovoxels,
+        ...normalizeNanovoxelList(node.nanovoxels ?? null),
+      ];
+      if (nodeNanovoxels.length > 0) {
+        metadata = appendNanovoxelDescriptor(metadata, {
+          type: 'node',
+          entries: nodeNanovoxels,
+          context: {
+            nodeId: node.id,
+            position,
+          },
+        });
+      }
       addVoxel(voxels, usedKeys, {
         ...nodeVoxelConfig,
         position,
         size,
+        metadata,
       });
     }
   });
@@ -205,9 +596,12 @@ export function generateNodeGrowthVoxels(object, config) {
     }
 
     const stepSize = clampStep(segment.step ?? config.step ?? DEFAULT_STEP);
-    const steps = segment.steps
+    const segmentSmoothing = normalizeSmoothingConfig(segment.smoothing, baseSmoothing);
+    const subdivisions = Math.max(1, segmentSmoothing.segmentSubdivisions);
+    const steps = (segment.steps
       ? Math.max(1, Math.floor(segment.steps))
-      : Math.max(1, Math.ceil(length / stepSize));
+      : Math.max(1, Math.ceil(length / stepSize))) * subdivisions;
+    const stepLength = length / steps;
 
     const startSize = toSize(
       segment.startSize ?? segment.size ?? config.segmentSize ?? 1,
@@ -226,6 +620,28 @@ export function generateNodeGrowthVoxels(object, config) {
 
     const includeStart = segment.includeStart ?? false;
     const includeEnd = segment.includeEnd ?? true;
+
+    const direction = {
+      x: delta.x / length,
+      y: delta.y / length,
+      z: delta.z / length,
+    };
+    const startPaddingValue = Math.max(
+      segmentSmoothing.segmentEndPadding,
+      fromNode.smoothing?.nodeInflate ?? 0,
+    );
+    const endPaddingValue = Math.max(
+      segmentSmoothing.segmentEndPadding,
+      toNode.smoothing?.nodeInflate ?? 0,
+    );
+
+    const smoothingActive =
+      segmentSmoothing.segmentOverlap > 0 ||
+      startPaddingValue > 0 ||
+      endPaddingValue > 0 ||
+      segmentSmoothing.embed > 0 ||
+      segmentSmoothing.featherLayers > 0 ||
+      segmentSmoothing.microJitter > 0;
 
     for (let i = 0; i <= steps; i += 1) {
       if (i === 0 && !includeStart) {
@@ -252,11 +668,56 @@ export function generateNodeGrowthVoxels(object, config) {
         tint = mixed ? tintToHex(mixed) : tint;
       }
 
+      let metadata = segmentVoxel.metadata ? { ...segmentVoxel.metadata } : null;
+      if (smoothingActive) {
+        const visual = { ...(metadata?.visual ?? {}) };
+        visual.smoothing = {
+          ...(visual.smoothing ?? {}),
+          type: 'segment',
+          overlap: segmentSmoothing.segmentOverlap,
+          stepLength,
+          direction: { ...direction },
+          distanceFromStart: length * t,
+          distanceFromEnd: length * (1 - t),
+          startPadding: startPaddingValue,
+          endPadding: endPaddingValue,
+          embed: segmentSmoothing.embed,
+          featherLayers: segmentSmoothing.featherLayers,
+          featherRadius: segmentSmoothing.featherRadius,
+          featherSpacing: segmentSmoothing.featherSpacing,
+          featherScale: segmentSmoothing.featherScale,
+          featherTint: segmentSmoothing.featherTint,
+          microJitter: segmentSmoothing.microJitter,
+          progress: t,
+          steps,
+        };
+        metadata = { ...(metadata ?? {}), visual };
+      }
+
+      const segmentNanovoxels = [
+        ...baseSegmentNanovoxels,
+        ...normalizeNanovoxelList(segment.nanovoxels ?? null),
+      ];
+      if (segmentNanovoxels.length > 0) {
+        metadata = appendNanovoxelDescriptor(metadata, {
+          type: 'segment',
+          entries: segmentNanovoxels,
+          context: {
+            from: segment.from,
+            to: segment.to,
+            length,
+            stepLength,
+            steps,
+          },
+        });
+      }
+
       addVoxel(voxels, usedKeys, {
         ...segmentVoxel,
         position,
         size,
         tint,
+        metadata,
       });
     }
   });

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -3,6 +3,7 @@ import {
   isVoxelObjectAllowedInBiome,
 } from './voxel-object-library.js';
 import { resolveVoxelObjectVoxels } from './voxel-object-processor.js';
+import { getNanovoxelDefinition } from './procedural/nanovoxel-palette.js';
 import {
   getSectorPlacementsForColumn,
   markPlacementCompleted,
@@ -27,6 +28,593 @@ function resolveScaleVector({ size }, voxelScale) {
 }
 
 
+const ZERO_OFFSET = { x: 0, y: 0, z: 0 };
+
+function cloneScale(scale) {
+  return { x: scale.x, y: scale.y, z: scale.z };
+}
+
+function cloneOffset(offset) {
+  return { x: offset.x, y: offset.y, z: offset.z };
+}
+
+function seededRandom(...components) {
+  let hash = 2166136261;
+  components.forEach((component) => {
+    const str = String(component);
+    for (let i = 0; i < str.length; i += 1) {
+      hash ^= str.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+  });
+  return (hash >>> 0) / 4294967296;
+}
+
+function seededRandomCentered(...components) {
+  return seededRandom(...components) * 2 - 1;
+}
+
+function normalizeVector(vector) {
+  const length = Math.hypot(vector.x, vector.y, vector.z);
+  if (length === 0) {
+    return null;
+  }
+  return { x: vector.x / length, y: vector.y / length, z: vector.z / length };
+}
+
+function crossVectors(a, b) {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function scaleVector(vector, amount) {
+  return { x: vector.x * amount, y: vector.y * amount, z: vector.z * amount };
+}
+
+function addVectors(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function createLocalFrame(direction, customUpHint = null) {
+  const forward = normalizeVector(direction);
+  if (!forward) {
+    return null;
+  }
+  const preferredUp =
+    (customUpHint && normalizeVector(customUpHint)) ||
+    (Math.abs(forward.y) < 0.999 ? { x: 0, y: 1, z: 0 } : { x: 1, y: 0, z: 0 });
+  let right = normalizeVector(crossVectors(preferredUp, forward));
+  if (!right) {
+    const fallback = Math.abs(forward.y) < 0.999 ? { x: 1, y: 0, z: 0 } : { x: 0, y: 0, z: 1 };
+    right = normalizeVector(crossVectors(fallback, forward)) ?? fallback;
+  }
+  let up = normalizeVector(crossVectors(forward, right));
+  if (!up) {
+    up = preferredUp;
+  }
+  return { forward, right, up };
+}
+
+function clamp01(value) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseHexColor(hex) {
+  if (typeof hex !== 'string') {
+    return null;
+  }
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!match) {
+    return null;
+  }
+  const int = parseInt(match[1], 16);
+  return {
+    r: (int >> 16) & 0xff,
+    g: (int >> 8) & 0xff,
+    b: int & 0xff,
+  };
+}
+
+function colorToHex({ r, g, b }) {
+  const clamp = (component) =>
+    Math.max(0, Math.min(255, Math.round(component))).toString(16).padStart(2, '0');
+  return `#${clamp(r)}${clamp(g)}${clamp(b)}`;
+}
+
+function blendTint(baseHex, accentHex, mix) {
+  const mixValue = clamp01(mix);
+  const base = parseHexColor(baseHex) ?? { r: 255, g: 255, b: 255 };
+  const accent = parseHexColor(accentHex) ?? { r: 255, g: 255, b: 255 };
+  return colorToHex({
+    r: base.r + (accent.r - base.r) * mixValue,
+    g: base.g + (accent.g - base.g) * mixValue,
+    b: base.b + (accent.b - base.b) * mixValue,
+  });
+}
+
+const DEFAULT_FRAME = {
+  forward: { x: 0, y: 1, z: 0 },
+  right: { x: 1, y: 0, z: 0 },
+  up: { x: 0, y: 0, z: 1 },
+};
+
+function ensureFrame(direction, upHint) {
+  return createLocalFrame(direction, upHint) ?? DEFAULT_FRAME;
+}
+
+function convertLocalToWorld(frame, local, voxelScale) {
+  return {
+    x:
+      frame.forward.x * local.forward * voxelScale +
+      frame.right.x * local.right * voxelScale +
+      frame.up.x * local.up * voxelScale,
+    y:
+      frame.forward.y * local.forward * voxelScale +
+      frame.right.y * local.right * voxelScale +
+      frame.up.y * local.up * voxelScale,
+    z:
+      frame.forward.z * local.forward * voxelScale +
+      frame.right.z * local.right * voxelScale +
+      frame.up.z * local.up * voxelScale,
+  };
+}
+
+function resolveNanovoxelTint(definition, entry, element, baseTint) {
+  const allowInherit =
+    (definition.inheritTint ?? true) && entry.inheritTint !== false && element.inheritTint !== false;
+  const inheritStrength = allowInherit
+    ? element.inheritTintStrength ?? entry.inheritTintStrength ?? definition.inheritTintStrength ?? 0.35
+    : 0;
+
+  let tint =
+    element.tint ?? entry.tint ?? definition.defaultTint ?? baseTint ?? '#ffffff';
+
+  if (allowInherit && baseTint && inheritStrength > 0) {
+    tint = blendTint(tint, baseTint, clamp01(inheritStrength));
+  }
+
+  const accentTint =
+    element.accentTint ?? entry.accentTint ?? definition.accentTint ?? null;
+  const accentStrength =
+    element.accentStrength ?? entry.accentStrength ?? definition.accentStrength ?? 0;
+  if (accentTint && accentStrength > 0) {
+    tint = blendTint(tint, accentTint, clamp01(accentStrength));
+  }
+
+  return tint;
+}
+
+function computeNanovoxelPlacementsForDescriptor(
+  voxel,
+  basePlacement,
+  object,
+  descriptor,
+  descriptorIndex,
+) {
+  if (!descriptor || !Array.isArray(descriptor.entries) || descriptor.entries.length === 0) {
+    return [];
+  }
+
+  const placements = [];
+  const smoothing = voxel?.metadata?.visual?.smoothing;
+  const baseOffset =
+    basePlacement.visualOffset === ZERO_OFFSET
+      ? ZERO_OFFSET
+      : cloneOffset(basePlacement.visualOffset);
+  const baseTint = basePlacement.tint;
+  const context = descriptor.context ?? {};
+
+  descriptor.entries.forEach((entry, entryIndex) => {
+    const definition = getNanovoxelDefinition(entry.id);
+    if (!definition) {
+      return;
+    }
+
+    const distribution =
+      entry.distribution && entry.distribution !== 'auto'
+        ? entry.distribution
+        : descriptor.type === 'segment'
+        ? 'line'
+        : 'ring';
+
+    if (
+      descriptor.type === 'segment' &&
+      (entry.minProgress > (smoothing?.progress ?? 0) ||
+        entry.maxProgress < (smoothing?.progress ?? 0))
+    ) {
+      return;
+    }
+
+    const direction =
+      descriptor.type === 'segment'
+        ? smoothing?.direction ?? ZERO_OFFSET
+        : entry.axis ?? context.axis ?? { x: 0, y: 1, z: 0 };
+    const upHint = entry.up ?? context.up ?? null;
+    const frame = ensureFrame(direction, upHint);
+
+    const progress = smoothing?.progress ?? 0;
+    let growthProgress = 1;
+    if (descriptor.type === 'segment' && entry.growth > 0) {
+      let factor = progress;
+      if (entry.progressMode === 'end' || entry.progressMode === 'fromend') {
+        factor = 1 - progress;
+      } else if (entry.progressMode === 'center') {
+        factor = 1 - Math.abs(progress - 0.5) * 2;
+      }
+      growthProgress = 1 + entry.growth * clamp01(factor);
+    }
+
+    const entryScale = {
+      right: entry.scale.right * growthProgress,
+      up: entry.scale.up * growthProgress,
+      forward: entry.scale.forward * growthProgress,
+    };
+
+    const count = Math.max(1, entry.count);
+    const arc = entry.arc;
+    const radiusRight = entry.radiusRight;
+    const radiusUp = entry.radiusUp;
+    const jitterStrength = entry.jitter * object.voxelScale;
+    const scatterRadius = entry.scatter * object.voxelScale;
+    const baseSeed = [
+      object.id ?? 'object',
+      voxel.index ?? 0,
+      descriptorIndex,
+      entryIndex,
+      entry.seed ?? entry.id,
+    ];
+
+    for (let copyIndex = 0; copyIndex < count; copyIndex += 1) {
+      const ratio =
+        distribution === 'line' && count > 1 ? copyIndex / (count - 1) : count <= 1 ? 0 : copyIndex / count;
+
+      const local = {
+        right: entry.offset.right,
+        up: entry.offset.up,
+        forward: entry.offset.forward,
+      };
+
+      if (distribution === 'line') {
+        const angle = entry.phase + ratio * arc;
+        local.forward += (ratio - 0.5) * entry.length;
+        local.right += Math.cos(angle) * radiusRight;
+        local.up += Math.sin(angle) * radiusUp;
+      } else if (distribution === 'cluster' || distribution === 'spray') {
+        const theta = seededRandom(...baseSeed, copyIndex, 'theta') * Math.PI * 2;
+        const phi = seededRandom(...baseSeed, copyIndex, 'phi') * Math.PI;
+        const magnitude = seededRandom(...baseSeed, copyIndex, 'mag');
+        local.right += Math.cos(theta) * Math.sin(phi) * radiusRight * magnitude;
+        local.up += Math.sin(theta) * Math.sin(phi) * radiusUp * magnitude;
+        local.forward += Math.cos(phi) * entry.length * magnitude * 0.5;
+      } else {
+        const effectiveRatio = distribution === 'fan' ? ratio : copyIndex / count;
+        const angle = entry.phase + effectiveRatio * arc;
+        local.right += Math.cos(angle) * radiusRight;
+        local.up += Math.sin(angle) * radiusUp;
+        if (distribution === 'fan') {
+          local.forward += (effectiveRatio - 0.5) * entry.length;
+        }
+      }
+
+      const scaledLocal = {
+        right: local.right * entryScale.right,
+        up: local.up * entryScale.up,
+        forward: local.forward * entryScale.forward,
+      };
+
+      let anchorOffset = convertLocalToWorld(frame, scaledLocal, object.voxelScale);
+
+      if (scatterRadius > 0) {
+        const theta = seededRandom(...baseSeed, copyIndex, 'scatter-theta') * Math.PI * 2;
+        const phi = seededRandom(...baseSeed, copyIndex, 'scatter-phi') * Math.PI;
+        const magnitude = seededRandom(...baseSeed, copyIndex, 'scatter-mag');
+        const scatterOffset = {
+          x: Math.cos(theta) * Math.sin(phi) * scatterRadius * magnitude,
+          y: Math.sin(theta) * Math.sin(phi) * scatterRadius * magnitude,
+          z: Math.cos(phi) * scatterRadius * magnitude,
+        };
+        anchorOffset = addVectors(anchorOffset, scatterOffset);
+      }
+
+      if (jitterStrength > 0) {
+        const jitter = {
+          x: seededRandomCentered(...baseSeed, copyIndex, 'jx') * jitterStrength,
+          y: seededRandomCentered(...baseSeed, copyIndex, 'jy') * jitterStrength,
+          z: seededRandomCentered(...baseSeed, copyIndex, 'jz') * jitterStrength,
+        };
+        anchorOffset = addVectors(anchorOffset, jitter);
+      }
+
+      definition.elements.forEach((element, elementIndex) => {
+        const elementOffset = element.offset
+          ? {
+              right: element.offset.right ?? 0,
+              up: element.offset.up ?? 0,
+              forward: element.offset.forward ?? 0,
+            }
+          : { right: 0, up: 0, forward: 0 };
+        const elementScaleLocal = element.scale
+          ? {
+              right: element.scale.right ?? 1,
+              up: element.scale.up ?? 1,
+              forward: element.scale.forward ?? 1,
+            }
+          : { right: 1, up: 1, forward: 1 };
+
+        const elementSeed = [...baseSeed, copyIndex, elementIndex];
+
+        const scaledElementOffset = {
+          right: elementOffset.right * entryScale.right,
+          up: elementOffset.up * entryScale.up,
+          forward: elementOffset.forward * entryScale.forward,
+        };
+        let elementWorldOffset = convertLocalToWorld(
+          frame,
+          scaledElementOffset,
+          object.voxelScale,
+        );
+
+        const elementJitterStrength = Math.max(0, element.jitter ?? 0) * object.voxelScale;
+        if (elementJitterStrength > 0) {
+          const elementJitter = {
+            x: seededRandomCentered(...elementSeed, 'ejx') * elementJitterStrength,
+            y: seededRandomCentered(...elementSeed, 'ejy') * elementJitterStrength,
+            z: seededRandomCentered(...elementSeed, 'ejz') * elementJitterStrength,
+          };
+          elementWorldOffset = addVectors(elementWorldOffset, elementJitter);
+        }
+
+        const combinedOffset = addVectors(anchorOffset, elementWorldOffset);
+
+        const finalOffset =
+          baseOffset === ZERO_OFFSET ? combinedOffset : addVectors(baseOffset, combinedOffset);
+
+        const scaleJitter = entry.scaleJitter;
+        const jitterMultiplier = scaleJitter > 0
+          ? {
+              right: 1 + seededRandomCentered(...elementSeed, 'sr') * scaleJitter,
+              up: 1 + seededRandomCentered(...elementSeed, 'su') * scaleJitter,
+              forward: 1 + seededRandomCentered(...elementSeed, 'sf') * scaleJitter,
+            }
+          : { right: 1, up: 1, forward: 1 };
+
+        const scale = {
+          x: Math.max(
+            0.01,
+            definition.baseScale.x *
+              entryScale.right *
+              elementScaleLocal.right *
+              jitterMultiplier.right *
+              object.voxelScale,
+          ),
+          y: Math.max(
+            0.01,
+            definition.baseScale.y *
+              entryScale.up *
+              elementScaleLocal.up *
+              jitterMultiplier.up *
+              object.voxelScale,
+          ),
+          z: Math.max(
+            0.01,
+            definition.baseScale.z *
+              entryScale.forward *
+              elementScaleLocal.forward *
+              jitterMultiplier.forward *
+              object.voxelScale,
+          ),
+        };
+
+        const tint = resolveNanovoxelTint(definition, entry, element, baseTint);
+
+        const key = `${basePlacement.key}|nano-${descriptorIndex}-${entryIndex}-${copyIndex}-${elementIndex}`;
+
+        placements.push({
+          type: element.type ?? entry.type ?? definition.baseType,
+          worldX: basePlacement.worldX,
+          worldY: basePlacement.worldY,
+          worldZ: basePlacement.worldZ,
+          options: {
+            scale,
+            visualScale: scale,
+            visualOffset: finalOffset,
+            tint,
+            collisionMode: 'none',
+            isSolid: false,
+            destructible: basePlacement.destructible,
+            sourceObjectId: object.id,
+            voxelIndex: voxel.index,
+            metadata: basePlacement.metadata,
+            key,
+          },
+        });
+      });
+    }
+  });
+
+  return placements;
+}
+
+function computeNanovoxelPlacements(voxel, basePlacement, object) {
+  const descriptor = voxel?.metadata?.visual?.nanovoxels;
+  if (!descriptor) {
+    return [];
+  }
+  const descriptors = Array.isArray(descriptor) ? descriptor : [descriptor];
+  const placements = [];
+  descriptors.forEach((entry, index) => {
+    placements.push(
+      ...computeNanovoxelPlacementsForDescriptor(voxel, basePlacement, object, entry, index),
+    );
+  });
+  return placements;
+}
+
+function computeSegmentVisualAdjustments(voxel, smoothing, scale, object) {
+  const direction = smoothing.direction ?? ZERO_OFFSET;
+  const length = Math.hypot(direction.x, direction.y, direction.z);
+  if (length === 0) {
+    return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+  }
+
+  const unit = {
+    x: direction.x / length,
+    y: direction.y / length,
+    z: direction.z / length,
+  };
+
+  const stepLength = Math.max(0, smoothing.stepLength ?? 0) * object.voxelScale;
+  const overlapRatio = Math.max(0, smoothing.overlap ?? 0);
+  const extendWorld = stepLength * overlapRatio;
+
+  const startPadding = Math.max(0, smoothing.startPadding ?? 0) * object.voxelScale;
+  const endPadding = Math.max(0, smoothing.endPadding ?? 0) * object.voxelScale;
+  const distanceFromStart =
+    Math.max(0, smoothing.distanceFromStart ?? 0) * object.voxelScale;
+  const distanceFromEnd =
+    Math.max(0, smoothing.distanceFromEnd ?? 0) * object.voxelScale;
+
+  const startAllowance = distanceFromStart + startPadding;
+  const endAllowance = distanceFromEnd + endPadding;
+  const startBias = Math.max(0, startPadding - distanceFromStart);
+  const endBias = Math.max(0, endPadding - distanceFromEnd);
+  const halfExtend = extendWorld / 2;
+
+  const computeExtend = (allowance, bias) => {
+    if (allowance <= 0 && bias <= 0 && halfExtend <= 0) {
+      return 0;
+    }
+    const desired = halfExtend + bias;
+    if (desired <= 0) {
+      return 0;
+    }
+    return Math.min(allowance, desired);
+  };
+
+  const backExtend = computeExtend(startAllowance, startBias);
+  const forwardExtend = computeExtend(endAllowance, endBias);
+  const actualExtend = backExtend + forwardExtend;
+
+  const visualScale = cloneScale(scale);
+  if (actualExtend > 0) {
+    visualScale.x += Math.abs(unit.x) * actualExtend;
+    visualScale.y += Math.abs(unit.y) * actualExtend;
+    visualScale.z += Math.abs(unit.z) * actualExtend;
+  }
+
+  let visualOffset = ZERO_OFFSET;
+  const offsetAlong = (forwardExtend - backExtend) / 2;
+  if (offsetAlong !== 0) {
+    visualOffset = {
+      x: unit.x * offsetAlong,
+      y: unit.y * offsetAlong,
+      z: unit.z * offsetAlong,
+    };
+  }
+
+  const embed = Math.max(0, smoothing.embed ?? 0) * object.voxelScale;
+  if (embed > 0) {
+    const startSpan = Math.max(stepLength + startPadding, stepLength || 1);
+    const endSpan = Math.max(stepLength + endPadding, stepLength || 1);
+    const startInfluence = clamp01(1 - distanceFromStart / startSpan);
+    const endInfluence = clamp01(1 - distanceFromEnd / endSpan);
+    const embedStrength = Math.max(startInfluence, endInfluence);
+    if (embedStrength > 0) {
+      const shrink = embed * embedStrength;
+      visualScale.x = Math.max(0.01, visualScale.x - shrink);
+      visualScale.y = Math.max(0.01, visualScale.y - shrink);
+      visualScale.z = Math.max(0.01, visualScale.z - shrink);
+      const embedBias = endInfluence - startInfluence;
+      const embedOffset = embed * embedBias * 0.5;
+      if (embedOffset !== 0) {
+        const offsetDelta = {
+          x: unit.x * embedOffset,
+          y: unit.y * embedOffset,
+          z: unit.z * embedOffset,
+        };
+        visualOffset = visualOffset === ZERO_OFFSET ? offsetDelta : addVectors(visualOffset, offsetDelta);
+      }
+    }
+  }
+
+  const decorativeLayers = Math.max(0, smoothing.featherLayers ?? 0);
+  if (decorativeLayers > 0) {
+    const shrinkFactor = Math.max(0.55, 1 - decorativeLayers * 0.08);
+    visualScale.x *= shrinkFactor;
+    visualScale.y *= shrinkFactor;
+    visualScale.z *= shrinkFactor;
+  }
+
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0);
+  if (jitterStrength > 0) {
+    const amplitude = jitterStrength * object.voxelScale * 0.35;
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jx') * amplitude,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jy') * amplitude,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'segment-jz') * amplitude,
+    };
+    visualOffset = visualOffset === ZERO_OFFSET ? jitter : addVectors(visualOffset, jitter);
+  }
+
+  return { visualScale, visualOffset };
+}
+
+function computeVisualAdjustments(voxel, scale, object) {
+  const smoothing = voxel?.metadata?.visual?.smoothing;
+  if (!smoothing) {
+    return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+  }
+
+  if (smoothing.type === 'node') {
+    const inflate = Math.max(0, smoothing.inflate ?? 0) * object.voxelScale;
+    const visualScale = cloneScale(scale);
+    if (inflate > 0) {
+      visualScale.x += inflate;
+      visualScale.y += inflate;
+      visualScale.z += inflate;
+    }
+    const embed = Math.max(0, smoothing.embed ?? 0) * object.voxelScale;
+    if (embed > 0) {
+      visualScale.x = Math.max(0.01, visualScale.x - embed);
+      visualScale.y = Math.max(0.01, visualScale.y - embed);
+      visualScale.z = Math.max(0.01, visualScale.z - embed);
+    }
+    const decorativeLayers = Math.max(0, smoothing.featherLayers ?? 0);
+    if (decorativeLayers > 0) {
+      const shrinkFactor = Math.max(0.5, 1 - decorativeLayers * 0.12);
+      visualScale.x *= shrinkFactor;
+      visualScale.y *= shrinkFactor;
+      visualScale.z *= shrinkFactor;
+    }
+    let visualOffset = ZERO_OFFSET;
+    const jitterStrength = Math.max(0, smoothing.microJitter ?? 0);
+    if (jitterStrength > 0) {
+      const amplitude = jitterStrength * object.voxelScale * 0.35;
+      const jitter = {
+        x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jx') * amplitude,
+        y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jy') * amplitude,
+        z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, 'node-jz') * amplitude,
+      };
+      visualOffset = jitter;
+    }
+    return { visualScale, visualOffset };
+  }
+
+  if (smoothing.type === 'segment') {
+    return computeSegmentVisualAdjustments(voxel, smoothing, scale, object);
+  }
+
+  return { visualScale: cloneScale(scale), visualOffset: ZERO_OFFSET };
+}
+
+
 function resolveCollisionMode(voxel, object) {
   if (voxel?.collisionMode) {
     return voxel.collisionMode;
@@ -41,6 +629,175 @@ function resolveCollisionMode(voxel, object) {
   return object.voxelScale < 1 ? 'none' : 'solid';
 }
 
+function computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing) {
+  const layerCount = Math.max(0, smoothing.featherLayers ?? 0);
+  if (layerCount === 0) {
+    return [];
+  }
+  const frame = createLocalFrame(smoothing.direction ?? ZERO_OFFSET);
+  if (!frame) {
+    return [];
+  }
+
+  const baseOffset =
+    basePlacement.visualOffset === ZERO_OFFSET
+      ? ZERO_OFFSET
+      : cloneOffset(basePlacement.visualOffset);
+  const spacing = Math.max(0, smoothing.featherSpacing ?? 0.2) * object.voxelScale;
+  const radius = Math.max(0, smoothing.featherRadius ?? 0.25) * object.voxelScale;
+  const scaleFactor = Math.max(0, smoothing.featherScale ?? 0.1);
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0) * object.voxelScale * 0.45;
+  const baseTint = basePlacement.tint;
+  const accentTint = smoothing.featherTint ?? baseTint;
+
+  const placements = [];
+  for (let i = 1; i <= layerCount; i += 1) {
+    const layerRatio = i / (layerCount + 1);
+    const alongOffset = (i - (layerCount + 1) / 2) * spacing * 0.6;
+    const swirlSeed = seededRandom(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer');
+    const swirlAngle = (smoothing.progress ?? 0) * Math.PI * 2 + swirlSeed * Math.PI * 2;
+    const radialAmount = radius * (0.65 + 0.35 * (1 - layerRatio));
+    const radialOffset = addVectors(
+      scaleVector(frame.right, Math.cos(swirlAngle) * radialAmount),
+      scaleVector(frame.up, Math.sin(swirlAngle) * radialAmount),
+    );
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jx') *
+        jitterStrength,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jy') *
+        jitterStrength,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'segment-layer-jz') *
+        jitterStrength,
+    };
+    const offset = addVectors(
+      baseOffset,
+      addVectors(scaleVector(frame.forward, alongOffset), addVectors(radialOffset, jitter)),
+    );
+
+    const scaleMultiplier = 1 + scaleFactor * (1 - layerRatio * 0.75);
+    const visualScale = {
+      x: basePlacement.visualScale.x * scaleMultiplier,
+      y: basePlacement.visualScale.y * (1 + scaleFactor * (1 - layerRatio) * 0.5),
+      z: basePlacement.visualScale.z * scaleMultiplier,
+    };
+
+    const tintMix = 0.35 + layerRatio * 0.35;
+    const tint = blendTint(baseTint, accentTint, tintMix);
+
+    placements.push({
+      type: voxel.type,
+      worldX: basePlacement.worldX,
+      worldY: basePlacement.worldY,
+      worldZ: basePlacement.worldZ,
+      options: {
+        scale: basePlacement.scale,
+        visualScale,
+        visualOffset: offset,
+        tint,
+        collisionMode: 'none',
+        isSolid: false,
+        destructible: basePlacement.destructible,
+        sourceObjectId: object.id,
+        voxelIndex: voxel.index,
+        metadata: basePlacement.metadata,
+        key: `${basePlacement.key}|layer-${i}`,
+      },
+    });
+  }
+
+  return placements;
+}
+
+function computeNodeFeatherPlacements(voxel, basePlacement, object, smoothing) {
+  const layerCount = Math.max(0, smoothing.featherLayers ?? 0);
+  if (layerCount === 0) {
+    return [];
+  }
+
+  const baseOffset =
+    basePlacement.visualOffset === ZERO_OFFSET
+      ? ZERO_OFFSET
+      : cloneOffset(basePlacement.visualOffset);
+  const radius = Math.max(0, smoothing.featherRadius ?? 0.35) * object.voxelScale;
+  const scaleFactor = Math.max(0, smoothing.featherScale ?? 0.2);
+  const jitterStrength = Math.max(0, smoothing.microJitter ?? 0) * object.voxelScale * 0.5;
+  const baseTint = basePlacement.tint;
+  const accentTint = smoothing.featherTint ?? baseTint;
+
+  const placements = [];
+  for (let i = 1; i <= layerCount; i += 1) {
+    const layerRatio = i / (layerCount + 1);
+    const angle = seededRandom(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-angle') *
+      Math.PI * 2;
+    const verticalSwing = seededRandomCentered(
+      object.id ?? 'object',
+      voxel.index ?? 0,
+      i,
+      'node-layer-vertical',
+    );
+    const radialAmount = radius * layerRatio;
+    const offset = {
+      x: Math.cos(angle) * radialAmount,
+      y: verticalSwing * radius * 0.4,
+      z: Math.sin(angle) * radialAmount,
+    };
+    const jitter = {
+      x: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jx') *
+        jitterStrength,
+      y: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jy') *
+        jitterStrength,
+      z: seededRandomCentered(object.id ?? 'object', voxel.index ?? 0, i, 'node-layer-jz') *
+        jitterStrength,
+    };
+    const finalOffset = addVectors(baseOffset, addVectors(offset, jitter));
+
+    const scaleMultiplier = 1 + scaleFactor * layerRatio;
+    const visualScale = {
+      x: basePlacement.visualScale.x * scaleMultiplier,
+      y: basePlacement.visualScale.y * (1 + scaleFactor * layerRatio * 0.65),
+      z: basePlacement.visualScale.z * scaleMultiplier,
+    };
+
+    const tintMix = 0.4 + layerRatio * 0.4;
+    const tint = blendTint(baseTint, accentTint, tintMix);
+
+    placements.push({
+      type: voxel.type,
+      worldX: basePlacement.worldX,
+      worldY: basePlacement.worldY,
+      worldZ: basePlacement.worldZ,
+      options: {
+        scale: basePlacement.scale,
+        visualScale,
+        visualOffset: finalOffset,
+        tint,
+        collisionMode: 'none',
+        isSolid: false,
+        destructible: basePlacement.destructible,
+        sourceObjectId: object.id,
+        voxelIndex: voxel.index,
+        metadata: basePlacement.metadata,
+        key: `${basePlacement.key}|petal-${i}`,
+      },
+    });
+  }
+
+  return placements;
+}
+
+function computeDecorativePlacements(voxel, basePlacement, object) {
+  const smoothing = voxel?.metadata?.visual?.smoothing;
+  if (!smoothing) {
+    return [];
+  }
+  if (smoothing.type === 'segment') {
+    return computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing);
+  }
+  if (smoothing.type === 'node') {
+    return computeNodeFeatherPlacements(voxel, basePlacement, object, smoothing);
+  }
+  return [];
+}
 
 export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
   if (!object || typeof addBlock !== 'function') {
@@ -54,21 +811,40 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
     z: base.z,
   };
 
-  const defaultSolidOverride = object.voxelScale < 1;
-
-
   const voxels = resolveVoxelObjectVoxels(object);
 
   voxels.forEach((voxel) => {
     const scale = resolveScaleVector(voxel, object.voxelScale);
+    const { visualScale, visualOffset } = computeVisualAdjustments(
+      voxel,
+      scale,
+      object,
+    );
     const worldX = anchor.x + voxel.position.x * object.voxelScale;
     const worldY = anchor.y + voxel.position.y * object.voxelScale + scale.y / 2;
     const worldZ = anchor.z + voxel.position.z * object.voxelScale;
 
     const collisionMode = resolveCollisionMode(voxel, object);
+    const baseKey = `${object.id}|${voxel.index}|${worldX}|${worldY}|${worldZ}`;
+    const basePlacement = {
+      type: voxel.type,
+      worldX,
+      worldY,
+      worldZ,
+      scale,
+      visualScale,
+      visualOffset,
+      tint: voxel.tint,
+      destructible: voxel.destructible,
+      metadata: voxel.metadata,
+      collisionMode,
+      key: baseKey,
+    };
 
     addBlock(voxel.type, worldX, worldY, worldZ, biome, {
       scale,
+      visualScale,
+      visualOffset,
       collisionMode,
       isSolid: collisionMode === 'solid',
 
@@ -77,7 +853,31 @@ export function placeVoxelObject(addBlock, object, { origin, biome } = {}) {
       sourceObjectId: object.id,
       voxelIndex: voxel.index,
       metadata: voxel.metadata,
-      key: `${object.id}|${voxel.index}|${worldX}|${worldY}|${worldZ}`,
+      key: baseKey,
+    });
+
+    const decorativePlacements = computeDecorativePlacements(voxel, basePlacement, object);
+    decorativePlacements.forEach((placement) => {
+      addBlock(
+        placement.type,
+        placement.worldX,
+        placement.worldY,
+        placement.worldZ,
+        biome,
+        placement.options,
+      );
+    });
+
+    const nanovoxelPlacements = computeNanovoxelPlacements(voxel, basePlacement, object);
+    nanovoxelPlacements.forEach((placement) => {
+      addBlock(
+        placement.type,
+        placement.worldX,
+        placement.worldY,
+        placement.worldZ,
+        biome,
+        placement.options,
+      );
     });
   });
 }

--- a/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
+++ b/three-demo/src/world/voxel-objects/large-plants/noctilucent_pillarcap.json
@@ -10,7 +10,9 @@
     "groundOffset": 0.2
   },
   "placement": {
-    "biomes": ["noctilucent_fungus_glade"],
+    "biomes": [
+      "noctilucent_fungus_glade"
+    ],
     "weight": 1.6,
     "maxSlope": 0.5,
     "forbidUnderwater": false,
@@ -19,42 +21,327 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.4,
-      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#6a4d84" },
+      "smoothing": {
+        "segmentOverlap": 0.5,
+        "segmentEndPadding": 0.45,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.22,
+        "embed": 0.12,
+        "featherLayers": 3,
+        "featherRadius": 0.45,
+        "featherSpacing": 0.28,
+        "featherScale": 0.22,
+        "microJitter": 0.18,
+        "featherTint": "#bdfbff"
+      },
+      "defaultVoxel": {
+        "type": "log",
+        "isSolid": true,
+        "tint": "#6a4d84"
+      },
       "nodes": [
         {
           "id": "base",
-          "position": [0, 0, 0],
-          "voxel": { "type": "log", "size": [1.3, 0.6, 1.3], "tint": "#6a4d84", "isSolid": true }
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.32,
+            "microJitter": 0.14,
+            "embed": 0.08,
+            "featherTint": "#86d0ff"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              1.3,
+              0.6,
+              1.3
+            ],
+            "tint": "#6a4d84",
+            "isSolid": true
+          }
         },
-        { "id": "mid", "position": [0.18, 2.8, -0.1] },
+        {
+          "id": "mid",
+          "position": [
+            0.18,
+            2.8,
+            -0.1
+          ],
+          "smoothing": {
+            "featherLayers": 1,
+            "featherRadius": 0.26,
+            "microJitter": 0.12
+          },
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 8,
+              "radius": 0.6,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.12,
+                0.1
+              ],
+              "scale": [
+                0.78,
+                0.78,
+                0.78
+              ],
+              "jitter": 0.08,
+              "accentTint": "#bff7ff",
+              "accentStrength": 0.5
+            }
+          ]
+        },
         {
           "id": "crown",
-          "position": [-0.12, 5.8, 0.16],
-          "voxel": { "type": "log", "size": [1.0, 0.8, 1.0], "tint": "#735694", "isSolid": true }
+          "position": [
+            -0.12,
+            5.8,
+            0.16
+          ],
+          "smoothing": {
+            "featherLayers": 4,
+            "featherRadius": 0.5,
+            "featherScale": 0.3,
+            "microJitter": 0.24,
+            "embed": 0.1,
+            "featherTint": "#d6f8ff"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              1.0,
+              0.8,
+              1.0
+            ],
+            "tint": "#735694",
+            "isSolid": true
+          },
+          "nanovoxels": [
+            {
+              "id": "petal-cluster",
+              "count": 9,
+              "radius": 0.82,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.2,
+                0.32
+              ],
+              "scale": [
+                1.18,
+                1.04,
+                1.36
+              ],
+              "jitter": 0.08,
+              "accentTint": "#dffcff",
+              "accentStrength": 0.45,
+              "tint": "#d6f8ff"
+            },
+            {
+              "id": "halo-spark",
+              "count": 14,
+              "radius": 1.2,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.28,
+                0.12
+              ],
+              "scale": [
+                0.9,
+                0.9,
+                0.9
+              ],
+              "jitter": 0.12,
+              "accentTint": "#ffffff",
+              "accentStrength": 0.55
+            }
+          ]
         }
       ],
       "segments": [
         {
           "from": "base",
           "to": "mid",
-          "voxel": { "type": "log", "tint": "#6f558d", "isSolid": true },
-          "startSize": [1.25, 1.2, 1.25],
-          "endSize": [1.1, 1.1, 1.1]
+          "voxel": {
+            "type": "log",
+            "tint": "#6f558d",
+            "isSolid": true
+          },
+          "startSize": [
+            1.25,
+            1.2,
+            1.25
+          ],
+          "endSize": [
+            1.1,
+            1.1,
+            1.1
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.6,
+            "segmentEndPadding": 0.52,
+            "featherLayers": 2,
+            "featherRadius": 0.32,
+            "featherSpacing": 0.22,
+            "featherScale": 0.18,
+            "microJitter": 0.16,
+            "featherTint": "#8ad8ff",
+            "embed": 0.12
+          },
+          "nanovoxels": [
+            {
+              "id": "feather-frond",
+              "count": 5,
+              "radius": 0.34,
+              "arcTurns": 1,
+              "length": 0.62,
+              "offset": [
+                0,
+                0.12,
+                0.08
+              ],
+              "scale": [
+                0.82,
+                0.92,
+                0.88
+              ],
+              "distribution": "line",
+              "jitter": 0.06,
+              "accentTint": "#8ad8ff",
+              "accentStrength": 0.35,
+              "minProgress": 0.05,
+              "maxProgress": 0.85,
+              "progressMode": "center"
+            }
+          ]
         },
         {
           "from": "mid",
           "to": "crown",
-          "voxel": { "type": "log", "tint": "#735694", "isSolid": true },
-          "startSize": [1.1, 1.05, 1.1],
-          "endSize": [0.95, 0.95, 0.95]
+          "voxel": {
+            "type": "log",
+            "tint": "#735694",
+            "isSolid": true
+          },
+          "startSize": [
+            1.1,
+            1.05,
+            1.1
+          ],
+          "endSize": [
+            0.95,
+            0.95,
+            0.95
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.65,
+            "segmentEndPadding": 0.6,
+            "featherLayers": 4,
+            "featherRadius": 0.42,
+            "featherSpacing": 0.3,
+            "featherScale": 0.24,
+            "microJitter": 0.2,
+            "featherTint": "#c7f6ff",
+            "embed": 0.14
+          },
+          "nanovoxels": [
+            {
+              "id": "coral-frill",
+              "count": 6,
+              "radius": 0.48,
+              "arcTurns": 1,
+              "length": 0.92,
+              "offset": [
+                0,
+                0.24,
+                0.12
+              ],
+              "scale": [
+                0.94,
+                1.04,
+                1
+              ],
+              "distribution": "line",
+              "jitter": 0.08,
+              "accentTint": "#c7f6ff",
+              "accentStrength": 0.42,
+              "minProgress": 0.1,
+              "maxProgress": 0.95
+            }
+          ]
         }
       ]
     }
   },
   "voxels": [
-    { "type": "leaf", "position": [0, 5.6, 0], "size": [3.4, 0.8, 3.4], "tint": "#6fe9f1", "isSolid": false },
-    { "type": "leaf", "position": [0, 6.4, 0], "size": [2.4, 0.6, 2.4], "tint": "#9bfdf7", "isSolid": false },
-    { "type": "leaf", "position": [0, 4.2, 0], "size": [1.6, 1.2, 1.6], "tint": "#5cd6dc", "isSolid": false },
-    { "type": "leaf", "position": [0, 1.2, 0], "size": [1.4, 0.6, 1.4], "tint": "#4bc2c8", "isSolid": false }
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        5.6,
+        0
+      ],
+      "size": [
+        3.4,
+        0.8,
+        3.4
+      ],
+      "tint": "#6fe9f1",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        6.4,
+        0
+      ],
+      "size": [
+        2.4,
+        0.6,
+        2.4
+      ],
+      "tint": "#9bfdf7",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        4.2,
+        0
+      ],
+      "size": [
+        1.6,
+        1.2,
+        1.6
+      ],
+      "tint": "#5cd6dc",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        1.2,
+        0
+      ],
+      "size": [
+        1.4,
+        0.6,
+        1.4
+      ],
+      "tint": "#4bc2c8",
+      "isSolid": false
+    }
   ]
 }

--- a/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
+++ b/three-demo/src/world/voxel-objects/large-plants/sunset_cactus.json
@@ -10,7 +10,9 @@
     "groundOffset": 0.2
   },
   "placement": {
-    "biomes": ["sunset_dunes"],
+    "biomes": [
+      "sunset_dunes"
+    ],
     "weight": 1.4,
     "maxSlope": 0.4,
     "minHeight": 3,
@@ -20,43 +22,346 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.38,
-      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#37b47a" },
+      "smoothing": {
+        "segmentOverlap": 0.45,
+        "segmentEndPadding": 0.4,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.2,
+        "embed": 0.1,
+        "featherLayers": 2,
+        "featherRadius": 0.4,
+        "featherSpacing": 0.24,
+        "featherScale": 0.2,
+        "microJitter": 0.16,
+        "featherTint": "#f4f0a6"
+      },
+      "defaultVoxel": {
+        "type": "log",
+        "isSolid": true,
+        "tint": "#37b47a"
+      },
       "nodes": [
         {
           "id": "base",
-          "position": [0, 0, 0],
-          "voxel": { "type": "log", "size": [1.25, 0.6, 1.25], "tint": "#2f9f6f", "isSolid": true }
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.28,
+            "microJitter": 0.1,
+            "embed": 0.08,
+            "featherTint": "#f2d384"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              1.25,
+              0.6,
+              1.25
+            ],
+            "tint": "#2f9f6f",
+            "isSolid": true
+          },
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 6,
+              "radius": 0.52,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.16,
+                0.08
+              ],
+              "scale": [
+                0.7,
+                0.7,
+                0.7
+              ],
+              "jitter": 0.08,
+              "accentTint": "#ffd68f",
+              "accentStrength": 0.5
+            }
+          ]
         },
-        { "id": "mid", "position": [0, 3.2, 0] },
+        {
+          "id": "mid",
+          "position": [
+            0,
+            3.2,
+            0
+          ],
+          "smoothing": {
+            "featherLayers": 1,
+            "featherRadius": 0.22,
+            "microJitter": 0.12,
+            "featherTint": "#f8e49b"
+          },
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 10,
+              "radius": 0.58,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.14,
+                0.08
+              ],
+              "scale": [
+                0.76,
+                0.76,
+                0.76
+              ],
+              "jitter": 0.08,
+              "accentTint": "#ffe7a8",
+              "accentStrength": 0.45
+            }
+          ]
+        },
         {
           "id": "upper",
-          "position": [0, 6.4, 0],
-          "voxel": { "type": "log", "size": [0.9, 0.6, 0.9], "tint": "#3fc488", "isSolid": true }
+          "position": [
+            0,
+            6.4,
+            0
+          ],
+          "smoothing": {
+            "featherLayers": 3,
+            "featherRadius": 0.36,
+            "featherScale": 0.22,
+            "microJitter": 0.18,
+            "embed": 0.1,
+            "featherTint": "#ffe7a8"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              0.9,
+              0.6,
+              0.9
+            ],
+            "tint": "#3fc488",
+            "isSolid": true
+          },
+          "nanovoxels": [
+            {
+              "id": "petal-cluster",
+              "count": 7,
+              "radius": 0.6,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.18,
+                0.24
+              ],
+              "scale": [
+                1.1,
+                1.02,
+                1.18
+              ],
+              "jitter": 0.08,
+              "accentTint": "#ffe6b8",
+              "accentStrength": 0.48,
+              "tint": "#ffe7a8"
+            }
+          ]
         }
       ],
       "segments": [
         {
           "from": "base",
           "to": "mid",
-          "voxel": { "type": "log", "tint": "#37b47a", "isSolid": true },
-          "startSize": [1.2, 1.1, 1.2],
-          "endSize": [1.05, 1.05, 1.05]
+          "voxel": {
+            "type": "log",
+            "tint": "#37b47a",
+            "isSolid": true
+          },
+          "startSize": [
+            1.2,
+            1.1,
+            1.2
+          ],
+          "endSize": [
+            1.05,
+            1.05,
+            1.05
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.5,
+            "segmentEndPadding": 0.48,
+            "featherLayers": 2,
+            "featherRadius": 0.26,
+            "featherSpacing": 0.2,
+            "featherScale": 0.18,
+            "microJitter": 0.18,
+            "featherTint": "#f6db8d",
+            "embed": 0.1
+          },
+          "nanovoxels": [
+            {
+              "id": "cactus-needle-bundle",
+              "count": 6,
+              "radius": 0.28,
+              "arcTurns": 1.2,
+              "length": 0.74,
+              "offset": [
+                0,
+                0.16,
+                0.04
+              ],
+              "scale": [
+                0.88,
+                1.1,
+                0.88
+              ],
+              "distribution": "line",
+              "jitter": 0.05,
+              "accentTint": "#ffdca1",
+              "accentStrength": 0.4,
+              "minProgress": 0.05,
+              "maxProgress": 0.95,
+              "growth": 0.25,
+              "progressMode": "center",
+              "seed": "spine-base"
+            }
+          ]
         },
         {
           "from": "mid",
           "to": "upper",
-          "voxel": { "type": "log", "tint": "#3fc488", "isSolid": true },
-          "startSize": [1.05, 1.0, 1.05],
-          "endSize": [0.9, 0.9, 0.9]
+          "voxel": {
+            "type": "log",
+            "tint": "#3fc488",
+            "isSolid": true
+          },
+          "startSize": [
+            1.05,
+            1.0,
+            1.05
+          ],
+          "endSize": [
+            0.9,
+            0.9,
+            0.9
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.52,
+            "segmentEndPadding": 0.55,
+            "featherLayers": 3,
+            "featherRadius": 0.34,
+            "featherSpacing": 0.26,
+            "featherScale": 0.24,
+            "microJitter": 0.2,
+            "featherTint": "#ffe0a1",
+            "embed": 0.12
+          },
+          "nanovoxels": [
+            {
+              "id": "cactus-needle-bundle",
+              "count": 7,
+              "radius": 0.24,
+              "arcTurns": 1.4,
+              "length": 0.68,
+              "offset": [
+                0,
+                0.18,
+                0.02
+              ],
+              "scale": [
+                0.78,
+                1.08,
+                0.78
+              ],
+              "distribution": "line",
+              "jitter": 0.05,
+              "accentTint": "#ffe0a1",
+              "accentStrength": 0.42,
+              "minProgress": 0.05,
+              "maxProgress": 0.95,
+              "growth": 0.3,
+              "progressMode": "end",
+              "seed": "spine-upper"
+            }
+          ]
         }
       ]
     }
   },
   "voxels": [
-    { "type": "leaf", "position": [1.4, 2.6, 0], "size": [1.1, 2.4, 1.1], "tint": "#3fb98a" },
-    { "type": "leaf", "position": [-1.4, 4.2, 0], "size": [0.9, 2.2, 0.9], "tint": "#42c996" },
-    { "type": "leaf", "position": [0, 4.6, 1.4], "size": [1.0, 2.1, 1.0], "tint": "#3fb98a" },
-    { "type": "leaf", "position": [0, 2.8, -1.4], "size": [0.9, 2.0, 0.9], "tint": "#44d09c" },
-    { "type": "leaf", "position": [0, 7.4, 0], "size": [1.2, 0.8, 1.2], "tint": "#f9c27a", "isSolid": false }
+    {
+      "type": "leaf",
+      "position": [
+        1.4,
+        2.6,
+        0
+      ],
+      "size": [
+        1.1,
+        2.4,
+        1.1
+      ],
+      "tint": "#3fb98a"
+    },
+    {
+      "type": "leaf",
+      "position": [
+        -1.4,
+        4.2,
+        0
+      ],
+      "size": [
+        0.9,
+        2.2,
+        0.9
+      ],
+      "tint": "#42c996"
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        4.6,
+        1.4
+      ],
+      "size": [
+        1.0,
+        2.1,
+        1.0
+      ],
+      "tint": "#3fb98a"
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        2.8,
+        -1.4
+      ],
+      "size": [
+        0.9,
+        2.0,
+        0.9
+      ],
+      "tint": "#44d09c"
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        7.4,
+        0
+      ],
+      "size": [
+        1.2,
+        0.8,
+        1.2
+      ],
+      "tint": "#f9c27a",
+      "isSolid": false
+    }
   ]
 }

--- a/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
+++ b/three-demo/src/world/voxel-objects/large-plants/vaporwave_palm.json
@@ -10,7 +10,9 @@
     "groundOffset": 0.2
   },
   "placement": {
-    "biomes": ["fading_vaporwave_dimension"],
+    "biomes": [
+      "fading_vaporwave_dimension"
+    ],
     "weight": 2.4,
     "maxSlope": 0.5,
     "forbidUnderwater": false,
@@ -19,45 +21,419 @@
   "procedural": {
     "nodeGrowth": {
       "step": 0.42,
-      "defaultVoxel": { "type": "log", "isSolid": true, "tint": "#f8a7ff" },
+      "smoothing": {
+        "segmentOverlap": 0.4,
+        "segmentEndPadding": 0.35,
+        "segmentSubdivisions": 3,
+        "nodeInflate": 0.18,
+        "embed": 0.1,
+        "featherLayers": 4,
+        "featherRadius": 0.5,
+        "featherSpacing": 0.3,
+        "featherScale": 0.25,
+        "microJitter": 0.22,
+        "featherTint": "#ffd6ff"
+      },
+      "defaultVoxel": {
+        "type": "log",
+        "isSolid": true,
+        "tint": "#f8a7ff"
+      },
       "nodes": [
         {
           "id": "base",
-          "position": [0, 0, 0],
-          "voxel": { "type": "log", "size": [1.15, 0.6, 1.15], "tint": "#f38ff9", "isSolid": true }
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "smoothing": {
+            "featherLayers": 3,
+            "featherRadius": 0.35,
+            "microJitter": 0.18,
+            "embed": 0.08,
+            "featherTint": "#ffb0ff"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              1.15,
+              0.6,
+              1.15
+            ],
+            "tint": "#f38ff9",
+            "isSolid": true
+          },
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 8,
+              "radius": 0.58,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.18,
+                0.1
+              ],
+              "scale": [
+                0.75,
+                0.75,
+                0.75
+              ],
+              "jitter": 0.1,
+              "accentTint": "#ffbfff",
+              "accentStrength": 0.55
+            }
+          ]
         },
-        { "id": "mid", "position": [0.25, 2.4, -0.15] },
+        {
+          "id": "mid",
+          "position": [
+            0.25,
+            2.4,
+            -0.15
+          ],
+          "smoothing": {
+            "featherLayers": 2,
+            "featherRadius": 0.28,
+            "microJitter": 0.2,
+            "featherTint": "#ffc3ff"
+          },
+          "nanovoxels": [
+            {
+              "id": "coral-frill",
+              "count": 8,
+              "radius": 0.64,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.18,
+                0.14
+              ],
+              "scale": [
+                0.96,
+                1.04,
+                1
+              ],
+              "jitter": 0.08,
+              "accentTint": "#ffe0ff",
+              "accentStrength": 0.38,
+              "tint": "#ffc3ff"
+            }
+          ]
+        },
         {
           "id": "crown",
-          "position": [0.05, 4.5, 0.2],
-          "voxel": { "type": "log", "size": [0.8, 0.6, 0.8], "tint": "#ffbffb", "isSolid": true }
+          "position": [
+            0.05,
+            4.5,
+            0.2
+          ],
+          "smoothing": {
+            "featherLayers": 5,
+            "featherRadius": 0.55,
+            "featherScale": 0.32,
+            "microJitter": 0.28,
+            "embed": 0.12,
+            "featherTint": "#fff0ff"
+          },
+          "voxel": {
+            "type": "log",
+            "size": [
+              0.8,
+              0.6,
+              0.8
+            ],
+            "tint": "#ffbffb",
+            "isSolid": true
+          },
+          "nanovoxels": [
+            {
+              "id": "feather-frond",
+              "count": 10,
+              "radius": 0.78,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.24,
+                0.28
+              ],
+              "scale": [
+                1.22,
+                1.08,
+                1.32
+              ],
+              "jitter": 0.12,
+              "accentTint": "#ffe8ff",
+              "accentStrength": 0.4,
+              "tint": "#ffccff"
+            },
+            {
+              "id": "halo-spark",
+              "count": 16,
+              "radius": 1.05,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.34,
+                0.1
+              ],
+              "scale": [
+                0.82,
+                0.82,
+                0.82
+              ],
+              "jitter": 0.14,
+              "accentTint": "#ffffff",
+              "accentStrength": 0.6
+            }
+          ]
         }
       ],
       "segments": [
         {
           "from": "base",
           "to": "mid",
-          "voxel": { "type": "log", "tint": "#f8a7ff", "isSolid": true },
-          "startSize": [1.05, 0.9, 1.05],
-          "endSize": [0.9, 0.85, 0.9]
+          "voxel": {
+            "type": "log",
+            "tint": "#f8a7ff",
+            "isSolid": true
+          },
+          "startSize": [
+            1.05,
+            0.9,
+            1.05
+          ],
+          "endSize": [
+            0.9,
+            0.85,
+            0.9
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.48,
+            "segmentEndPadding": 0.42,
+            "featherLayers": 3,
+            "featherRadius": 0.36,
+            "featherSpacing": 0.26,
+            "featherScale": 0.22,
+            "microJitter": 0.24,
+            "featherTint": "#ffd9ff",
+            "embed": 0.12
+          },
+          "nanovoxels": [
+            {
+              "id": "feather-frond",
+              "count": 6,
+              "radius": 0.36,
+              "arcTurns": 1.1,
+              "length": 0.68,
+              "offset": [
+                0,
+                0.18,
+                0.12
+              ],
+              "scale": [
+                0.86,
+                1.02,
+                0.9
+              ],
+              "distribution": "line",
+              "jitter": 0.06,
+              "accentTint": "#ffd9ff",
+              "accentStrength": 0.36,
+              "minProgress": 0.08,
+              "maxProgress": 0.92,
+              "progressMode": "center",
+              "growth": 0.2
+            }
+          ]
         },
         {
           "from": "mid",
           "to": "crown",
-          "voxel": { "type": "log", "tint": "#ffbdfc", "isSolid": true },
-          "startSize": [0.9, 0.8, 0.9],
-          "endSize": [0.7, 0.7, 0.7]
+          "voxel": {
+            "type": "log",
+            "tint": "#ffbdfc",
+            "isSolid": true
+          },
+          "startSize": [
+            0.9,
+            0.8,
+            0.9
+          ],
+          "endSize": [
+            0.7,
+            0.7,
+            0.7
+          ],
+          "smoothing": {
+            "segmentOverlap": 0.55,
+            "segmentEndPadding": 0.5,
+            "featherLayers": 5,
+            "featherRadius": 0.48,
+            "featherSpacing": 0.32,
+            "featherScale": 0.3,
+            "microJitter": 0.3,
+            "featherTint": "#fff4ff",
+            "embed": 0.16
+          },
+          "nanovoxels": [
+            {
+              "id": "coral-frill",
+              "count": 8,
+              "radius": 0.42,
+              "arcTurns": 1.3,
+              "length": 0.76,
+              "offset": [
+                0,
+                0.22,
+                0.16
+              ],
+              "scale": [
+                0.92,
+                1.08,
+                1.02
+              ],
+              "distribution": "line",
+              "jitter": 0.08,
+              "accentTint": "#fff3ff",
+              "accentStrength": 0.44,
+              "minProgress": 0.1,
+              "maxProgress": 0.95,
+              "progressMode": "end",
+              "growth": 0.32
+            },
+            {
+              "id": "halo-spark",
+              "count": 10,
+              "radius": 0.52,
+              "arcTurns": 1,
+              "offset": [
+                0,
+                0.28,
+                0.08
+              ],
+              "scale": [
+                0.6,
+                0.6,
+                0.6
+              ],
+              "jitter": 0.1,
+              "accentTint": "#ffeaff",
+              "accentStrength": 0.52,
+              "minProgress": 0.05,
+              "maxProgress": 0.9
+            }
+          ]
         }
       ]
     }
   },
   "voxels": [
-    { "type": "leaf", "position": [0, 4.2, 0], "size": [3.2, 0.6, 1.1], "tint": "#6dffd2", "isSolid": false },
-    { "type": "leaf", "position": [0, 4.2, 0], "size": [1.1, 0.6, 3.2], "tint": "#7affff", "isSolid": false },
-    { "type": "leaf", "position": [1.8, 4.4, 1.8], "size": [2.4, 0.5, 1.0], "tint": "#9dffe0", "isSolid": false },
-    { "type": "leaf", "position": [-1.8, 4.4, -1.8], "size": [1.0, 0.5, 2.4], "tint": "#8bfff0", "isSolid": false },
-    { "type": "leaf", "position": [1.8, 4.4, -1.8], "size": [2.4, 0.5, 1.0], "tint": "#7bf2ff", "isSolid": false },
-    { "type": "leaf", "position": [-1.8, 4.4, 1.8], "size": [1.0, 0.5, 2.4], "tint": "#72ffe2", "isSolid": false },
-    { "type": "leaf", "position": [0, 5.2, 0], "size": [1.4, 0.4, 1.4], "tint": "#ffe4fd", "isSolid": false }
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        4.2,
+        0
+      ],
+      "size": [
+        3.2,
+        0.6,
+        1.1
+      ],
+      "tint": "#6dffd2",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        4.2,
+        0
+      ],
+      "size": [
+        1.1,
+        0.6,
+        3.2
+      ],
+      "tint": "#7affff",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        1.8,
+        4.4,
+        1.8
+      ],
+      "size": [
+        2.4,
+        0.5,
+        1.0
+      ],
+      "tint": "#9dffe0",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        -1.8,
+        4.4,
+        -1.8
+      ],
+      "size": [
+        1.0,
+        0.5,
+        2.4
+      ],
+      "tint": "#8bfff0",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        1.8,
+        4.4,
+        -1.8
+      ],
+      "size": [
+        2.4,
+        0.5,
+        1.0
+      ],
+      "tint": "#7bf2ff",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        -1.8,
+        4.4,
+        1.8
+      ],
+      "size": [
+        1.0,
+        0.5,
+        2.4
+      ],
+      "tint": "#72ffe2",
+      "isSolid": false
+    },
+    {
+      "type": "leaf",
+      "position": [
+        0,
+        5.2,
+        0
+      ],
+      "size": [
+        1.4,
+        0.4,
+        1.4
+      ],
+      "tint": "#ffe4fd",
+      "isSolid": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- rewrite the large plant voxel-object JSON definitions with canonical JSON formatting so Vite's JSON parser accepts them across environments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bb146ab4832aa2af5e3e0bd74660