### PR TITLE
Incrementally preload chunks to smooth world streaming

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -158,6 +158,8 @@ try {
     scene,
     blockMaterials,
     viewDistance: 2,
+    retainDistance: 4,
+    maxPreloadPerUpdate: 3,
   })
 
   playerControls = createPlayerControls({

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -246,11 +246,19 @@ export function createPlayerControls({
   }
 
   function preloadChunksAround(position) {
-    if (!chunkManager || typeof chunkManager.update !== 'function') {
+    if (!chunkManager) {
       return false;
     }
     try {
-      chunkManager.update(position);
+      const preferredRadius =
+        typeof chunkManager.getRetentionDistance === 'function'
+          ? chunkManager.getRetentionDistance()
+          : undefined;
+      if (typeof chunkManager.preloadAround === 'function') {
+        chunkManager.preloadAround(position, preferredRadius);
+      } else if (typeof chunkManager.update === 'function') {
+        chunkManager.update(position);
+      }
       return true;
     } catch (error) {
       console.error('Failed to update chunks near position:', position, error);

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -10,13 +10,36 @@ function worldToChunk(value) {
   return Math.floor((value + halfSize) / worldConfig.chunkSize);
 }
 
-export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) {
+function normalizeDistance(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return Math.max(0, Math.floor(fallback ?? 0));
+  }
+  return Math.max(0, Math.floor(numeric));
+}
+
+export function createChunkManager({
+  scene,
+  blockMaterials,
+  viewDistance = 1,
+  retainDistance: initialRetainDistance,
+  maxPreloadPerUpdate = 4,
+}) {
   const loadedChunks = new Map();
   const solidBlocks = new Set();
   const softBlocks = new Set();
   const waterColumns = new Set();
   const isDevBuild = Boolean(import.meta.env && import.meta.env.DEV);
   let lastCenterKey = null;
+  let currentViewDistance = normalizeDistance(viewDistance, 1);
+  let retentionDistance = Math.max(
+    currentViewDistance,
+    normalizeDistance(initialRetainDistance, currentViewDistance)
+  );
+  const preloadQueue = [];
+  const pendingPreloadKeys = new Set();
+  let queueDirty = false;
+  let lastImmediateRadius = currentViewDistance;
 
   function ensureChunk(chunkX, chunkZ) {
     const key = chunkKey(chunkX, chunkZ);
@@ -62,37 +85,141 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     loadedChunks.delete(key);
   }
 
-  function update(position) {
+  function schedulePreload(chunkX, chunkZ, priority) {
+    const key = chunkKey(chunkX, chunkZ);
+    if (loadedChunks.has(key) || pendingPreloadKeys.has(key)) {
+      return;
+    }
+    pendingPreloadKeys.add(key);
+    preloadQueue.push({ key, chunkX, chunkZ, priority });
+    queueDirty = true;
+  }
+
+  function processPreloadQueue(limit) {
+    if (preloadQueue.length === 0) {
+      return 0;
+    }
+    if (queueDirty) {
+      preloadQueue.sort((a, b) => a.priority - b.priority);
+      queueDirty = false;
+    }
+    let processed = 0;
+    while (preloadQueue.length > 0 && processed < limit) {
+      const next = preloadQueue.shift();
+      pendingPreloadKeys.delete(next.key);
+      if (loadedChunks.has(next.key)) {
+        continue;
+      }
+      ensureChunk(next.chunkX, next.chunkZ);
+      processed += 1;
+    }
+    return processed;
+  }
+
+  function update(position, options = {}) {
+    const {
+      loadRadius,
+      skipUnload = false,
+      force = false,
+      maxPreloadPerFrame,
+    } = options ?? {};
     const centerChunkX = worldToChunk(position.x);
     const centerChunkZ = worldToChunk(position.z);
     const centerKey = chunkKey(centerChunkX, centerChunkZ);
 
-    if (centerKey === lastCenterKey && loadedChunks.size > 0) {
+    const desiredRadius = Math.max(
+      retentionDistance,
+      currentViewDistance,
+      normalizeDistance(loadRadius, 0)
+    );
+
+    const immediateRadius = Math.max(
+      currentViewDistance,
+      normalizeDistance(loadRadius, currentViewDistance)
+    );
+
+    const centerChanged = centerKey !== lastCenterKey;
+    const radiusReduced = immediateRadius < lastImmediateRadius;
+    if ((centerChanged || radiusReduced) && preloadQueue.length > 0) {
+      let removedAny = false;
+      for (let i = preloadQueue.length - 1; i >= 0; i -= 1) {
+        const entry = preloadQueue[i];
+        const distanceX = Math.abs(entry.chunkX - centerChunkX);
+        const distanceZ = Math.abs(entry.chunkZ - centerChunkZ);
+        if (distanceX > desiredRadius || distanceZ > desiredRadius) {
+          preloadQueue.splice(i, 1);
+          pendingPreloadKeys.delete(entry.key);
+          removedAny = true;
+        }
+      }
+      if (removedAny) {
+        queueDirty = true;
+      }
+    }
+    const shouldProcess =
+      force || centerChanged || radiusReduced || preloadQueue.length > 0;
+    if (!shouldProcess && loadedChunks.size > 0) {
       return;
     }
 
-    const needed = new Set();
-    for (let dx = -viewDistance; dx <= viewDistance; dx++) {
-      for (let dz = -viewDistance; dz <= viewDistance; dz++) {
-        const chunkX = centerChunkX + dx;
-        const chunkZ = centerChunkZ + dz;
-        const key = chunkKey(chunkX, chunkZ);
-        needed.add(key);
-        ensureChunk(chunkX, chunkZ);
+    for (let dx = -immediateRadius; dx <= immediateRadius; dx++) {
+      for (let dz = -immediateRadius; dz <= immediateRadius; dz++) {
+        ensureChunk(centerChunkX + dx, centerChunkZ + dz);
       }
     }
 
-    Array.from(loadedChunks.keys()).forEach((key) => {
-      if (!needed.has(key)) {
-        disposeChunk(key);
+    if (desiredRadius > immediateRadius) {
+      for (let dx = -desiredRadius; dx <= desiredRadius; dx++) {
+        for (let dz = -desiredRadius; dz <= desiredRadius; dz++) {
+          const maxDistance = Math.max(Math.abs(dx), Math.abs(dz));
+          if (maxDistance <= immediateRadius) {
+            continue;
+          }
+          const chunkX = centerChunkX + dx;
+          const chunkZ = centerChunkZ + dz;
+          const priority = dx * dx + dz * dz;
+          schedulePreload(chunkX, chunkZ, priority);
+        }
       }
-    });
+    }
+
+    const preloadLimit = Math.max(
+      1,
+      normalizeDistance(
+        maxPreloadPerFrame,
+        normalizeDistance(maxPreloadPerUpdate, maxPreloadPerUpdate)
+      )
+    );
+    processPreloadQueue(preloadLimit);
+
+    if (!skipUnload) {
+      const unloadRadius = desiredRadius;
+      loadedChunks.forEach((chunk, key) => {
+        const chunkX =
+          typeof chunk?.chunkX === 'number'
+            ? chunk.chunkX
+            : Number.parseInt(key.split('|')[0], 10);
+        const chunkZ =
+          typeof chunk?.chunkZ === 'number'
+            ? chunk.chunkZ
+            : Number.parseInt(key.split('|')[1], 10);
+        const distanceX = Math.abs(chunkX - centerChunkX);
+        const distanceZ = Math.abs(chunkZ - centerChunkZ);
+        if (distanceX > unloadRadius || distanceZ > unloadRadius) {
+          disposeChunk(key);
+        }
+      });
+    }
 
     lastCenterKey = centerKey;
+    lastImmediateRadius = immediateRadius;
   }
 
   function dispose() {
     Array.from(loadedChunks.keys()).forEach((key) => disposeChunk(key));
+    preloadQueue.length = 0;
+    pendingPreloadKeys.clear();
+    queueDirty = false;
   }
 
   function computeMaterialVisibility(material) {
@@ -289,6 +416,43 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     return removed;
   }
 
+  function preloadAround(position, distance) {
+    const preloadRadius = Math.max(
+      currentViewDistance,
+      normalizeDistance(distance, retentionDistance)
+    );
+    setRetentionDistance(preloadRadius);
+    update(position, {
+      loadRadius: currentViewDistance,
+      skipUnload: true,
+      force: true,
+    });
+  }
+
+  function setViewDistance(distance) {
+    currentViewDistance = normalizeDistance(distance, currentViewDistance);
+    if (retentionDistance < currentViewDistance) {
+      retentionDistance = currentViewDistance;
+    }
+    lastImmediateRadius = Math.min(lastImmediateRadius, currentViewDistance);
+  }
+
+  function setRetentionDistance(distance) {
+    retentionDistance = Math.max(
+      currentViewDistance,
+      normalizeDistance(distance, retentionDistance)
+    );
+    lastImmediateRadius = Math.min(lastImmediateRadius, currentViewDistance);
+  }
+
+  function getViewDistance() {
+    return currentViewDistance;
+  }
+
+  function getRetentionDistance() {
+    return retentionDistance;
+  }
+
   return {
     update,
     dispose,
@@ -297,6 +461,11 @@ export function createChunkManager({ scene, blockMaterials, viewDistance = 1 }) 
     waterColumns,
     getBlockFromIntersection,
     removeBlockInstance,
+    preloadAround,
+    setViewDistance,
+    setRetentionDistance,
+    getViewDistance,
+    getRetentionDistance,
     ...(debugSnapshot ? { debugSnapshot } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- queue chunk preloads beyond the active view distance so larger retention radii load over multiple frames instead of all at once
- adjust player spawn chunk priming to rely on the chunk manager’s incremental preload helper rather than forcing a full synchronous load
- retune the default view and retention distances to pair with the incremental loader for smoother streaming

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fa3e8a74832aa2d8bafab56609c3