### PR TITLE
Add per-voxel destruction mode for voxel objects

### DIFF
--- a/three-demo/src/world/voxel-object-library.js
+++ b/three-demo/src/world/voxel-object-library.js
@@ -2,6 +2,12 @@ const voxelObjectModules = import.meta.glob('./voxel-objects/**/*.json', {
   eager: true,
 });
 
+const DEFAULT_DESTRUCTION_MODE = 'prototype';
+const ALLOWED_DESTRUCTION_MODES = new Set([
+  'prototype',
+  'per-voxel',
+]);
+
 function asArray(value, dimension, label, path) {
   if (!Array.isArray(value) || value.length !== dimension) {
     throw new Error(
@@ -149,6 +155,17 @@ function normalizeDefinition(path, raw) {
     ? definition.voxels.map((voxel, index) => normalizeVoxel(voxel, index, { path }))
     : [];
 
+  let destructionMode = DEFAULT_DESTRUCTION_MODE;
+  if (typeof definition.destructionMode === 'string') {
+    const normalizedMode = definition.destructionMode.trim().toLowerCase();
+    if (!ALLOWED_DESTRUCTION_MODES.has(normalizedMode)) {
+      throw new Error(
+        `Unsupported destructionMode "${definition.destructionMode}" in voxel object definition at ${path}.`,
+      );
+    }
+    destructionMode = normalizedMode;
+  }
+
   const attachment = {
     groundOffset:
       typeof definition?.attachment?.groundOffset === 'number'
@@ -250,6 +267,7 @@ function normalizeDefinition(path, raw) {
     placement,
     voxels,
     boundingBox,
+    destructionMode,
 
     collision: { mode: normalizedCollision },
 

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -48,7 +48,10 @@ export function placeVoxelObject(
     z: base.z,
   };
 
-  if (typeof addPrototypeInstance === 'function') {
+  const usePrototypePlacement =
+    object?.destructionMode !== 'per-voxel' && typeof addPrototypeInstance === 'function';
+
+  if (usePrototypePlacement) {
     const prototype = getVoxelObjectPrototype(object);
     if (prototype) {
       const instanceKey = [
@@ -339,11 +342,18 @@ export function populateColumnWithVoxelObjects({
         y: groundHeight + (object.attachment?.groundOffset ?? object.voxelScale),
         z: baseZ + Math.sin(angle) * radius,
       };
-      placeVoxelObject(
-        { addBlock, addDecorationInstance, addPrototypeInstance, addDecorationMesh },
-        object,
-        { origin, biome },
-      );
+      const placementHandlers = {
+        addBlock,
+        addDecorationInstance,
+        addDecorationMesh,
+      };
+      if (
+        object.destructionMode !== 'per-voxel' &&
+        typeof addPrototypeInstance === 'function'
+      ) {
+        placementHandlers.addPrototypeInstance = addPrototypeInstance;
+      }
+      placeVoxelObject(placementHandlers, object, { origin, biome });
     }
     return true;
   };

--- a/three-demo/src/world/voxel-object-prototypes.js
+++ b/three-demo/src/world/voxel-object-prototypes.js
@@ -894,6 +894,9 @@ export function clearVoxelObjectPrototypeCache() {
 }
 
 export function buildVoxelObjectPrototype(object) {
+  if (object?.destructionMode === 'per-voxel') {
+    return null;
+  }
   const placements = computeVoxelObjectPlacements(object);
   if (!placements) {
     return null;
@@ -912,6 +915,9 @@ export function buildVoxelObjectPrototype(object) {
 
 export function getVoxelObjectPrototype(object) {
   if (!object) {
+    return null;
+  }
+  if (object.destructionMode === 'per-voxel') {
     return null;
   }
   const cacheKey = object.id;

--- a/three-demo/src/world/voxel-objects/large-plants/temperate_oak.json
+++ b/three-demo/src/world/voxel-objects/large-plants/temperate_oak.json
@@ -5,6 +5,8 @@
   "author": "system",
   "description": "Compact broadleaf tree built from terrain-scale voxels.",
 
+  "destructionMode": "per-voxel",
+
   "collision": "solid",
 
   "voxelScale": 1,


### PR DESCRIPTION
## Summary
- add `destructionMode` parsing to the voxel object library so definitions can opt into per-voxel destruction
- ensure placement and prototype helpers bypass instanced prototype placement when per-voxel mode is enabled
- tag the temperate oak definition with per-voxel destruction so logs can be removed independently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d755a1a330832aa50f1e22f811c042