### PR TITLE
Add decoration group destructibility metadata handling

### DIFF
--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -1125,11 +1125,18 @@ export function createPlayerControls({
     const intersections = attackRay.intersectObjects(scene.children, true);
     let blockInfo = null;
     for (const intersection of intersections) {
-      if (!intersection.object?.isInstancedMesh) {
+      const info = chunkManager.getBlockFromIntersection(intersection);
+      if (!info) {
         continue;
       }
-      const info = chunkManager.getBlockFromIntersection(intersection);
-      if (!info?.entry?.destructible) {
+      if (info.decorationGroup) {
+        if (!info.decorationGroup.destructible) {
+          continue;
+        }
+        blockInfo = info;
+        break;
+      }
+      if (!info.entry?.destructible) {
         continue;
       }
       blockInfo = info;
@@ -1141,21 +1148,53 @@ export function createPlayerControls({
       return;
     }
 
-    if (!attackState.target || attackState.target.entry.key !== blockInfo.entry.key) {
-      attackState.target = blockInfo;
+    const targetKey = blockInfo.decorationGroup
+      ? blockInfo.decorationGroup.key
+      : blockInfo.entry?.key;
+
+    if (!targetKey) {
+      decayAttack(delta);
+      return;
+    }
+
+    const targetPosition = blockInfo.entry?.position
+      ? blockInfo.entry.position.clone()
+      : blockInfo.decorationGroup?.position
+      ? blockInfo.decorationGroup.position.clone()
+      : null;
+
+    if (!attackState.target || attackState.target.key !== targetKey) {
+      attackState.target = {
+        key: targetKey,
+        chunk: blockInfo.chunk,
+        type: blockInfo.type,
+        instanceId: blockInfo.instanceId ?? null,
+        entry: blockInfo.entry ?? null,
+        decorationGroup: blockInfo.decorationGroup ?? null,
+        position: targetPosition,
+      };
       attackState.progress = 0;
+    } else if (!attackState.target.position && targetPosition) {
+      attackState.target.position = targetPosition.clone();
     }
 
     if (attackState.swinging) {
-      const type = attackState.target.entry.type;
+      const type = attackState.target.type;
       const durability = blockDurability.get(type) ?? 1.2;
       attackState.progress += delta / Math.max(durability, 0.1);
       if (attackState.progress >= 1) {
-        chunkManager.removeBlockInstance({
-          chunk: attackState.target.chunk,
-          type: attackState.target.type,
-          instanceId: attackState.target.instanceId,
-        });
+        if (attackState.target.decorationGroup) {
+          chunkManager.removeDecorationGroup({
+            chunk: attackState.target.chunk,
+            groupKey: attackState.target.decorationGroup.key,
+          });
+        } else {
+          chunkManager.removeBlockInstance({
+            chunk: attackState.target.chunk,
+            type: attackState.target.type,
+            instanceId: attackState.target.instanceId,
+          });
+        }
         resetAttackProgress();
         return;
       }
@@ -1164,7 +1203,7 @@ export function createPlayerControls({
     }
 
     if (attackState.target && attackState.progress > 0) {
-      showDamageOverlay(attackState.target.entry.position, attackState.progress);
+      showDamageOverlay(attackState.target.position, attackState.progress);
     } else {
       hideDamageOverlay();
     }

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -131,6 +131,8 @@ export function createChunkManager({
     }
     const chunk = generateChunk(blockMaterials, chunkX, chunkZ);
     chunk.group.frustumCulled = false;
+    chunk.decorationGroups = chunk.decorationGroups ?? new Map();
+    chunk.decorationGroupsByOwner = chunk.decorationGroupsByOwner ?? new Map();
     applyChunkBounds(chunk);
     chunk.group.children.forEach((child) => {
       if (!child.isInstancedMesh) {
@@ -170,6 +172,8 @@ export function createChunkManager({
     if (chunk.boundsBox) {
       chunk.boundsBox.makeEmpty?.();
     }
+    chunk.decorationGroups?.clear?.();
+    chunk.decorationGroupsByOwner?.clear?.();
     loadedChunks.delete(key);
   }
 
@@ -523,7 +527,7 @@ export function createChunkManager({
       };
 
   function getChunkForMesh(mesh) {
-    if (!mesh?.isInstancedMesh) {
+    if (!mesh) {
       return null;
     }
     const key = mesh.userData?.chunkKey;
@@ -534,10 +538,35 @@ export function createChunkManager({
   }
 
   function getBlockFromIntersection(intersection) {
-    if (!intersection || typeof intersection.instanceId !== 'number') {
+    if (!intersection || !intersection.object) {
       return null;
     }
     const mesh = intersection.object;
+    if (mesh.userData?.decorationGroup) {
+      const chunk = getChunkForMesh(mesh);
+      if (!chunk) {
+        return null;
+      }
+      const groupKey = mesh.userData.decorationGroup.key;
+      if (!groupKey) {
+        return null;
+      }
+      const group = chunk.decorationGroups?.get(groupKey);
+      if (!group) {
+        return null;
+      }
+      return {
+        chunk,
+        type: group.type ?? mesh.userData?.type ?? null,
+        decorationGroup: {
+          ...mesh.userData.decorationGroup,
+          mesh,
+        },
+      };
+    }
+    if (typeof intersection.instanceId !== 'number') {
+      return null;
+    }
     if (!mesh?.isInstancedMesh) {
       return null;
     }
@@ -563,6 +592,44 @@ export function createChunkManager({
       instanceId: intersection.instanceId,
       entry,
     };
+  }
+
+  function removeDecorationGroup({ chunk, groupKey }) {
+    if (!chunk || !groupKey) {
+      return null;
+    }
+    const groups = chunk.decorationGroups;
+    if (!groups || !groups.has(groupKey)) {
+      return null;
+    }
+    const metadata = groups.get(groupKey);
+    const { mesh, placementKeys = [], ownerKey } = metadata ?? {};
+
+    if (mesh?.parent) {
+      mesh.parent.remove(mesh);
+    }
+    mesh?.geometry?.dispose?.();
+    metadata?.tintAttribute?.dispose?.();
+
+    if (chunk.blockLookup) {
+      chunk.blockLookup.delete(groupKey);
+      placementKeys.forEach((key) => {
+        chunk.blockLookup.delete(key);
+      });
+    }
+
+    groups.delete(groupKey);
+    if (chunk.decorationGroupsByOwner && ownerKey) {
+      const ownerSet = chunk.decorationGroupsByOwner.get(ownerKey);
+      if (ownerSet) {
+        ownerSet.delete(groupKey);
+        if (ownerSet.size === 0) {
+          chunk.decorationGroupsByOwner.delete(ownerKey);
+        }
+      }
+    }
+
+    return metadata;
   }
 
   function removeBlockInstance({ chunk, type, instanceId }) {
@@ -645,6 +712,15 @@ export function createChunkManager({
       waterColumns.delete(`${removed.position.x}|${removed.position.z}`);
     }
 
+    if (removed?.key && chunk.decorationGroupsByOwner) {
+      const ownerGroups = chunk.decorationGroupsByOwner.get(removed.key);
+      if (ownerGroups && ownerGroups.size > 0) {
+        Array.from(ownerGroups).forEach((groupKey) => {
+          removeDecorationGroup({ chunk, groupKey });
+        });
+      }
+    }
+
     return removed;
   }
 
@@ -656,6 +732,7 @@ export function createChunkManager({
     waterColumns,
     getBlockFromIntersection,
     removeBlockInstance,
+    removeDecorationGroup,
     preloadAround,
     setViewDistance,
     setRetentionDistance,

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1,5 +1,6 @@
 import { createTerrainEngine } from './terrain-engine.js';
 import { populateColumnWithVoxelObjects } from './voxel-object-placement.js';
+import { createDecorationMeshBatches } from './voxel-object-decoration-mesh.js';
 import {
   createFluidSurface,
   isFluidType,
@@ -114,6 +115,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   }
   const instancedData = new Map();
   const decorationInstancedData = new Map();
+  const decorationGroups = new Map();
+  const decorationGroupsByOwner = new Map();
   const solidBlockKeys = new Set();
   const softBlockKeys = new Set();
   const waterColumnKeys = new Set();
@@ -364,6 +367,13 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       voxelIndex: options.voxelIndex ?? null,
       metadata: options.metadata ?? null,
       tintOverride,
+      destructibilityMode:
+        typeof options.destructibilityMode === 'string'
+          ? options.destructibilityMode
+          : null,
+      ownerKey: options.ownerKey ?? null,
+      destructible:
+        typeof options.destructible === 'boolean' ? options.destructible : undefined,
     };
   };
 
@@ -460,6 +470,63 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     decorationInstancedData.get(type).push(entry);
   };
 
+  const addDecorationMesh = (targetGroup, type, batch) => {
+    if (!batch?.entries || batch.entries.length === 0) {
+      return null;
+    }
+    const { mesh, tintAttribute } = buildInstancedMesh(batch.entries, type);
+    mesh.userData.decoration = true;
+
+    const placementKeys = Array.isArray(batch.placementKeys)
+      ? [...batch.placementKeys]
+      : [];
+    const ownerKey = batch.ownerKey ?? null;
+    const destructible = batch.destructible !== false;
+
+    const center = new THREE.Vector3();
+    batch.entries.forEach((entry) => {
+      if (entry?.position) {
+        center.add(entry.position);
+      }
+    });
+    if (batch.entries.length > 0) {
+      center.multiplyScalar(1 / batch.entries.length);
+    }
+
+    const metadata = {
+      key: batch.groupKey,
+      type,
+      mesh,
+      tintAttribute,
+      entries: batch.entries,
+      placementKeys,
+      ownerKey,
+      destructible,
+      position: center.clone(),
+    };
+
+    mesh.userData.decorationGroup = {
+      key: metadata.key,
+      type: metadata.type,
+      destructible,
+      ownerKey,
+      placementKeys: placementKeys.slice(),
+      position: metadata.position.clone(),
+    };
+
+    decorationGroups.set(metadata.key, metadata);
+    if (ownerKey) {
+      if (!decorationGroupsByOwner.has(ownerKey)) {
+        decorationGroupsByOwner.set(ownerKey, new Set());
+      }
+      decorationGroupsByOwner.get(ownerKey).add(metadata.key);
+    }
+    blockLookup.set(metadata.key, metadata);
+
+    targetGroup.add(mesh);
+    return metadata;
+  };
+
   const buildInstancedMesh = (entries, type) => {
     const geometry = blockGeometry.clone();
     const mesh = new THREE.InstancedMesh(
@@ -505,11 +572,23 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       if (!entries || entries.length === 0) {
         return;
       }
-      const { mesh, tintAttribute } = buildInstancedMesh(entries, type);
+      let entryList = entries;
+      if (decoration) {
+        const { instancedEntries, batches } = createDecorationMeshBatches(entries, { type });
+        batches.forEach((batch) => {
+          addDecorationMesh(targetGroup, type, batch);
+        });
+        entryList = instancedEntries;
+        decorationInstancedData.set(type, instancedEntries);
+      }
+      if (!entryList || entryList.length === 0) {
+        return;
+      }
+      const { mesh, tintAttribute } = buildInstancedMesh(entryList, type);
       if (decoration) {
         mesh.userData.decoration = true;
       } else {
-        typeData.set(type, { entries, mesh, tintAttribute });
+        typeData.set(type, { entries: entryList, mesh, tintAttribute });
       }
       targetGroup.add(mesh);
     });
@@ -733,6 +812,8 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     waterColumnKeys,
     fluidSurfaces,
     blockLookup,
+    decorationGroups,
+    decorationGroupsByOwner,
     typeData,
     biomes,
     bounds: (() => {

--- a/three-demo/src/world/voxel-object-decoration-mesh.js
+++ b/three-demo/src/world/voxel-object-decoration-mesh.js
@@ -1,0 +1,62 @@
+export function createDecorationMeshBatches(entries = [], { type: fallbackType } = {}) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return { instancedEntries: [], batches: [] };
+  }
+
+  const instancedEntries = [];
+  const grouped = new Map();
+
+  entries.forEach((entry) => {
+    if (!entry) {
+      return;
+    }
+
+    const mode =
+      typeof entry.destructibilityMode === 'string'
+        ? entry.destructibilityMode
+        : typeof entry.metadata?.decorationDestructibility === 'string'
+        ? entry.metadata.decorationDestructibility
+        : 'group';
+
+    if (mode === 'individual') {
+      instancedEntries.push(entry);
+      return;
+    }
+
+    const ownerKey = entry.ownerKey ?? entry.metadata?.ownerKey ?? null;
+    const groupType = entry.type ?? fallbackType ?? null;
+    const groupKey = ownerKey
+      ? `decor:${ownerKey}`
+      : `decor:${groupType ?? 'unknown'}:${entry.key}`;
+
+    if (!grouped.has(groupKey)) {
+      grouped.set(groupKey, {
+        type: groupType,
+        ownerKey,
+        entries: [],
+        placementKeys: [],
+        destructible: false,
+      });
+    }
+
+    const group = grouped.get(groupKey);
+    group.entries.push(entry);
+    group.placementKeys.push(entry.key);
+    if (entry.destructible !== false) {
+      group.destructible = true;
+    }
+  });
+
+  const batches = Array.from(grouped.entries()).map(([groupKey, group]) => ({
+    type: group.type ?? fallbackType ?? null,
+    entries: group.entries,
+    groupKey,
+    ownerKey: group.ownerKey,
+    destructible: group.destructible,
+    placementKeys: group.placementKeys,
+  }));
+
+  return { instancedEntries, batches };
+}
+
+export default createDecorationMeshBatches;

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -437,9 +437,11 @@ function computeNanovoxelPlacementsForDescriptor(
             collisionMode: 'none',
             isSolid: false,
             destructible: basePlacement.destructible,
+            destructibilityMode: resolveDecorationDestructibility(basePlacement.metadata),
             sourceObjectId: object.id,
             voxelIndex: voxel.index,
             metadata: basePlacement.metadata,
+            ownerKey: basePlacement.key,
             key,
           },
         });
@@ -642,6 +644,36 @@ function resolveCollisionMode(voxel, object) {
   return object.voxelScale < 1 ? 'none' : 'solid';
 }
 
+function resolveDecorationDestructibility(metadata) {
+  const root = metadata ?? {};
+  const decorationMeta =
+    root.decoration && typeof root.decoration === 'object' ? root.decoration : null;
+
+  const candidateModes = [
+    decorationMeta?.destructibilityMode,
+    decorationMeta?.destructibility,
+    root.decorationDestructibility,
+  ];
+
+  for (const mode of candidateModes) {
+    if (typeof mode === 'string') {
+      return mode;
+    }
+  }
+
+  if (decorationMeta?.individualDestruction === true) {
+    return 'individual';
+  }
+  if (decorationMeta?.groupDestructible === false) {
+    return 'individual';
+  }
+  if (root.individualDecorationDestruction === true) {
+    return 'individual';
+  }
+
+  return 'group';
+}
+
 function computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing) {
   const layerCount = Math.max(0, smoothing.featherLayers ?? 0);
   if (layerCount === 0) {
@@ -710,9 +742,11 @@ function computeSegmentFeatherPlacements(voxel, basePlacement, object, smoothing
         collisionMode: 'none',
         isSolid: false,
         destructible: basePlacement.destructible,
+        destructibilityMode: resolveDecorationDestructibility(basePlacement.metadata),
         sourceObjectId: object.id,
         voxelIndex: voxel.index,
         metadata: basePlacement.metadata,
+        ownerKey: basePlacement.key,
         key: `${basePlacement.key}|layer-${i}`,
       },
     });
@@ -787,9 +821,11 @@ function computeNodeFeatherPlacements(voxel, basePlacement, object, smoothing) {
         collisionMode: 'none',
         isSolid: false,
         destructible: basePlacement.destructible,
+        destructibilityMode: resolveDecorationDestructibility(basePlacement.metadata),
         sourceObjectId: object.id,
         voxelIndex: voxel.index,
         metadata: basePlacement.metadata,
+        ownerKey: basePlacement.key,
         key: `${basePlacement.key}|petal-${i}`,
       },
     });


### PR DESCRIPTION
## Summary
- tag decorative and nanovoxel placements with destructibility metadata and owner keys so they can be grouped when batching
- batch grouped decorations into meshes during chunk generation, track them in the chunk manager, and expose removal helpers
- allow the player attack ray to target decoration groups while keeping individual voxels on the instanced removal path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6dcd49fa8832a8830909430d14a55