### PR TITLE
Restore viewport rendering via dedicated canvas container

### DIFF
--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -9,26 +9,40 @@
       body {
         margin: 0;
         padding: 0;
-        overflow: hidden;
+        width: 100%;
         height: 100%;
+        overflow: hidden;
         background: #000;
-        font-family: "Segoe UI", sans-serif;
+        font-family: 'Segoe UI', sans-serif;
         color: #fff;
       }
 
-      #overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
+      #app {
+        position: relative;
         width: 100%;
         height: 100%;
+        overflow: hidden;
+      }
+
+      #viewport {
+        position: fixed;
+        inset: 0;
+        z-index: 0;
+        background: #000;
+      }
+
+      #overlay {
+        position: fixed;
+        inset: 0;
         display: flex;
         align-items: center;
         justify-content: center;
         flex-direction: column;
+        padding: clamp(16px, 5vw, 72px);
         background: rgba(0, 0, 0, 0.6);
         cursor: pointer;
         transition: opacity 0.3s ease;
+        z-index: 10;
       }
 
       #overlay.hidden {
@@ -38,13 +52,19 @@
 
       #instructions {
         text-align: center;
-        max-width: 420px;
+        max-width: min(520px, 90vw);
         line-height: 1.6;
+        font-size: clamp(14px, 2vw, 18px);
+      }
+
+      #instructions h1 {
+        margin-bottom: clamp(12px, 3vh, 24px);
+        font-size: clamp(26px, 5vw, 48px);
       }
 
       #overlay-status {
-        margin-top: 18px;
-        font-size: 13px;
+        margin-top: clamp(14px, 2.5vh, 22px);
+        font-size: clamp(13px, 1.6vw, 16px);
         color: rgba(255, 255, 255, 0.85);
         line-height: 1.5;
         opacity: 0;
@@ -60,33 +80,34 @@
       }
 
       #hud {
-        position: absolute;
-        left: 24px;
-        bottom: 24px;
+        position: fixed;
+        left: clamp(12px, 2.6vw, 36px);
+        bottom: clamp(12px, 3vh, 40px);
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: clamp(6px, 1.5vh, 12px);
         pointer-events: none;
-        min-width: 220px;
-        font-size: 14px;
+        min-width: clamp(180px, 26vw, 280px);
+        font-size: clamp(13px, 1.6vw, 16px);
+        z-index: 20;
       }
 
       .hud-bar {
         display: flex;
         align-items: center;
-        gap: 10px;
+        gap: clamp(8px, 2vw, 16px);
       }
 
       .hud-label {
         text-transform: uppercase;
-        font-size: 11px;
+        font-size: clamp(10px, 1.1vw, 12px);
         letter-spacing: 0.08em;
         color: rgba(255, 255, 255, 0.8);
       }
 
       .hud-track {
         flex: 1;
-        height: 6px;
+        height: clamp(6px, 1vh, 10px);
         background: rgba(255, 255, 255, 0.2);
         border-radius: 6px;
         overflow: hidden;
@@ -105,15 +126,15 @@
 
       .hud-value {
         font-variant-numeric: tabular-nums;
-        font-size: 12px;
+        font-size: clamp(11px, 1.2vw, 14px);
         color: rgba(255, 255, 255, 0.9);
-        min-width: 32px;
+        min-width: clamp(28px, 3vw, 38px);
         text-align: right;
       }
 
       #hud-status {
-        min-height: 18px;
-        font-size: 13px;
+        min-height: clamp(18px, 3vh, 28px);
+        font-size: clamp(12px, 1.5vw, 16px);
         color: #ffe28a;
         opacity: 0;
         transition: opacity 0.3s ease;
@@ -133,17 +154,19 @@
 
       canvas {
         display: block;
+        width: 100%;
+        height: 100%;
       }
 
       .volume-widget {
         position: fixed;
-        top: 16px;
-        right: 16px;
-        width: 220px;
-        padding: 10px 12px 12px 12px;
+        top: clamp(12px, 2.6vw, 24px);
+        right: clamp(12px, 2.6vw, 24px);
+        width: min(240px, 80vw);
+        padding: clamp(10px, 2vw, 16px);
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: clamp(6px, 1.4vh, 12px);
         background: rgba(12, 16, 24, 0.78);
         border: 1px solid rgba(132, 160, 220, 0.24);
         border-radius: 12px;
@@ -162,7 +185,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        font-size: 12px;
+        font-size: clamp(10px, 1.2vw, 12px);
         letter-spacing: 0.08em;
         text-transform: uppercase;
         color: rgba(200, 220, 255, 0.72);
@@ -172,13 +195,13 @@
 
       .volume-widget-title {
         font-weight: 600;
-        font-size: 11px;
+        font-size: clamp(10px, 1.1vw, 12px);
       }
 
       .volume-widget-controls {
         display: flex;
         align-items: center;
-        gap: 10px;
+        gap: clamp(8px, 2vw, 14px);
       }
 
       .volume-widget button {
@@ -187,8 +210,8 @@
         background: rgba(18, 24, 36, 0.85);
         color: inherit;
         border-radius: 8px;
-        padding: 6px 10px;
-        font-size: 12px;
+        padding: clamp(4px, 1vh, 7px) clamp(8px, 2vw, 12px);
+        font-size: clamp(11px, 1.3vw, 13px);
         line-height: 1;
         cursor: pointer;
         transition: border-color 160ms ease, background 160ms ease;
@@ -206,29 +229,30 @@
       }
 
       .volume-widget-toggle {
-        width: 42px;
+        width: clamp(38px, 12vw, 48px);
       }
 
       .volume-widget-next {
-        width: 42px;
+        width: clamp(38px, 12vw, 48px);
       }
 
       .volume-widget-slider {
         flex: 1;
+        min-width: 0;
         accent-color: #94b9ff;
         cursor: pointer;
       }
 
       .volume-widget-track {
-        min-height: 16px;
-        font-size: 12px;
+        min-height: clamp(14px, 2vh, 18px);
+        font-size: clamp(11px, 1.2vw, 13px);
         line-height: 1.4;
         color: rgba(214, 228, 255, 0.85);
         text-shadow: 0 1px 1px rgba(2, 4, 8, 0.5);
       }
 
       .volume-widget-hint {
-        font-size: 11px;
+        font-size: clamp(10px, 1.1vw, 12px);
         line-height: 1.4;
         color: rgba(255, 190, 140, 0.85);
       }
@@ -240,6 +264,7 @@
   </head>
   <body>
     <div id="app">
+      <div id="viewport" aria-hidden="true"></div>
       <div id="overlay" class="hidden" aria-hidden="true">
         <div id="instructions">
           <h1>Procedural Block World</h1>

--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -18,6 +18,7 @@ import {
 } from './world/fluids/fluid-registry.js'
 
 const overlay = document.getElementById('overlay')
+const viewport = document.getElementById('viewport')
 const overlayStatus = overlay?.querySelector('#overlay-status')
 
 function setOverlayStatus(message, { isError = false, revealOverlay = true } = {}) {
@@ -45,23 +46,30 @@ const scene = new THREE.Scene()
 scene.background = new THREE.Color(0xa9d6ff)
 scene.fog = new THREE.Fog(0xa9d6ff, 20, 140)
 
-const camera = new THREE.PerspectiveCamera(
-  75,
-  window.innerWidth / window.innerHeight,
-  0.1,
-  500,
-)
+const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 500)
 camera.position.set(0, 25, 30)
 
 const renderer = new THREE.WebGLRenderer({ antialias: true })
-renderer.setPixelRatio(window.devicePixelRatio)
-renderer.setSize(window.innerWidth, window.innerHeight)
 renderer.outputColorSpace = THREE.SRGBColorSpace
 renderer.shadowMap.enabled = true
 renderer.shadowMap.type = THREE.PCFSoftShadowMap
 renderer.toneMapping = THREE.ACESFilmicToneMapping
 renderer.toneMappingExposure = 1.1
-document.body.appendChild(renderer.domElement)
+;(viewport ?? document.body).appendChild(renderer.domElement)
+
+const MAX_PIXEL_RATIO = 2
+
+function resizeToViewport() {
+  const width = Math.max(window.innerWidth, 1)
+  const height = Math.max(window.innerHeight, 1)
+  camera.aspect = width / height
+  camera.updateProjectionMatrix()
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO))
+  renderer.setSize(width, height)
+}
+
+resizeToViewport()
+window.addEventListener('resize', resizeToViewport)
 
 const clock = new THREE.Clock()
 const diagnosticOverlayCallbacks = new Set()
@@ -183,6 +191,8 @@ try {
   if (import.meta.env.DEV) {
     const debugNamespace = (window.__VOXEL_DEBUG__ = window.__VOXEL_DEBUG__ || {})
     debugNamespace.chunkSnapshot = () => chunkManager.debugSnapshot?.()
+    debugNamespace.scene = scene
+    debugNamespace.renderer = renderer
     debugNamespace.player = {
       controls: playerControls,
       setPosition: (position) => playerControls.setPosition(position),
@@ -279,6 +289,7 @@ if (!initializationError) {
   animate()
 
   window.addEventListener('beforeunload', () => {
+    window.removeEventListener('resize', resizeToViewport)
     playerControls.dispose()
     chunkManager.dispose()
     musicSystem?.dispose()


### PR DESCRIPTION
## Summary
- mount the WebGL canvas inside a dedicated viewport container so it consistently renders behind the UI layers
- adjust layout layering and canvas sizing styles to keep HUD/overlay responsive without obscuring the scene
- expose the scene and renderer through the debug namespace for easier runtime inspection during development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54ad26260832a983b9bb56bdaeada