### PR TITLE
Fix prototype generation for vaporwave palm

### DIFF
--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -52,7 +52,30 @@ export function placeVoxelObject(
     object?.destructionMode !== 'per-voxel' && typeof addPrototypeInstance === 'function';
 
   if (usePrototypePlacement) {
+    const debugPrototypeLogs =
+      typeof console !== 'undefined' && (import.meta.env?.DEV ?? true);
+    if (debugPrototypeLogs) {
+      console.debug('[voxel-object-placement] evaluating prototype placement', {
+        objectId: object.id ?? null,
+      });
+    }
     const prototype = getVoxelObjectPrototype(object);
+    if (!prototype) {
+      if (debugPrototypeLogs) {
+        console.debug(
+          '[voxel-object-placement] prototype unavailable, using per-voxel placement',
+          {
+            objectId: object.id ?? null,
+          },
+        );
+      }
+    } else if (debugPrototypeLogs) {
+      console.debug('[voxel-object-placement] using prototype placement', {
+        objectId: object.id ?? null,
+        blockCount: prototype.blocks?.length ?? 0,
+        decorationCount: prototype.decorations?.length ?? 0,
+      });
+    }
     if (prototype) {
       const instanceKey = [
         object.id ?? 'object',

--- a/three-demo/src/world/voxel-object-processor.js
+++ b/three-demo/src/world/voxel-object-processor.js
@@ -67,7 +67,12 @@ export function resolveVoxelObjectVoxels(object) {
     : [];
 
   let proceduralVoxels = [];
-  const proceduralConfig = object.raw?.procedural ?? null;
+  const proceduralConfigCandidate =
+    object.raw?.procedural ?? object.procedural ?? object.rawProcedural ?? null;
+  const proceduralConfig =
+    proceduralConfigCandidate && typeof proceduralConfigCandidate === 'object'
+      ? proceduralConfigCandidate
+      : null;
   if (proceduralConfig?.nodeGrowth) {
     proceduralVoxels = generateNodeGrowthVoxels(object, proceduralConfig.nodeGrowth);
   }


### PR DESCRIPTION
## Summary
- add debug logs around palm prototype placement to verify when we fall back to per-voxel placement
- extend voxel resolution to read procedural configs from cloned definitions so the vaporwave palm rebuilds its prototype

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d763993e50832aa8f4a9fa9c3e54e3