### PR TITLE
Cache voxel decoration templates and reuse during placement

### DIFF
--- a/three-demo/src/world/voxel-object-processor.js
+++ b/three-demo/src/world/voxel-object-processor.js
@@ -1,4 +1,5 @@
 import generateNodeGrowthVoxels from './procedural/node-growth-generator.js';
+import { invalidateDecorationMeshCache } from './voxel-object-decoration-mesh.js';
 
 const resolvedVoxelCache = new WeakMap();
 
@@ -89,4 +90,5 @@ export function invalidateResolvedVoxelCache(object) {
     return;
   }
   resolvedVoxelCache.delete(object);
+  invalidateDecorationMeshCache(object);
 }


### PR DESCRIPTION
## Summary
- add a WeakMap-backed cache for voxel object decoration mesh templates and expose helpers to clone decoration options
- update voxel object placement and chunk generation to request cached decoration meshes, falling back to instanced decorations when needed
- invalidate cached decoration meshes when voxel object definitions are refreshed

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7120ff220832a94f2dc01f6b21a96