### PR TITLE
Allow players to sink in default water columns

### DIFF
--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -99,12 +99,81 @@ export function createPlayerControls({
   const gravity = 18;
   const jumpVelocity = 10.2;
   const nearGroundThreshold = 0.18;
+  const waterColumnEpsilon = 1e-3;
   const spawnDropHeight = 6;
   const minSpawnHeight = worldConfig.maxHeight + playerEyeHeight + 8;
   const maxRescueHeight = worldConfig.maxHeight + playerEyeHeight + 60;
   const spawnSearchRadius = 30;
   const spawnSearchStep = 6;
   const fallbackSpawnPosition = new THREE.Vector3(0, minSpawnHeight, 0);
+
+  function normalizeWaterColumnMetadata(metadata) {
+    if (!metadata || typeof metadata !== 'object') {
+      return null;
+    }
+    const resolveValue = (value) => {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+    const bottomCandidates = [
+      metadata.bottomY,
+      metadata.minY,
+      metadata.yMin,
+      metadata.min,
+    ];
+    const surfaceCandidates = [
+      metadata.surfaceY,
+      metadata.maxY,
+      metadata.yMax,
+      metadata.max,
+    ];
+    let bottom = null;
+    for (let i = 0; i < bottomCandidates.length && bottom === null; i += 1) {
+      bottom = resolveValue(bottomCandidates[i]);
+    }
+    let surface = null;
+    for (let i = 0; i < surfaceCandidates.length && surface === null; i += 1) {
+      surface = resolveValue(surfaceCandidates[i]);
+    }
+    if (bottom === null && surface === null) {
+      return null;
+    }
+    if (bottom === null) {
+      bottom = surface;
+    }
+    if (surface === null) {
+      surface = bottom;
+    }
+    const min = Math.min(bottom, surface);
+    const max = Math.max(bottom, surface);
+    return { bottomY: min, surfaceY: max };
+  }
+
+  function getWaterColumnInfo(columnKey) {
+    if (!columnKey) {
+      return { exists: false, bounds: null, metadata: null };
+    }
+    if (!waterColumns) {
+      return { exists: false, bounds: null, metadata: null };
+    }
+    if (typeof waterColumns.has === 'function') {
+      const exists = waterColumns.has(columnKey);
+      if (!exists) {
+        return { exists: false, bounds: null, metadata: null };
+      }
+      if (typeof waterColumns.get === 'function') {
+        const metadata = waterColumns.get(columnKey);
+        const bounds = metadata === null ? null : normalizeWaterColumnMetadata(metadata);
+        return { exists: true, bounds, metadata };
+      }
+      return { exists: true, bounds: null, metadata: null };
+    }
+    if (Array.isArray(waterColumns)) {
+      const exists = waterColumns.includes(columnKey);
+      return { exists, bounds: null, metadata: null };
+    }
+    return { exists: false, bounds: null, metadata: null };
+  }
   const pointerLockElement = renderer.domElement;
   const pointerLockDocument = pointerLockElement.ownerDocument;
   const pointerLockSupported = isPointerLockSupported(pointerLockDocument);
@@ -311,8 +380,11 @@ export function createPlayerControls({
     }
 
     const columnKey = `${x}|${z}`;
-    const hasWaterColumn = Boolean(waterColumns?.has?.(columnKey));
-    const isSubmerged = hasWaterColumn && surfaceY <= worldConfig.waterLevel + 0.5;
+    const { exists: hasWaterColumn, bounds } = getWaterColumnInfo(columnKey);
+    const waterSurface = Number.isFinite(bounds?.surfaceY)
+      ? bounds.surfaceY
+      : worldConfig.waterLevel + 0.5;
+    const isSubmerged = hasWaterColumn && surfaceY <= waterSurface;
     const spawnY = Math.max(surfaceY + playerEyeHeight + spawnDropHeight, minSpawnHeight);
 
     return {
@@ -915,12 +987,35 @@ export function createPlayerControls({
     }
 
     const columnKey = `${Math.round(position.x)}|${Math.round(position.z)}`;
-    const waterSurface = worldConfig.waterLevel + 0.5;
     const feetY = position.y - playerEyeHeight;
     const headY = position.y;
-    const inWaterColumn = waterColumns.has(columnKey);
-    const feetInWater = inWaterColumn && feetY < waterSurface;
-    const headUnderwater = inWaterColumn && headY < waterSurface;
+    const columnInfo = getWaterColumnInfo(columnKey);
+    const columnBounds = columnInfo.bounds;
+    const columnMetadata = columnInfo.metadata;
+    const fallbackWaterSurface = worldConfig.waterLevel + 0.5;
+    const effectiveWaterSurface = Number.isFinite(columnBounds?.surfaceY)
+      ? columnBounds.surfaceY
+      : fallbackWaterSurface;
+    const inWaterColumn = columnInfo.exists;
+    let feetInWater = false;
+    let headUnderwater = false;
+    if (inWaterColumn) {
+      if (columnBounds) {
+        const minWater = Math.min(columnBounds.bottomY, columnBounds.surfaceY);
+        const maxWater = Math.max(columnBounds.bottomY, columnBounds.surfaceY);
+        const feetWithin =
+          feetY >= minWater - waterColumnEpsilon &&
+          feetY <= maxWater + waterColumnEpsilon;
+        const headWithin =
+          headY >= minWater - waterColumnEpsilon &&
+          headY <= maxWater + waterColumnEpsilon;
+        feetInWater = feetWithin;
+        headUnderwater = headWithin && headY < maxWater - waterColumnEpsilon;
+      } else {
+        feetInWater = feetY < effectiveWaterSurface;
+        headUnderwater = headY < effectiveWaterSurface;
+      }
+    }
     const inSoftMedium = !feetInWater && isInSoftMedium(position);
 
     if (playerState.isInWater !== feetInWater) {
@@ -1037,12 +1132,7 @@ export function createPlayerControls({
       const supportTargetY = standingSurface
         ? standingSurface.height + playerEyeHeight
         : Number.NEGATIVE_INFINITY;
-      const waterTarget =
-        worldConfig.waterLevel + 0.5 + playerEyeHeight - 0.2;
       let targetY = supportTargetY;
-      if (!feetInWater && inWaterColumn) {
-        targetY = Math.max(targetY, waterTarget);
-      }
 
       if (jumpRequested) {
         const nearGround =
@@ -1061,9 +1151,20 @@ export function createPlayerControls({
       const effectiveGravity = feetInWater ? gravity * 0.35 : gravity;
       verticalVelocity -= effectiveGravity * delta;
       if (feetInWater) {
-        const submersion = THREE.MathUtils.clamp(waterSurface - feetY, 0, 6);
-        const buoyancy = submersion * 2.4;
-        verticalVelocity += buoyancy * delta;
+        const submersion = THREE.MathUtils.clamp(
+          effectiveWaterSurface - feetY,
+          0,
+          6,
+        );
+        const columnBuoyancy = Number.isFinite(columnMetadata?.buoyancy)
+          ? columnMetadata.buoyancy
+          : Number.isFinite(columnBounds?.buoyancy)
+          ? columnBounds.buoyancy
+          : 0;
+        if (columnBuoyancy > 0) {
+          const buoyancy = submersion * columnBuoyancy;
+          verticalVelocity += buoyancy * delta;
+        }
         verticalVelocity *= 0.82;
         if (sprint && !isGrounded) {
           verticalVelocity -= 4.2 * delta;

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -124,7 +124,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const decorationTypeIndex = new Map();
   const solidBlockKeys = new Set();
   const softBlockKeys = new Set();
-  const waterColumnKeys = new Set();
+  const waterColumnMetadata = new Map();
   const fluidColumnsByType = new Map();
   const fluidSurfaces = [];
   let minBoundX = Number.POSITIVE_INFINITY;
@@ -441,7 +441,26 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         }
       }
       if (isWater) {
-        waterColumnKeys.add(columnKey);
+        const bottomY = column.minY;
+        const surfaceY = column.maxY;
+        const previous = waterColumnMetadata.get(columnKey);
+        if (previous) {
+          const nextBottom = Number.isFinite(previous.bottomY)
+            ? Math.min(previous.bottomY, bottomY)
+            : bottomY;
+          const nextSurface = Number.isFinite(previous.surfaceY)
+            ? Math.max(previous.surfaceY, surfaceY)
+            : surfaceY;
+          waterColumnMetadata.set(columnKey, {
+            bottomY: nextBottom,
+            surfaceY: nextSurface,
+          });
+        } else {
+          waterColumnMetadata.set(columnKey, {
+            bottomY,
+            surfaceY,
+          });
+        }
       }
       return;
     }
@@ -873,6 +892,33 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       column.depth = Math.max(0.05, column.surfaceY - column.bottomY);
     });
 
+    if (type === 'water') {
+      columns.forEach((column) => {
+        const metadata = waterColumnMetadata.get(column.key);
+        const bottomY = Number.isFinite(column.bottomY)
+          ? column.bottomY
+          : metadata?.bottomY;
+        const surfaceY = Number.isFinite(column.surfaceY)
+          ? column.surfaceY
+          : metadata?.surfaceY;
+        if (!Number.isFinite(bottomY) && !Number.isFinite(surfaceY)) {
+          return;
+        }
+        const normalizedBottom = Number.isFinite(bottomY)
+          ? bottomY
+          : surfaceY;
+        const normalizedSurface = Number.isFinite(surfaceY)
+          ? surfaceY
+          : bottomY;
+        const bottom = Math.min(normalizedBottom, normalizedSurface);
+        const surface = Math.max(normalizedBottom, normalizedSurface);
+        waterColumnMetadata.set(column.key, {
+          bottomY: bottom,
+          surfaceY: surface,
+        });
+      });
+    }
+
     columns.forEach((column) => {
       const neighbors = {};
       let foamExposure = 0;
@@ -1002,7 +1048,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group,
     solidBlockKeys,
     softBlockKeys,
-    waterColumnKeys,
+    waterColumns: waterColumnMetadata,
     fluidSurfaces,
     blockLookup,
     typeData,
@@ -1041,7 +1087,7 @@ export function generateWorld(blockMaterials) {
   return {
     meshes: [...chunk.group.children],
     solidBlocks: new Set(chunk.solidBlockKeys),
-    waterColumns: new Set(chunk.waterColumnKeys),
+    waterColumns: new Map(chunk.waterColumns ?? []),
     biomes: chunk.biomes,
   };
 }


### PR DESCRIPTION
## Summary
- expose raw water column metadata to the player controller so it can inspect fluid properties
- remove the automatic lift-to-surface target so default water no longer forces players upward
- apply buoyancy impulses only when a fluid column explicitly provides a buoyancy value

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d71b3ca418832a914d8678d7621f75