### PR TITLE
Batch decorative voxel meshes for chunk generation

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -113,6 +113,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     blockGeometry = new THREE.BoxGeometry(1, 1, 1);
   }
   const instancedData = new Map();
+  const decorationEntries = [];
+  const decorationMeshes = [];
   const solidBlockKeys = new Set();
   const softBlockKeys = new Set();
   const waterColumnKeys = new Set();
@@ -282,6 +284,44 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     }
   };
 
+  const computeTintColor = ({ type, y, biome, tintOverride = null, paletteColor = null }) => {
+    const tintStrength = clamp(biome?.shader?.tintStrength ?? 1, 0, 1);
+    const paletteBlend = new THREE.Color(1, 1, 1);
+    const resolvedPaletteColor = paletteColor ?? engine.getBlockColor(biome, type);
+    if (resolvedPaletteColor) {
+      paletteBlend.lerp(resolvedPaletteColor, tintStrength);
+    }
+
+    if (biome?.shader?.tintColor) {
+      const biomeTintBlend = new THREE.Color(1, 1, 1);
+      biomeTintBlend.lerp(biome.shader.tintColor, tintStrength * 0.65);
+      paletteBlend.multiply(biomeTintBlend);
+    }
+
+    if (biome?.climate) {
+      const dryness = clamp(1 - biome.climate.moisture, 0, 1);
+      const climateBlend = new THREE.Color(1, 1, 1);
+      climateBlend.lerp(new THREE.Color(1.02, 0.98, 0.92), dryness * 0.35);
+      paletteBlend.multiply(climateBlend);
+    }
+
+    const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
+    const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
+    const altitudeBlend = new THREE.Color(1, 1, 1);
+    if (altitude > 0) {
+      altitudeBlend.lerp(new THREE.Color(0.95, 0.98, 1.04), altitude * 0.3);
+    } else if (altitude < 0) {
+      altitudeBlend.lerp(new THREE.Color(1.04, 1.01, 0.94), Math.abs(altitude) * 0.25);
+    }
+    paletteBlend.multiply(altitudeBlend);
+
+    if (tintOverride) {
+      paletteBlend.multiply(tintOverride);
+    }
+
+    return paletteBlend;
+  };
+
   const addBlock = (type, x, y, z, biome, options = {}) => {
     const scaleVector = resolveScaleVector(options.scale);
     const visualScaleVector = resolveScaleVector(
@@ -310,43 +350,15 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     const coordinateKey = blockKey(x, y, z);
     const key = options.key ?? coordinateKey;
 
-    const paletteColor = engine.getBlockColor(biome, type);
-    const tintStrength = clamp(biome?.shader?.tintStrength ?? 1, 0, 1);
-
-    const paletteBlend = new THREE.Color(1, 1, 1);
-    if (paletteColor) {
-      paletteBlend.lerp(paletteColor, tintStrength);
-    }
-
-    if (biome?.shader?.tintColor) {
-      const biomeTintBlend = new THREE.Color(1, 1, 1);
-      biomeTintBlend.lerp(biome.shader.tintColor, tintStrength * 0.65);
-      paletteBlend.multiply(biomeTintBlend);
-    }
-
-    if (biome?.climate) {
-      const dryness = clamp(1 - biome.climate.moisture, 0, 1);
-      const climateBlend = new THREE.Color(1, 1, 1);
-      climateBlend.lerp(new THREE.Color(1.02, 0.98, 0.92), dryness * 0.35);
-      paletteBlend.multiply(climateBlend);
-    }
-
-    const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
-    const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
-    const altitudeBlend = new THREE.Color(1, 1, 1);
-    if (altitude > 0) {
-      altitudeBlend.lerp(new THREE.Color(0.95, 0.98, 1.04), altitude * 0.3);
-    } else if (altitude < 0) {
-      altitudeBlend.lerp(new THREE.Color(1.04, 1.01, 0.94), Math.abs(altitude) * 0.25);
-    }
-    paletteBlend.multiply(altitudeBlend);
-
     const tintOverride = parseTintOverride(options.tint);
-    if (tintOverride) {
-      paletteBlend.multiply(tintOverride);
-    }
-
-    const tintColor = paletteBlend;
+    const paletteColor = engine.getBlockColor(biome, type);
+    const tintColor = computeTintColor({
+      type,
+      y,
+      biome,
+      tintOverride,
+      paletteColor,
+    });
 
     const isWater = type === 'water';
     const isFluid = isFluidType(type);
@@ -440,6 +452,29 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     }
   };
 
+  const addDecorationMesh = ({
+    type,
+    geometry,
+    origin,
+    biome,
+    segments = [],
+  } = {}) => {
+    if (!type || !geometry) {
+      return;
+    }
+    const positionAttribute = geometry.getAttribute('position');
+    if (!positionAttribute || positionAttribute.count === 0) {
+      return;
+    }
+    decorationEntries.push({
+      type,
+      geometry,
+      origin: new THREE.Vector3(origin?.x ?? 0, origin?.y ?? 0, origin?.z ?? 0),
+      biome,
+      segments,
+    });
+  };
+
   for (let lx = 0; lx < chunkSize; lx++) {
     const worldX = minX + lx;
     for (let lz = 0; lz < chunkSize; lz++) {
@@ -487,6 +522,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
       populateColumnWithVoxelObjects({
         addBlock,
+        addDecorationMesh,
+        THREE,
         biome,
         columnSample,
         groundHeight: height,
@@ -664,6 +701,61 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group.add(mesh);
   });
 
+  decorationEntries.forEach((entry) => {
+    const material = blockMaterials[entry.type];
+    if (!material) {
+      return;
+    }
+    const geometry = entry.geometry.clone();
+    const tintAttribute = geometry.getAttribute('biomeTint');
+    if (tintAttribute) {
+      const array = tintAttribute.array;
+      const paletteColor = engine.getBlockColor(entry.biome, entry.type);
+      entry.segments.forEach((segment) => {
+        const tintOverride = parseTintOverride(segment.tint);
+        const tintColor = computeTintColor({
+          type: entry.type,
+          y: segment.worldPosition?.y ?? entry.origin.y,
+          biome: entry.biome,
+          tintOverride,
+          paletteColor,
+        });
+        const start = segment.vertexStart * 3;
+        const end = start + segment.vertexCount * 3;
+        for (let i = start; i < end; i += 3) {
+          array[i] = tintColor.r;
+          array[i + 1] = tintColor.g;
+          array[i + 2] = tintColor.b;
+        }
+      });
+      tintAttribute.needsUpdate = true;
+    }
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.copy(entry.origin);
+    mesh.castShadow = !['cloud', 'water'].includes(entry.type);
+    mesh.receiveShadow = entry.type !== 'cloud';
+    mesh.frustumCulled = false;
+    mesh.userData.type = entry.type;
+    mesh.userData.biomePalette = true;
+    mesh.userData.biomeTintAttribute = geometry.getAttribute('biomeTint');
+    decorationMeshes.push(mesh);
+    group.add(mesh);
+
+    geometry.computeBoundingBox();
+    if (geometry.boundingBox) {
+      const min = geometry.boundingBox.min.clone().add(mesh.position);
+      const max = geometry.boundingBox.max.clone().add(mesh.position);
+      minBoundX = Math.min(minBoundX, min.x);
+      maxBoundX = Math.max(maxBoundX, max.x);
+      minBoundY = Math.min(minBoundY, min.y);
+      maxBoundY = Math.max(maxBoundY, max.y);
+      minBoundZ = Math.min(minBoundZ, min.z);
+      maxBoundZ = Math.max(maxBoundZ, max.z);
+      hasBoundData = true;
+    }
+  });
+
   logFluidDebug('fluid surfaces count before group add', fluidSurfaces.length);
   fluidSurfaces.forEach((surface) => {
     if (surface.userData?.type === 'fluid:water') {
@@ -697,6 +789,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     fluidSurfaces,
     blockLookup,
     typeData,
+    decorationMeshes,
     biomes,
     bounds: (() => {
       if (!hasBoundData) {

--- a/three-demo/src/world/voxel-object-decoration-mesh.js
+++ b/three-demo/src/world/voxel-object-decoration-mesh.js
@@ -1,0 +1,196 @@
+export function createDecorationMeshBatches({ THREE, placements = [], origin = null } = {}) {
+  if (!THREE) {
+    throw new Error('createDecorationMeshBatches requires a THREE instance');
+  }
+  if (!placements || placements.length === 0) {
+    return [];
+  }
+
+  const baseGeometry = new THREE.BoxGeometry(1, 1, 1);
+  const basePosition = baseGeometry.getAttribute('position');
+  const baseNormal = baseGeometry.getAttribute('normal');
+  const baseUv = baseGeometry.getAttribute('uv');
+  const baseIndex = baseGeometry.getIndex();
+
+  const originVector = new THREE.Vector3(
+    origin?.x ?? placements[0].worldX ?? 0,
+    origin?.y ?? placements[0].worldY ?? 0,
+    origin?.z ?? placements[0].worldZ ?? 0,
+  );
+
+  const defaultQuaternion = new THREE.Quaternion();
+  const transformMatrix = new THREE.Matrix4();
+  const normalMatrix = new THREE.Matrix3();
+  const vertex = new THREE.Vector3();
+  const normal = new THREE.Vector3();
+  const visualPosition = new THREE.Vector3();
+
+  const resolveScaleVector = (option) => {
+    if (!option && option !== 0) {
+      return new THREE.Vector3(1, 1, 1);
+    }
+    if (option.isVector3) {
+      return option.clone();
+    }
+    if (typeof option === 'number') {
+      return new THREE.Vector3(option, option, option);
+    }
+    if (Array.isArray(option)) {
+      const [sx = 1, sy = 1, sz = 1] = option;
+      return new THREE.Vector3(sx, sy, sz);
+    }
+    if (typeof option === 'object') {
+      const sx =
+        typeof option.x === 'number'
+          ? option.x
+          : typeof option.scaleX === 'number'
+          ? option.scaleX
+          : 1;
+      const sy =
+        typeof option.y === 'number'
+          ? option.y
+          : typeof option.scaleY === 'number'
+          ? option.scaleY
+          : 1;
+      const sz =
+        typeof option.z === 'number'
+          ? option.z
+          : typeof option.scaleZ === 'number'
+          ? option.scaleZ
+          : 1;
+      return new THREE.Vector3(sx, sy, sz);
+    }
+    return new THREE.Vector3(1, 1, 1);
+  };
+
+  const resolveOffsetVector = (option) => {
+    if (!option && option !== 0) {
+      return new THREE.Vector3(0, 0, 0);
+    }
+    if (option.isVector3) {
+      return option.clone();
+    }
+    if (typeof option === 'number') {
+      return new THREE.Vector3(option, option, option);
+    }
+    if (Array.isArray(option)) {
+      const [ox = 0, oy = 0, oz = 0] = option;
+      return new THREE.Vector3(ox, oy, oz);
+    }
+    if (typeof option === 'object') {
+      const ox =
+        typeof option.x === 'number'
+          ? option.x
+          : typeof option.offsetX === 'number'
+          ? option.offsetX
+          : 0;
+      const oy =
+        typeof option.y === 'number'
+          ? option.y
+          : typeof option.offsetY === 'number'
+          ? option.offsetY
+          : 0;
+      const oz =
+        typeof option.z === 'number'
+          ? option.z
+          : typeof option.offsetZ === 'number'
+          ? option.offsetZ
+          : 0;
+      return new THREE.Vector3(ox, oy, oz);
+    }
+    return new THREE.Vector3(0, 0, 0);
+  };
+
+  const grouped = new Map();
+
+  placements.forEach((placement) => {
+    const type = placement.type;
+    if (!type) {
+      return;
+    }
+    if (!grouped.has(type)) {
+      grouped.set(type, {
+        positions: [],
+        normals: [],
+        uvs: [],
+        indices: [],
+        segments: [],
+        vertexCount: 0,
+      });
+    }
+    const group = grouped.get(type);
+    const options = placement.options ?? {};
+    const visualScale = resolveScaleVector(options.visualScale ?? options.scale);
+    const offsetVector = resolveOffsetVector(options.visualOffset);
+    visualPosition.set(placement.worldX ?? 0, placement.worldY ?? 0, placement.worldZ ?? 0);
+    visualPosition.add(offsetVector);
+
+    transformMatrix.compose(visualPosition, defaultQuaternion, visualScale);
+    normalMatrix.getNormalMatrix(transformMatrix);
+
+    const vertexStart = group.vertexCount;
+
+    for (let i = 0; i < basePosition.count; i += 1) {
+      vertex.set(basePosition.getX(i), basePosition.getY(i), basePosition.getZ(i));
+      vertex.applyMatrix4(transformMatrix);
+      vertex.sub(originVector);
+      group.positions.push(vertex.x, vertex.y, vertex.z);
+
+      normal.set(baseNormal.getX(i), baseNormal.getY(i), baseNormal.getZ(i));
+      normal.applyMatrix3(normalMatrix).normalize();
+      group.normals.push(normal.x, normal.y, normal.z);
+
+      group.uvs.push(baseUv.getX(i), baseUv.getY(i));
+    }
+
+    for (let i = 0; i < baseIndex.count; i += 1) {
+      group.indices.push(baseIndex.getX(i) + vertexStart);
+    }
+
+    group.segments.push({
+      vertexStart,
+      vertexCount: basePosition.count,
+      tint: options.tint ?? null,
+      worldPosition: {
+        x: placement.worldX ?? originVector.x,
+        y: placement.worldY ?? originVector.y,
+        z: placement.worldZ ?? originVector.z,
+      },
+    });
+
+    group.vertexCount += basePosition.count;
+  });
+
+  baseGeometry.dispose();
+
+  return Array.from(grouped.entries()).map(([type, group]) => {
+    const geometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(group.positions);
+    const normals = new Float32Array(group.normals);
+    const uvs = new Float32Array(group.uvs);
+    const indices = new Uint32Array(group.indices);
+    const biomeTints = new Float32Array(group.vertexCount * 3);
+    biomeTints.fill(1);
+
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+    geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+    const tintAttribute = new THREE.Float32BufferAttribute(biomeTints, 3);
+    tintAttribute.setUsage(THREE.DynamicDrawUsage);
+    geometry.setAttribute('biomeTint', tintAttribute);
+    geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+
+    return {
+      type,
+      geometry,
+      origin: {
+        x: originVector.x,
+        y: originVector.y,
+        z: originVector.z,
+      },
+      segments: group.segments,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add a batching helper to build local-space geometries for decorative and nanovoxel placements
- update voxel object placement to funnel decorative batches through the new helper and report them to chunk generation
- extend chunk generation to tint and place cached decoration meshes alongside instanced blocks without affecting collision data

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d15e6f44832aa86e0a068c0c882a