### PR TITLE
Add flower variants and balance spawning

### DIFF
--- a/three-demo/src/world/biomes/temperate.json
+++ b/three-demo/src/world/biomes/temperate.json
@@ -14,7 +14,7 @@
     "deepBlock": "stone",
     "treeDensity": 0.08,
     "shrubChance": 0.045,
-    "flowerChance": 0.08,
+    "flowerChance": 0.06,
     "rockChance": 0.04,
     "fungiChance": 0.05,
     "waterPlantChance": 0.0,

--- a/three-demo/src/world/voxel-objects/flowers/blue_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/blue_flower.json
@@ -13,7 +13,7 @@
   },
   "placement": {
     "biomes": ["temperate_forest"],
-    "weight": 1.2,
+    "weight": 0.4,
     "maxSlope": 0.65,
     "forbidUnderwater": true,
     "jitterRadius": 0.6,

--- a/three-demo/src/world/voxel-objects/flowers/golden_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/golden_flower.json
@@ -1,0 +1,34 @@
+{
+  "id": "golden_flower",
+  "label": "Golden Meadow Flower",
+  "category": "flowers",
+  "author": "system",
+  "description": "Sun-kissed petals with warm amber hues and a sturdy stem.",
+
+  "collision": "none",
+
+  "voxelScale": 0.2,
+  "attachment": {
+    "groundOffset": 0.1
+  },
+  "placement": {
+    "biomes": ["temperate_forest"],
+    "weight": 0.4,
+    "maxSlope": 0.65,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.6,
+    "maxInstancesPerColumn": 3
+  },
+  "voxels": [
+    { "type": "log", "position": [0, 0, 0], "tint": "#665028", "destructible": true },
+    { "type": "log", "position": [0, 1, 0], "tint": "#665028" },
+    { "type": "leaf", "position": [0, 2, 0], "size": [1, 1.2, 1], "tint": "#7a9c3c" },
+    { "type": "leaf", "position": [0, 2.8, 0], "size": [1.2, 0.6, 1.2], "tint": "#94b94c" },
+    { "type": "leaf", "position": [0, 3.6, 0], "size": [1.2, 0.6, 1.2], "tint": "#a2c85a" },
+    { "type": "leaf", "position": [1.2, 4, 0], "size": [1.4, 0.6, 1.4], "tint": "#f4c44d", "isSolid": false },
+    { "type": "leaf", "position": [-1.2, 4, 0], "size": [1.4, 0.6, 1.4], "tint": "#f4c44d", "isSolid": false },
+    { "type": "leaf", "position": [0, 4, 1.2], "size": [1.4, 0.6, 1.4], "tint": "#f4c44d", "isSolid": false },
+    { "type": "leaf", "position": [0, 4, -1.2], "size": [1.4, 0.6, 1.4], "tint": "#f4c44d", "isSolid": false },
+    { "type": "leaf", "position": [0, 4.5, 0], "size": [1.2, 0.6, 1.2], "tint": "#ffeb9a", "isSolid": false }
+  ]
+}

--- a/three-demo/src/world/voxel-objects/flowers/pink_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/pink_flower.json
@@ -1,0 +1,34 @@
+{
+  "id": "pink_flower",
+  "label": "Pink Meadow Flower",
+  "category": "flowers",
+  "author": "system",
+  "description": "Bright spring bloom with candy-pink petals and soft green stem.",
+
+  "collision": "none",
+
+  "voxelScale": 0.2,
+  "attachment": {
+    "groundOffset": 0.1
+  },
+  "placement": {
+    "biomes": ["temperate_forest"],
+    "weight": 0.4,
+    "maxSlope": 0.65,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.6,
+    "maxInstancesPerColumn": 3
+  },
+  "voxels": [
+    { "type": "log", "position": [0, 0, 0], "tint": "#4f6334", "destructible": true },
+    { "type": "log", "position": [0, 1, 0], "tint": "#4f6334" },
+    { "type": "leaf", "position": [0, 2, 0], "size": [1, 1.2, 1], "tint": "#6ebf53" },
+    { "type": "leaf", "position": [0, 2.8, 0], "size": [1.2, 0.6, 1.2], "tint": "#7fda70" },
+    { "type": "leaf", "position": [0, 3.6, 0], "size": [1.2, 0.6, 1.2], "tint": "#8fe983" },
+    { "type": "leaf", "position": [1.2, 4, 0], "size": [1.4, 0.6, 1.4], "tint": "#ff7ac9", "isSolid": false },
+    { "type": "leaf", "position": [-1.2, 4, 0], "size": [1.4, 0.6, 1.4], "tint": "#ff7ac9", "isSolid": false },
+    { "type": "leaf", "position": [0, 4, 1.2], "size": [1.4, 0.6, 1.4], "tint": "#ff7ac9", "isSolid": false },
+    { "type": "leaf", "position": [0, 4, -1.2], "size": [1.4, 0.6, 1.4], "tint": "#ff7ac9", "isSolid": false },
+    { "type": "leaf", "position": [0, 4.5, 0], "size": [1.2, 0.6, 1.2], "tint": "#ffe0f3", "isSolid": false }
+  ]
+}


### PR DESCRIPTION
## Summary
- add pink and golden meadow flower voxel object definitions with unique petal and stem tints
- rebalance meadow flower weights and temperate biome flower spawn chance to keep total frequency steady

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d767d0c104832a95efe07a55db680d