### PR TITLE
feat: support ignore biome tint overrides

### DIFF
--- a/three-demo/package.json
+++ b/three-demo/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "devDependencies": {
     "vite": "^7.1.6"

--- a/three-demo/src/world/__tests__/color-utils.test.js
+++ b/three-demo/src/world/__tests__/color-utils.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Color } from 'three';
+
+import { resolveBiomeTintMultiplier } from '../color-utils.js';
+
+function createPaletteEntries(type, neutralHex, paletteHex) {
+  const neutral = new Color(neutralHex);
+  const paletteColor = new Color(paletteHex);
+  const ratio = new Color(
+    paletteColor.r / Math.max(neutral.r, Number.EPSILON),
+    paletteColor.g / Math.max(neutral.g, Number.EPSILON),
+    paletteColor.b / Math.max(neutral.b, Number.EPSILON),
+  );
+  return {
+    palette: { [type]: paletteHex },
+    paletteColors: { [type]: ratio },
+  };
+}
+
+test('resolveBiomeTintMultiplier matches sakura leaf expectation', () => {
+  const type = 'leaf';
+  const strength = 0.85;
+  const desiredHex = '#ffc8e4';
+  const neutralHex = '#3f7c35';
+  const paletteHex = '#66b756';
+  const { palette, paletteColors } = createPaletteEntries(
+    type,
+    neutralHex,
+    paletteHex,
+  );
+  const blockMaterial = {
+    userData: {
+      biomeTintUniforms: {
+        biomeTintStrength: { value: strength },
+      },
+    },
+  };
+
+  const multiplier = resolveBiomeTintMultiplier({
+    desiredHex,
+    type,
+    palette,
+    paletteColors,
+    blockMaterial,
+  });
+
+  assert.ok(multiplier, 'expected a multiplier colour to be returned');
+
+  const neutralColor = new Color(neutralHex);
+  const tintedColor = neutralColor.clone().multiply(multiplier);
+  const finalColor = new Color(
+    neutralColor.r * (1 - strength) + tintedColor.r * strength,
+    neutralColor.g * (1 - strength) + tintedColor.g * strength,
+    neutralColor.b * (1 - strength) + tintedColor.b * strength,
+  );
+  const desiredColor = new Color(desiredHex);
+
+  const tolerance = 1e-4;
+  assert.ok(
+    Math.abs(finalColor.r - desiredColor.r) < tolerance,
+    `expected red channel ${desiredColor.r}, received ${finalColor.r}`,
+  );
+  assert.ok(
+    Math.abs(finalColor.g - desiredColor.g) < tolerance,
+    `expected green channel ${desiredColor.g}, received ${finalColor.g}`,
+  );
+  assert.ok(
+    Math.abs(finalColor.b - desiredColor.b) < tolerance,
+    `expected blue channel ${desiredColor.b}, received ${finalColor.b}`,
+  );
+});
+
+test('resolveBiomeTintMultiplier defaults to white when strength is zero', () => {
+  const type = 'grass';
+  const blockMaterial = {
+    userData: {
+      biomeTintUniforms: {
+        biomeTintStrength: { value: 0 },
+      },
+    },
+  };
+
+  const multiplier = resolveBiomeTintMultiplier({
+    desiredHex: '#abcdef',
+    type,
+    palette: {},
+    paletteColors: {},
+    blockMaterial,
+  });
+
+  assert.equal(multiplier.r, 1);
+  assert.equal(multiplier.g, 1);
+  assert.equal(multiplier.b, 1);
+});

--- a/three-demo/src/world/biomes/README.md
+++ b/three-demo/src/world/biomes/README.md
@@ -29,3 +29,7 @@ Because both levels multiply together, you can clamp the entire biome down and t
 ```
 
 The example above makes the biome 40% lighter overall while keeping flowers close to their original density.
+
+## Palette overrides for `ignoreBiomeTint`
+
+Some voxel libraries expose an `ignoreBiomeTint` flag so that specific blocks render without the biome palette mix. When this flag is set you may now supply a `tint` hex string for each voxel and the renderer will calculate the correct biome tint multiplier so the final shaded colour matches your request. If you omit the `tint` string, the instance keeps the neutral `[1, 1, 1]` multiplier (no extra tint), making it easy to author props that should display their base texture colours untouched.

--- a/three-demo/src/world/color-utils.js
+++ b/three-demo/src/world/color-utils.js
@@ -1,0 +1,82 @@
+import { Color } from 'three';
+
+const DEFAULT_TINT_MULTIPLIER = new Color(1, 1, 1);
+const EPSILON = 1e-6;
+
+function isColor(value) {
+  return Boolean(value && typeof value === 'object' && value.isColor === true);
+}
+
+function computeMultiplierComponent(desired, base, strength) {
+  const safeBase = Math.max(base, EPSILON);
+  const numerator = desired / safeBase - (1 - strength);
+  const result = numerator / strength;
+  if (!Number.isFinite(result)) {
+    return 1;
+  }
+  return Math.max(0, result);
+}
+
+function deriveNeutralBaseColor(type, palette, paletteColors) {
+  const paletteHex = palette?.[type];
+  const paletteTint = paletteColors?.[type];
+
+  if (typeof paletteHex === 'string' && isColor(paletteTint)) {
+    try {
+      const tintedColor = new Color(paletteHex);
+      return new Color(
+        paletteTint.r === 0 ? tintedColor.r : tintedColor.r / Math.max(paletteTint.r, EPSILON),
+        paletteTint.g === 0 ? tintedColor.g : tintedColor.g / Math.max(paletteTint.g, EPSILON),
+        paletteTint.b === 0 ? tintedColor.b : tintedColor.b / Math.max(paletteTint.b, EPSILON),
+      );
+    } catch (error) {
+      console.warn(
+        'Failed to derive neutral base colour for palette entry',
+        type,
+        paletteHex,
+        error,
+      );
+    }
+  }
+
+  return DEFAULT_TINT_MULTIPLIER.clone();
+}
+
+export function resolveBiomeTintMultiplier({
+  desiredHex,
+  type,
+  palette,
+  paletteColors,
+  blockMaterial,
+}) {
+  if (typeof desiredHex !== 'string') {
+    return null;
+  }
+
+  let desiredColor;
+  try {
+    desiredColor = new Color(desiredHex);
+  } catch (error) {
+    console.warn('Invalid desired biome tint override provided:', desiredHex, error);
+    return null;
+  }
+
+  const strength =
+    blockMaterial?.userData?.biomeTintUniforms?.biomeTintStrength?.value ?? 1;
+
+  if (!Number.isFinite(strength) || strength <= 0) {
+    return DEFAULT_TINT_MULTIPLIER.clone();
+  }
+
+  const baseColor = deriveNeutralBaseColor(type, palette, paletteColors);
+
+  const multiplier = new Color(
+    computeMultiplierComponent(desiredColor.r, baseColor.r, strength),
+    computeMultiplierComponent(desiredColor.g, baseColor.g, strength),
+    computeMultiplierComponent(desiredColor.b, baseColor.b, strength),
+  );
+
+  return multiplier;
+}
+
+export { DEFAULT_TINT_MULTIPLIER };

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -14,6 +14,7 @@ import {
   cloneDecorationOptions,
   createDecorationMeshBatches,
 } from './voxel-object-decoration-mesh.js';
+import { resolveBiomeTintMultiplier } from './color-utils.js';
 
 initializeFluidDebug({ defaultEnabled: false, persistDefault: true, forceDefault: true });
 
@@ -324,8 +325,11 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
     const paletteColor = engine.getBlockColor(biome, type);
     const tintStrength = clamp(biome?.shader?.tintStrength ?? 1, 0, 1);
+    const tintHexOverride =
+      typeof options.tint === 'string' ? options.tint : null;
     const tintOverride = parseTintOverride(options.tint);
     const ignoreBiomeTint = options.ignoreBiomeTint === true;
+    const blockMaterial = blockMaterials?.[type];
 
     const paletteBlend = new THREE.Color(1, 1, 1);
     if (!ignoreBiomeTint) {
@@ -359,10 +363,23 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       if (tintOverride) {
         paletteBlend.multiply(tintOverride);
       }
-    } else if (tintOverride) {
-      paletteBlend.copy(tintOverride);
-    } else if (paletteColor) {
-      paletteBlend.copy(paletteColor);
+    } else if (tintHexOverride) {
+      const multiplier = resolveBiomeTintMultiplier({
+        desiredHex: tintHexOverride,
+        type,
+        palette: biome?.palette,
+        paletteColors: biome?.paletteColors,
+        blockMaterial,
+      });
+      if (multiplier) {
+        paletteBlend.copy(multiplier);
+      } else if (tintOverride) {
+        paletteBlend.copy(tintOverride);
+      } else {
+        paletteBlend.setRGB(1, 1, 1);
+      }
+    } else {
+      paletteBlend.setRGB(1, 1, 1);
     }
 
     return {


### PR DESCRIPTION
## Summary
- add a color utility to convert desired ignore-biome tint colors into biome shader multipliers
- use the helper inside world generation so ignoreBiomeTint voxels respect explicit tint overrides or stay neutral by default
- cover the helper with regression tests and document the new authoring workflow for ignoreBiomeTint content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d858813164832aa7b71e2afb92eee3