### PR TITLE
Propagate ignoreBiomeTint flag to prototype blocks

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -646,6 +646,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         isSolid: block.collisionMode === 'solid',
         destructible: block.destructible,
         tint: block.tint,
+        ignoreBiomeTint: block.ignoreBiomeTint === true,
         sourceObjectId: block.sourceObjectId ?? prototype.id ?? null,
         voxelIndex: block.voxelIndex,
         metadata: block.metadata,


### PR DESCRIPTION
## Summary
- propagate the ignoreBiomeTint flag from prototype block definitions into generated instanced blocks so tint logic continues to respect the option

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d7713f539c832aa4a28124e6c2b88c