### PR TITLE
Add biome object density multipliers

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -44,6 +44,24 @@ function mixValues(a, b, weight) {
   return a * (1 - weight) + b * weight;
 }
 
+function normalizeMultiplier(value, fallback = 1) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, value);
+}
+
+function normalizeCategoryMultipliers(definition) {
+  if (!definition || typeof definition !== 'object' || Array.isArray(definition)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(definition)
+      .filter((entry) => typeof entry[0] === 'string')
+      .map(([key, value]) => [key, normalizeMultiplier(value, 1)]),
+  );
+}
+
 export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
   if (!THREE) {
     throw new Error('createBiomeEngine requires a THREE instance');
@@ -85,6 +103,14 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
     const terrainDefinition = definition.terrain ?? {};
     const treeHeight = terrainDefinition.treeHeight ?? {};
 
+    const objectDensityMultiplier = normalizeMultiplier(
+      terrainDefinition.objectDensityMultiplier,
+      1,
+    );
+    const objectDensityMultipliers = normalizeCategoryMultipliers(
+      terrainDefinition.objectDensityMultipliers,
+    );
+
     const shaderDefinition = definition.shader ?? {};
 
     return {
@@ -113,6 +139,8 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
         fungiChance: clamp01(terrainDefinition.fungiChance ?? 0),
         waterPlantChance: clamp01(terrainDefinition.waterPlantChance ?? 0),
         structureChance: clamp01(terrainDefinition.structureChance ?? 0),
+        objectDensityMultiplier,
+        objectDensityMultipliers,
         treeHeight: {
           min: Math.max(1, Math.floor(treeHeight.min ?? 3)),
           max: Math.max(Math.floor(treeHeight.max ?? 6), Math.floor(treeHeight.min ?? 3)),

--- a/three-demo/src/world/biomes/README.md
+++ b/three-demo/src/world/biomes/README.md
@@ -1,0 +1,31 @@
+# Biome configuration quick reference
+
+Biomes describe both climate targets and how object placement behaves in that region. Each biome's `terrain` block now supports two helpers for controlling how dense environmental objects should spawn:
+
+- `objectDensityMultiplier` — optional global multiplier applied to every spawn category. Defaults to `1.0` if omitted.
+- `objectDensityMultipliers` — optional object keyed map for fine-tuning individual categories on top of the global multiplier. Omitted entries default to `1.0`.
+
+Supported category keys currently include:
+
+| Key | Affects |
+| --- | ------- |
+| `trees` | Large plant placements such as trees. |
+| `shrubs` | Smaller plants that use the `small-plants` library. |
+| `flowers` | Flower objects (falls back to shrub chance if a flower chance is not specified). |
+| `rocks` | Rock scatter objects. |
+| `fungi` | Mushroom and fungus props. |
+| `waterPlants` | Aquatic vegetation spawned underwater. |
+| `structures` | Decorative structures planned for a column. |
+
+Because both levels multiply together, you can clamp the entire biome down and then boost specific categories back up. For example:
+
+```json
+"terrain": {
+  "objectDensityMultiplier": 0.6,
+  "objectDensityMultipliers": {
+    "flowers": 1.25
+  }
+}
+```
+
+The example above makes the biome 40% lighter overall while keeping flowers close to their original density.

--- a/three-demo/src/world/biomes/fading_vaporwave_dimension.json
+++ b/three-demo/src/world/biomes/fading_vaporwave_dimension.json
@@ -12,6 +12,7 @@
     "subSurfaceBlock": "sand",
     "subSurfaceDepth": 4,
     "deepBlock": "stone",
+    "objectDensityMultiplier": 0.6,
     "treeDensity": 0.03,
     "shrubChance": 0.03,
     "flowerChance": 0.06,

--- a/three-demo/src/world/biomes/noctilucent_fungus_glade.json
+++ b/three-demo/src/world/biomes/noctilucent_fungus_glade.json
@@ -12,6 +12,11 @@
     "subSurfaceBlock": "dirt",
     "subSurfaceDepth": 5,
     "deepBlock": "stone",
+    "objectDensityMultiplier": 0.8,
+    "objectDensityMultipliers": {
+      "flowers": 1.3,
+      "fungi": 1.1
+    },
     "treeDensity": 0.03,
     "shrubChance": 0.05,
     "flowerChance": 0.1,

--- a/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
+++ b/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
@@ -12,6 +12,7 @@
     "subSurfaceBlock": "stone",
     "subSurfaceDepth": 6,
     "deepBlock": "stone",
+    "objectDensityMultiplier": 0.75,
     "treeDensity": 0.02,
     "shrubChance": 0.04,
     "flowerChance": 0.12,

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -184,6 +184,30 @@ export function populateColumnWithVoxelObjects({
   }
   const random = ensureRandomSource(randomSource);
   const terrain = biome.terrain ?? {};
+  const objectDensityMultiplier =
+    typeof terrain.objectDensityMultiplier === 'number' &&
+    Number.isFinite(terrain.objectDensityMultiplier)
+      ? Math.max(0, terrain.objectDensityMultiplier)
+      : 1;
+  const categoryMultipliers =
+    terrain.objectDensityMultipliers &&
+    typeof terrain.objectDensityMultipliers === 'object' &&
+    !Array.isArray(terrain.objectDensityMultipliers)
+      ? terrain.objectDensityMultipliers
+      : {};
+
+  const getCategoryMultiplier = (key) => {
+    const raw = categoryMultipliers?.[key];
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      return 1;
+    }
+    return Math.max(0, raw);
+  };
+
+  const applyMultipliers = (chance, key) => {
+    const scaled = chance * objectDensityMultiplier * getCategoryMultiplier(key);
+    return Math.max(0, scaled);
+  };
 
   const climate = columnSample?.climate ?? biome?.climate ?? {};
   const columnBaseOffset = {
@@ -407,7 +431,10 @@ export function populateColumnWithVoxelObjects({
     return placeObject(object, randomOffset);
   };
 
-  const treeDensity = Math.max(0, terrain.treeDensity ?? 0) * densityScale;
+  const treeDensity = applyMultipliers(
+    Math.max(0, terrain.treeDensity ?? 0) * densityScale,
+    'trees',
+  );
   if (treeDensity > 0 && !isUnderwater) {
     const roll = random(31);
     if (roll > 1 - treeDensity) {
@@ -416,7 +443,10 @@ export function populateColumnWithVoxelObjects({
     }
   }
 
-  const shrubChance = Math.max(0, terrain.shrubChance ?? 0) * densityScale;
+  const shrubChance = applyMultipliers(
+    Math.max(0, terrain.shrubChance ?? 0) * densityScale,
+    'shrubs',
+  );
   if (shrubChance > 0 && !isUnderwater) {
     const roll = random(51);
     if (roll > 1 - shrubChance) {
@@ -425,8 +455,12 @@ export function populateColumnWithVoxelObjects({
     }
   }
 
-  const flowerChanceRaw = terrain.flowerChance ?? shrubChance * 0.65;
-  const flowerChance = Math.max(0, Math.min(1, flowerChanceRaw || 0));
+  const shrubBaseForFallback = Math.max(0, terrain.shrubChance ?? 0) * densityScale;
+  const flowerChanceRaw = terrain.flowerChance ?? shrubBaseForFallback * 0.65;
+  const flowerChance = Math.max(
+    0,
+    Math.min(1, applyMultipliers(flowerChanceRaw || 0, 'flowers')),
+  );
   if (flowerChance > 0 && !isUnderwater) {
     const roll = random(71);
     if (roll > 1 - flowerChance) {
@@ -437,26 +471,34 @@ export function populateColumnWithVoxelObjects({
 
   attemptCategory(
     'rocks',
-    Math.max(0, terrain.rockChance ?? 0) * densityScale,
+    applyMultipliers(Math.max(0, terrain.rockChance ?? 0) * densityScale, 'rocks'),
     91,
     {
       allowUnderwater: false,
     },
   );
 
-  attemptCategory('fungi', Math.max(0, terrain.fungiChance ?? 0) * densityScale, 111, {
-    allowUnderwater: false,
-  });
+  attemptCategory(
+    'fungi',
+    applyMultipliers(Math.max(0, terrain.fungiChance ?? 0) * densityScale, 'fungi'),
+    111,
+    {
+      allowUnderwater: false,
+    },
+  );
 
   attemptCategory(
     'water-plants',
-    Math.max(0, terrain.waterPlantChance ?? 0),
+    applyMultipliers(Math.max(0, terrain.waterPlantChance ?? 0), 'waterPlants'),
     131,
     { allowUnderwater: true, requireUnderwater: true },
   );
 
   const structureChanceRaw = Math.max(0, terrain.structureChance ?? 0);
-  const structureChance = Math.min(1, structureChanceRaw) * densityScale;
+  const structureChance = Math.min(
+    1,
+    applyMultipliers(structureChanceRaw, 'structures'),
+  ) * densityScale;
   const adjustedStructureChance =
     plannedStructurePlacements > 0 ? structureChance * 0.1 : structureChance;
   if (adjustedStructureChance > 0) {


### PR DESCRIPTION
## Summary
- allow biome normalization to parse global and per-category object density multipliers
- apply biome multipliers when rolling voxel object spawn chances
- tune dense biomes with the new multiplier fields and document the configuration options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84cfa4164832ab664c5f025e12616