### PR TITLE
Enable ignoreBiomeTint for flower voxel objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ npm run build
 ```
 
 The output is written to `three-demo/dist/` and can be hosted on any static web server.
+
+## Voxel Object JSON Notes
+- `ignoreBiomeTint` (boolean, optional): when `true`, the object's voxels render using their explicit `tint` values without
+  additional biome- or altitude-based color grading. Use this for foliage or decorations that should preserve author-defined
+  hues regardless of the surrounding biome lighting.

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -324,38 +324,45 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
     const paletteColor = engine.getBlockColor(biome, type);
     const tintStrength = clamp(biome?.shader?.tintStrength ?? 1, 0, 1);
+    const tintOverride = parseTintOverride(options.tint);
+    const ignoreBiomeTint = options.ignoreBiomeTint === true;
 
     const paletteBlend = new THREE.Color(1, 1, 1);
-    if (paletteColor) {
-      paletteBlend.lerp(paletteColor, tintStrength);
-    }
+    if (!ignoreBiomeTint) {
+      if (paletteColor) {
+        paletteBlend.lerp(paletteColor, tintStrength);
+      }
 
-    if (biome?.shader?.tintColor) {
-      const biomeTintBlend = new THREE.Color(1, 1, 1);
-      biomeTintBlend.lerp(biome.shader.tintColor, tintStrength * 0.65);
-      paletteBlend.multiply(biomeTintBlend);
-    }
+      if (biome?.shader?.tintColor) {
+        const biomeTintBlend = new THREE.Color(1, 1, 1);
+        biomeTintBlend.lerp(biome.shader.tintColor, tintStrength * 0.65);
+        paletteBlend.multiply(biomeTintBlend);
+      }
 
-    if (biome?.climate) {
-      const dryness = clamp(1 - biome.climate.moisture, 0, 1);
-      const climateBlend = new THREE.Color(1, 1, 1);
-      climateBlend.lerp(new THREE.Color(1.02, 0.98, 0.92), dryness * 0.35);
-      paletteBlend.multiply(climateBlend);
-    }
+      if (biome?.climate) {
+        const dryness = clamp(1 - biome.climate.moisture, 0, 1);
+        const climateBlend = new THREE.Color(1, 1, 1);
+        climateBlend.lerp(new THREE.Color(1.02, 0.98, 0.92), dryness * 0.35);
+        paletteBlend.multiply(climateBlend);
+      }
 
-    const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
-    const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
-    const altitudeBlend = new THREE.Color(1, 1, 1);
-    if (altitude > 0) {
-      altitudeBlend.lerp(new THREE.Color(0.95, 0.98, 1.04), altitude * 0.3);
-    } else if (altitude < 0) {
-      altitudeBlend.lerp(new THREE.Color(1.04, 1.01, 0.94), Math.abs(altitude) * 0.25);
-    }
-    paletteBlend.multiply(altitudeBlend);
+      const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
+      const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
+      const altitudeBlend = new THREE.Color(1, 1, 1);
+      if (altitude > 0) {
+        altitudeBlend.lerp(new THREE.Color(0.95, 0.98, 1.04), altitude * 0.3);
+      } else if (altitude < 0) {
+        altitudeBlend.lerp(new THREE.Color(1.04, 1.01, 0.94), Math.abs(altitude) * 0.25);
+      }
+      paletteBlend.multiply(altitudeBlend);
 
-    const tintOverride = parseTintOverride(options.tint);
-    if (tintOverride) {
-      paletteBlend.multiply(tintOverride);
+      if (tintOverride) {
+        paletteBlend.multiply(tintOverride);
+      }
+    } else if (tintOverride) {
+      paletteBlend.copy(tintOverride);
+    } else if (paletteColor) {
+      paletteBlend.copy(paletteColor);
     }
 
     return {

--- a/three-demo/src/world/voxel-object-decoration-mesh.js
+++ b/three-demo/src/world/voxel-object-decoration-mesh.js
@@ -76,6 +76,7 @@ function cloneBlockPlacement(block) {
     voxelIndex: block.voxelIndex,
     sourceObjectId: block.sourceObjectId ?? null,
     key: block.key ?? null,
+    ignoreBiomeTint: block.ignoreBiomeTint === true,
   };
 }
 

--- a/three-demo/src/world/voxel-object-library.js
+++ b/three-demo/src/world/voxel-object-library.js
@@ -104,6 +104,8 @@ function normalizeVoxel(voxel, index, { path }) {
     typeof voxel.isSolid === 'boolean' ? voxel.isSolid : undefined;
   const destructible =
     typeof voxel.destructible === 'boolean' ? voxel.destructible : undefined;
+  const ignoreBiomeTint =
+    typeof voxel.ignoreBiomeTint === 'boolean' ? voxel.ignoreBiomeTint : undefined;
 
   let collisionMode = null;
   if (typeof voxel.collision === 'string') {
@@ -126,6 +128,7 @@ function normalizeVoxel(voxel, index, { path }) {
     tint,
     isSolid,
     destructible,
+    ignoreBiomeTint,
 
     collisionMode,
 
@@ -154,6 +157,11 @@ function normalizeDefinition(path, raw) {
   const voxels = Array.isArray(definition.voxels)
     ? definition.voxels.map((voxel, index) => normalizeVoxel(voxel, index, { path }))
     : [];
+
+  const ignoreBiomeTint =
+    typeof definition.ignoreBiomeTint === 'boolean'
+      ? definition.ignoreBiomeTint
+      : false;
 
   let destructionMode = DEFAULT_DESTRUCTION_MODE;
   if (typeof definition.destructionMode === 'string') {
@@ -268,6 +276,7 @@ function normalizeDefinition(path, raw) {
     voxels,
     boundingBox,
     destructionMode,
+    ignoreBiomeTint,
 
     collision: { mode: normalizedCollision },
 

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -120,6 +120,7 @@ export function placeVoxelObject(
       voxelIndex: block.voxelIndex,
       metadata: block.metadata,
       key,
+      ignoreBiomeTint: block.ignoreBiomeTint === true,
     });
   });
 

--- a/three-demo/src/world/voxel-object-prototypes.js
+++ b/three-demo/src/world/voxel-object-prototypes.js
@@ -419,6 +419,7 @@ export function computeNanovoxelPlacementsForDescriptor(
             voxelIndex: voxel.index,
             metadata: basePlacement.metadata,
             key,
+            ignoreBiomeTint: basePlacement.ignoreBiomeTint,
           },
         });
       });
@@ -626,6 +627,7 @@ export function computeSegmentFeatherPlacements(voxel, basePlacement, object, sm
         voxelIndex: voxel.index,
         metadata: basePlacement.metadata,
         key: `${basePlacement.key}|layer-${i}`,
+        ignoreBiomeTint: basePlacement.ignoreBiomeTint,
       },
     });
   }
@@ -697,6 +699,7 @@ export function computeNodeFeatherPlacements(voxel, basePlacement, object, smoot
         voxelIndex: voxel.index,
         metadata: basePlacement.metadata,
         key: `${basePlacement.key}|petal-${i}`,
+        ignoreBiomeTint: basePlacement.ignoreBiomeTint,
       },
     });
   }
@@ -820,6 +823,10 @@ export function computeVoxelObjectPlacements(object) {
 
     const collisionMode = resolveCollisionMode(voxel, object);
     const baseKey = `${object.id ?? 'object'}|${voxel.index}`;
+    const ignoreBiomeTint =
+      typeof voxel.ignoreBiomeTint === 'boolean'
+        ? voxel.ignoreBiomeTint
+        : object.ignoreBiomeTint === true;
 
     const blockEntry = {
       type: voxel.type,
@@ -834,6 +841,7 @@ export function computeVoxelObjectPlacements(object) {
       voxelIndex: voxel.index,
       key: baseKey,
       sourceObjectId: object.id ?? null,
+      ignoreBiomeTint,
     };
     blocks.push(blockEntry);
 
@@ -850,6 +858,7 @@ export function computeVoxelObjectPlacements(object) {
       metadata: voxel.metadata,
       collisionMode,
       key: baseKey,
+      ignoreBiomeTint,
     };
 
     const decorativePlacements = computeDecorativePlacements(voxel, basePlacement, object);

--- a/three-demo/src/world/voxel-objects/flowers/blue_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/blue_flower.json
@@ -7,6 +7,8 @@
 
   "collision": "none",
 
+  "ignoreBiomeTint": true,
+
   "voxelScale": 0.2,
   "attachment": {
     "groundOffset": 0.1

--- a/three-demo/src/world/voxel-objects/flowers/golden_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/golden_flower.json
@@ -7,6 +7,8 @@
 
   "collision": "none",
 
+  "ignoreBiomeTint": true,
+
   "voxelScale": 0.2,
   "attachment": {
     "groundOffset": 0.1

--- a/three-demo/src/world/voxel-objects/flowers/librarium_glowglyph.json
+++ b/three-demo/src/world/voxel-objects/flowers/librarium_glowglyph.json
@@ -5,6 +5,9 @@
   "author": "system",
   "description": "Hovering glyph that whispers page numbers.",
   "collision": "soft",
+
+  "ignoreBiomeTint": true,
+
   "voxelScale": 0.24,
   "attachment": {
     "groundOffset": 0.2

--- a/three-demo/src/world/voxel-objects/flowers/pink_flower.json
+++ b/three-demo/src/world/voxel-objects/flowers/pink_flower.json
@@ -7,6 +7,8 @@
 
   "collision": "none",
 
+  "ignoreBiomeTint": true,
+
   "voxelScale": 0.2,
   "attachment": {
     "groundOffset": 0.1

--- a/three-demo/src/world/voxel-objects/flowers/vaporwave_orchid.json
+++ b/three-demo/src/world/voxel-objects/flowers/vaporwave_orchid.json
@@ -5,6 +5,9 @@
   "author": "system",
   "description": "Glowing petals shimmering with synthwave gradients.",
   "collision": "soft",
+
+  "ignoreBiomeTint": true,
+
   "voxelScale": 0.24,
   "attachment": {
     "groundOffset": 0.12

--- a/three-demo/src/world/voxel-objects/large-plants/temperate_sakura.json
+++ b/three-demo/src/world/voxel-objects/large-plants/temperate_sakura.json
@@ -10,6 +10,7 @@
   "collision": "solid",
 
   "voxelScale": 1,
+  "ignoreBiomeTint": true,
   "attachment": {
     "groundOffset": 1
   },


### PR DESCRIPTION
## Summary
- enable the ignoreBiomeTint flag on all flower voxel-object definitions so their colors remain author-intended across biomes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76d8ed0f4832abe1062171a5d572b