### PR TITLE
Preload larger chunk radius to reduce world streaming hitching

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -157,7 +157,8 @@ try {
   chunkManager = createChunkManager({
     scene,
     blockMaterials,
-    viewDistance: 2,
+    viewDistance: 3,
+    retainDistance: 5,
   })
 
   playerControls = createPlayerControls({

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -246,11 +246,31 @@ export function createPlayerControls({
   }
 
   function preloadChunksAround(position) {
-    if (!chunkManager || typeof chunkManager.update !== 'function') {
+    if (!chunkManager) {
       return false;
     }
     try {
-      chunkManager.update(position);
+      if (typeof chunkManager.preloadAround === 'function') {
+        const preferredRadius =
+          typeof chunkManager.getRetentionDistance === 'function'
+            ? chunkManager.getRetentionDistance()
+            : undefined;
+        chunkManager.preloadAround(position, preferredRadius);
+      } else if (typeof chunkManager.update === 'function') {
+        const preferredRadius =
+          typeof chunkManager.getRetentionDistance === 'function'
+            ? chunkManager.getRetentionDistance()
+            : undefined;
+        if (preferredRadius !== undefined) {
+          chunkManager.update(position, {
+            loadRadius: preferredRadius,
+            skipUnload: true,
+            force: true,
+          });
+        } else {
+          chunkManager.update(position);
+        }
+      }
       return true;
     } catch (error) {
       console.error('Failed to update chunks near position:', position, error);

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -10,13 +10,32 @@ function worldToChunk(value) {
   return Math.floor((value + halfSize) / worldConfig.chunkSize);
 }
 
-export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) {
+function normalizeDistance(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return Math.max(0, Math.floor(fallback ?? 0));
+  }
+  return Math.max(0, Math.floor(numeric));
+}
+
+export function createChunkManager({
+  scene,
+  blockMaterials,
+  viewDistance = 1,
+  retainDistance: initialRetainDistance,
+}) {
   const loadedChunks = new Map();
   const solidBlocks = new Set();
   const softBlocks = new Set();
   const waterColumns = new Set();
   const isDevBuild = Boolean(import.meta.env && import.meta.env.DEV);
   let lastCenterKey = null;
+  let lastEffectiveRadius = 0;
+  let currentViewDistance = normalizeDistance(viewDistance, 1);
+  let retentionDistance = Math.max(
+    currentViewDistance,
+    normalizeDistance(initialRetainDistance, currentViewDistance)
+  );
 
   function ensureChunk(chunkX, chunkZ) {
     const key = chunkKey(chunkX, chunkZ);
@@ -62,33 +81,56 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     loadedChunks.delete(key);
   }
 
-  function update(position) {
+  function update(position, options = {}) {
+    const { loadRadius, skipUnload = false, force = false } = options ?? {};
     const centerChunkX = worldToChunk(position.x);
     const centerChunkZ = worldToChunk(position.z);
     const centerKey = chunkKey(centerChunkX, centerChunkZ);
 
-    if (centerKey === lastCenterKey && loadedChunks.size > 0) {
+    const desiredRadius = Math.max(
+      retentionDistance,
+      currentViewDistance,
+      normalizeDistance(loadRadius, 0)
+    );
+
+    if (
+      centerKey === lastCenterKey &&
+      loadedChunks.size > 0 &&
+      desiredRadius <= lastEffectiveRadius &&
+      !force
+    ) {
       return;
     }
 
-    const needed = new Set();
-    for (let dx = -viewDistance; dx <= viewDistance; dx++) {
-      for (let dz = -viewDistance; dz <= viewDistance; dz++) {
+    for (let dx = -desiredRadius; dx <= desiredRadius; dx++) {
+      for (let dz = -desiredRadius; dz <= desiredRadius; dz++) {
         const chunkX = centerChunkX + dx;
         const chunkZ = centerChunkZ + dz;
-        const key = chunkKey(chunkX, chunkZ);
-        needed.add(key);
         ensureChunk(chunkX, chunkZ);
       }
     }
 
-    Array.from(loadedChunks.keys()).forEach((key) => {
-      if (!needed.has(key)) {
-        disposeChunk(key);
-      }
-    });
+    if (!skipUnload) {
+      const unloadRadius = retentionDistance;
+      loadedChunks.forEach((chunk, key) => {
+        const chunkX =
+          typeof chunk?.chunkX === 'number'
+            ? chunk.chunkX
+            : Number.parseInt(key.split('|')[0], 10);
+        const chunkZ =
+          typeof chunk?.chunkZ === 'number'
+            ? chunk.chunkZ
+            : Number.parseInt(key.split('|')[1], 10);
+        const distanceX = Math.abs(chunkX - centerChunkX);
+        const distanceZ = Math.abs(chunkZ - centerChunkZ);
+        if (distanceX > unloadRadius || distanceZ > unloadRadius) {
+          disposeChunk(key);
+        }
+      });
+    }
 
     lastCenterKey = centerKey;
+    lastEffectiveRadius = desiredRadius;
   }
 
   function dispose() {
@@ -289,6 +331,35 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     return removed;
   }
 
+  function preloadAround(position, distance) {
+    const preloadRadius = Math.max(
+      retentionDistance,
+      normalizeDistance(distance, retentionDistance)
+    );
+    update(position, { loadRadius: preloadRadius, skipUnload: true, force: true });
+  }
+
+  function setViewDistance(distance) {
+    currentViewDistance = normalizeDistance(distance, currentViewDistance);
+    lastEffectiveRadius = 0;
+  }
+
+  function setRetentionDistance(distance) {
+    retentionDistance = Math.max(
+      currentViewDistance,
+      normalizeDistance(distance, retentionDistance)
+    );
+    lastEffectiveRadius = 0;
+  }
+
+  function getViewDistance() {
+    return currentViewDistance;
+  }
+
+  function getRetentionDistance() {
+    return retentionDistance;
+  }
+
   return {
     update,
     dispose,
@@ -297,6 +368,11 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     waterColumns,
     getBlockFromIntersection,
     removeBlockInstance,
+    preloadAround,
+    setViewDistance,
+    setRetentionDistance,
+    getViewDistance,
+    getRetentionDistance,
     ...(debugSnapshot ? { debugSnapshot } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- expand the chunk manager to support configurable retention distances and background preloading helpers
- update player controls to use the new preloading helper when preparing spawn areas
- increase the active and retained chunk radii so a larger area is generated up front

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fa3e8a74832aa2d8bafab56609c3