### PR TITLE
Throttle chunk preloading for smoother streaming

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -158,6 +158,8 @@ try {
     scene,
     blockMaterials,
     viewDistance: 2,
+    retainDistance: 3,
+    maxPreloadPerUpdate: 3,
   })
 
   playerControls = createPlayerControls({

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -246,11 +246,30 @@ export function createPlayerControls({
   }
 
   function preloadChunksAround(position) {
-    if (!chunkManager || typeof chunkManager.update !== 'function') {
+    if (!chunkManager) {
       return false;
     }
     try {
-      chunkManager.update(position);
+      const preferredRadius = (() => {
+        if (typeof chunkManager.getRetentionDistance === 'function') {
+          return chunkManager.getRetentionDistance();
+        }
+        if (typeof chunkManager.getViewDistance === 'function') {
+          return chunkManager.getViewDistance();
+        }
+        return undefined;
+      })();
+
+      if (typeof chunkManager.preloadAround === 'function') {
+        chunkManager.preloadAround(position, preferredRadius, {
+          maxPreload:
+            typeof preferredRadius === 'number'
+              ? Math.max(6, preferredRadius * 2)
+              : undefined,
+        });
+      } else if (typeof chunkManager.update === 'function') {
+        chunkManager.update(position);
+      }
       return true;
     } catch (error) {
       console.error('Failed to update chunks near position:', position, error);


### PR DESCRIPTION
## Summary
- replace the chunk manager’s synchronous retention logic with a queued preloader that limits new chunk generation per frame while keeping a modest ring of nearby chunks resident
- have the player controls call the chunk manager’s warm-up helper during spawn so the surrounding area streams in with a generous but bounded chunk budget
- tune the default chunk manager configuration to keep a 3-chunk radius retained with a small per-frame preload budget for smoother traversal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fa3e8a74832aa2d8bafab56609c3