### PR TITLE
Force fluid debug logging off by default

### DIFF
--- a/three-demo/src/world/fluids/fluid-debug.js
+++ b/three-demo/src/world/fluids/fluid-debug.js
@@ -1,0 +1,103 @@
+let fluidDebugEnabled = false;
+
+const parseBoolean = (value) => {
+  if (value == null || value === '') {
+    return true;
+  }
+  const normalized = String(value).toLowerCase();
+  if (['1', 'true', 'on', 'yes', 'enable', 'enabled'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'off', 'no', 'disable', 'disabled'].includes(normalized)) {
+    return false;
+  }
+  return Boolean(value);
+};
+
+const persistPreference = (enabled) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage?.setItem('fluidDebug', enabled ? 'true' : 'false');
+  } catch (error) {
+    console.warn('[browser] [fluid debug] failed to persist debug flag', error);
+  }
+};
+
+export const isFluidDebugEnabled = () => fluidDebugEnabled;
+
+export const setFluidDebugEnabled = (enabled, { persist = true } = {}) => {
+  fluidDebugEnabled = Boolean(enabled);
+  if (persist) {
+    persistPreference(fluidDebugEnabled);
+  }
+  return fluidDebugEnabled;
+};
+
+const readQueryPreference = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('fluidDebug')) {
+      return null;
+    }
+    return parseBoolean(params.get('fluidDebug'));
+  } catch (error) {
+    console.warn('[browser] [fluid debug] failed to resolve query flag', error);
+    return null;
+  }
+};
+
+const readStoredPreference = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = window.localStorage?.getItem('fluidDebug');
+    if (stored == null) {
+      return null;
+    }
+    return parseBoolean(stored);
+  } catch (error) {
+    console.warn('[browser] [fluid debug] failed to resolve stored flag', error);
+    return null;
+  }
+};
+
+export const initializeFluidDebug = ({
+  defaultEnabled = false,
+  persistDefault = false,
+  forceDefault = false,
+} = {}) => {
+  const fromQuery = readQueryPreference();
+  if (fromQuery != null) {
+    return setFluidDebugEnabled(fromQuery, { persist: false });
+  }
+
+  if (!forceDefault) {
+    const fromStorage = readStoredPreference();
+    if (fromStorage != null) {
+      return setFluidDebugEnabled(fromStorage, { persist: false });
+    }
+  }
+
+  return setFluidDebugEnabled(defaultEnabled, { persist: persistDefault });
+};
+
+initializeFluidDebug();
+
+export const enableFluidDebug = (options) =>
+  setFluidDebugEnabled(true, options);
+
+export const disableFluidDebug = (options) =>
+  setFluidDebugEnabled(false, options);
+
+export const logFluidDebug = (...args) => {
+  if (!fluidDebugEnabled) {
+    return;
+  }
+  console.log('[browser] [fluid debug]', ...args);
+};

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -6,6 +6,12 @@ import {
   resolveFluidPresence,
 } from './fluids/fluid-registry.js';
 import { buildFluidGeometry } from './fluids/fluid-geometry.js';
+import {
+  initializeFluidDebug,
+  logFluidDebug,
+} from './fluids/fluid-debug.js';
+
+initializeFluidDebug({ defaultEnabled: false, persistDefault: true, forceDefault: true });
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
@@ -509,10 +515,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     }
 
     if (type === 'water') {
-      console.log(
-        '[fluid debug] processing water columns',
-        columns.size,
-      );
+      logFluidDebug('processing water columns', columns.size);
     }
 
     columns.forEach((column) => {
@@ -596,13 +599,13 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     });
     if (!geometry.getAttribute('position') || geometry.getAttribute('position').count === 0) {
       if (type === 'water') {
-        console.log('[fluid debug] water geometry has no vertices');
+        logFluidDebug('water geometry has no vertices');
       }
       return;
     }
     const surface = createFluidSurface({ type, geometry });
     if (type === 'water') {
-      console.log('[fluid debug] created water surface', surface?.uuid);
+      logFluidDebug('created water surface', surface?.uuid);
     }
     surface.userData.type = `fluid:${type}`;
     fluidSurfaces.push(surface);
@@ -661,10 +664,10 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group.add(mesh);
   });
 
-  console.log('[fluid debug] fluid surfaces count before group add', fluidSurfaces.length);
+  logFluidDebug('fluid surfaces count before group add', fluidSurfaces.length);
   fluidSurfaces.forEach((surface) => {
     if (surface.userData?.type === 'fluid:water') {
-      console.log('[fluid debug] adding water surface to group', surface.uuid);
+      logFluidDebug('adding water surface to group', surface.uuid);
     }
     group.add(surface);
   });


### PR DESCRIPTION
## Summary
- add a shared fluid debug helper that can persist a toggle via query params or local storage
- gate the world generation fluid logs behind the new helper so they stay silent by default
- force-initialize the helper to overwrite any stored preference so fluid logs are off unless explicitly re-enabled

## Testing
- npm run build
- node --input-type=module <<'EOF' ... EOF

------
https://chatgpt.com/codex/tasks/task_e_68d6cc4a9804832a82d9a565c0c028c2