### PR TITLE
Refactor world settings into shared module

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -4,8 +4,8 @@ import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockCont
 import { createBlockMaterials } from './rendering/textures.js'
 import {
   initializeWorldGeneration,
-  worldConfig,
   terrainHeight,
+  getWorldOptions,
 } from './world/generation.js'
 import { createChunkManager } from './world/chunk-manager.js'
 import { createPlayerControls } from './player/controls.js'
@@ -40,6 +40,8 @@ function setOverlayStatus(message, { isError = false, revealOverlay = true } = {
 
 initializeWorldGeneration({ THREE })
 initializeFluidRegistry({ THREE })
+
+const worldConfig = getWorldOptions()
 
 const scene = new THREE.Scene()
 scene.background = new THREE.Color(0xa9d6ff)

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -1,3 +1,5 @@
+import { getWorldOptions } from '../world/world-settings.js';
+
 function blockKey(x, y, z) {
   return `${x}|${y}|${z}`;
 }
@@ -30,7 +32,7 @@ export function createPlayerControls({
   camera,
   renderer,
   overlay,
-  worldConfig,
+  worldConfig = getWorldOptions(),
   terrainHeight,
   solidBlocks,
   softBlocks,

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1,6 +1,8 @@
 import { renderAsciiViewport } from '../devtools/ascii-viewport.js';
 import { createHeadlessScanner } from '../devtools/headless-scanner.js';
-import { sampleBiomeAt, worldConfig } from '../world/generation.js';
+import { sampleBiomeAt, getWorldOptions } from '../world/generation.js';
+
+const worldConfig = getWorldOptions();
 
 export function registerDeveloperCommands({
   commandConsole,

--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -229,5 +229,8 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
     getDefaultBlockColor() {
       return defaultColor;
     },
+    dispose() {
+      biomes.length = 0;
+    },
   };
 }

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -1,8 +1,10 @@
 import * as THREE from 'three';
 
-import { generateChunk, worldConfig } from './generation.js';
+import { generateChunk, getWorldOptions } from './generation.js';
 import { createFluidSurface, disposeFluidSurface } from './fluids/fluid-registry.js';
 import { buildFluidGeometry } from './fluids/fluid-geometry.js';
+
+const worldConfig = getWorldOptions();
 
 function chunkKey(x, z) {
   return `${x}|${z}`;

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -1,4 +1,5 @@
 import { createHydraWaterMaterial } from './water-material.js';
+import { getWorldOptions } from '../world-settings.js';
 
 let THREERef = null;
 
@@ -40,9 +41,10 @@ export function initializeFluidRegistry({ THREE }) {
       sampleColumnHeight,
       worldConfig,
     }) => {
+      const config = worldConfig ?? getWorldOptions();
       const groundHeight = sampleColumnHeight(x, z);
-      if (groundHeight < worldConfig.waterLevel) {
-        const surfaceY = worldConfig.waterLevel + 0.5;
+      if (groundHeight < config.waterLevel) {
+        const surfaceY = config.waterLevel + 0.5;
         return {
           hasFluid: true,
           surfaceY,
@@ -189,7 +191,14 @@ export function getFluidMaterial(type) {
   return runtime.material;
 }
 
-export function resolveFluidPresence({ type, x, z, sampleColumnHeight, worldConfig }) {
+export function resolveFluidPresence({
+  type,
+  x,
+  z,
+  sampleColumnHeight,
+  worldConfig,
+}) {
+  const config = worldConfig ?? getWorldOptions();
   const definition = fluidDefinitions.get(type);
   if (!definition) {
     const fallbackSurface = sampleColumnHeight(x, z) + 0.5;
@@ -204,7 +213,7 @@ export function resolveFluidPresence({ type, x, z, sampleColumnHeight, worldConf
       x,
       z,
       sampleColumnHeight,
-      worldConfig,
+      worldConfig: config,
     });
   }
   const groundHeight = sampleColumnHeight(x, z);

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -15,6 +15,8 @@ import {
   createDecorationMeshBatches,
 } from './voxel-object-decoration-mesh.js';
 import { resolveBiomeTintMultiplier } from './color-utils.js';
+import { worldOptions, applyWorldOptions } from './world-settings.js';
+export { worldOptions, getWorldOptions } from './world-settings.js';
 
 initializeFluidDebug({ defaultEnabled: false, persistDefault: true, forceDefault: true });
 
@@ -40,26 +42,45 @@ function ensureTerrainEngine() {
   return terrainEngine;
 }
 
-export function initializeWorldGeneration({ THREE }) {
+function disposeTerrainEngineInstance(instance) {
+  if (!instance) {
+    return;
+  }
+  instance.dispose?.();
+  instance.biomeEngine?.dispose?.();
+}
+
+export function initializeWorldGeneration({ THREE, worldOptions: overrides } = {}) {
   if (!THREE) {
     throw new Error('initializeWorldGeneration requires a THREE instance');
   }
-  THREERef = THREE;
-  blockGeometry = new THREE.BoxGeometry(1, 1, 1);
-  terrainEngine = createTerrainEngine({ THREE, seed: 1337, worldConfig });
-}
 
-export const worldConfig = {
-  chunkSize: 48,
-  maxHeight: 20,
-  baseHeight: 6,
-  waterLevel: 9,
-};
+  THREERef = THREE;
+
+  if (overrides) {
+    applyWorldOptions(overrides);
+  }
+
+  if (terrainEngine) {
+    disposeTerrainEngineInstance(terrainEngine);
+  }
+
+  blockGeometry = new THREE.BoxGeometry(1, 1, 1);
+  terrainEngine = createTerrainEngine({
+    THREE,
+    seed: worldOptions.seed,
+    worldConfig: worldOptions,
+  });
+}
 
 export function terrainHeight(x, z) {
   const engine = ensureTerrainEngine();
   const sample = engine.sampleColumn(x, z);
-  return Math.floor(clamp(sample.height, 2, worldConfig.maxHeight));
+  const clampRange =
+    worldOptions.terrain?.clamp ?? { min: 2, max: worldOptions.maxHeight };
+  const minHeight = clampRange.min ?? 2;
+  const maxHeight = clampRange.max ?? worldOptions.maxHeight;
+  return Math.floor(clamp(sample.height, minHeight, maxHeight));
 }
 
 export function sampleBiomeAt(x, z) {
@@ -103,7 +124,7 @@ function addCloud(addBlock, x, y, z) {
 }
 
 function chunkWorldBounds(chunkX, chunkZ) {
-  const { chunkSize } = worldConfig;
+  const { chunkSize } = worldOptions;
   const halfSize = chunkSize / 2;
   return {
     minX: chunkX * chunkSize - halfSize,
@@ -145,7 +166,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   let prototypeInstanceCounter = 0;
 
   const { minX, minZ } = chunkWorldBounds(chunkX, chunkZ);
-  const { chunkSize, waterLevel } = worldConfig;
+  const { chunkSize, waterLevel } = worldOptions;
 
   const columnSampleCache = new Map();
 
@@ -163,7 +184,11 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
   const getColumnHeight = (x, z) => {
     const sample = sampleColumnCached(x, z);
-    return Math.floor(clamp(sample.height, 2, worldConfig.maxHeight));
+    const clampRange =
+      worldOptions.terrain?.clamp ?? { min: 2, max: worldOptions.maxHeight };
+    const minHeight = clampRange.min ?? 2;
+    const maxHeight = clampRange.max ?? worldOptions.maxHeight;
+    return Math.floor(clamp(sample.height, minHeight, maxHeight));
   };
 
   const computeSlope = (x, z, baseHeight) => {
@@ -350,7 +375,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         paletteBlend.multiply(climateBlend);
       }
 
-      const altitudeRange = Math.max(1, worldConfig.maxHeight - waterLevel + 6);
+      const altitudeRange = Math.max(1, worldOptions.maxHeight - waterLevel + 6);
       const altitude = clamp((y - waterLevel + 2) / altitudeRange, -0.25, 1);
       const altitudeBlend = new THREE.Color(1, 1, 1);
       if (altitude > 0) {
@@ -977,7 +1002,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
             x: nx,
             z: nz,
             sampleColumnHeight: getColumnHeight,
-            worldConfig,
+            worldConfig: worldOptions,
           });
           neighborInfo = {
             hasFluid: Boolean(presence?.hasFluid),
@@ -1102,7 +1127,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
           minZ: chunkZ * chunkSize - halfSize - 0.5,
           maxZ: chunkZ * chunkSize + halfSize + 0.5,
           minY: -32,
-          maxY: worldConfig.maxHeight + 32,
+          maxY: worldOptions.maxHeight + 32,
         };
       }
       return {

--- a/three-demo/src/world/terrain-engine.js
+++ b/three-demo/src/world/terrain-engine.js
@@ -42,5 +42,8 @@ export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {
     getBlockColor: (biome, type) => biomeEngine.getBlockColor(biome, type),
     getDefaultBlockColor: () => biomeEngine.getDefaultBlockColor(),
     biomeEngine,
+    dispose() {
+      biomeEngine.dispose?.();
+    },
   };
 }

--- a/three-demo/src/world/world-settings.js
+++ b/three-demo/src/world/world-settings.js
@@ -1,0 +1,161 @@
+const defaultTerrainClamp = Object.freeze({
+  min: 2,
+  max: 20,
+})
+
+export const defaultWorldOptions = Object.freeze({
+  seed: 1337,
+  chunkSize: 48,
+  baseHeight: 6,
+  maxHeight: 20,
+  waterLevel: 9,
+  chunk: Object.freeze({
+    size: 48,
+  }),
+  water: Object.freeze({
+    level: 9,
+  }),
+  terrain: Object.freeze({
+    baseHeight: 6,
+    maxHeight: 20,
+    clamp: defaultTerrainClamp,
+  }),
+  biome: Object.freeze({
+    climateScale: 0.003,
+    detailScaleMultiplier: 2.15,
+    varianceScaleMultiplier: 0.45,
+  }),
+})
+
+function createMutableWorldOptions() {
+  return {
+    seed: defaultWorldOptions.seed,
+    chunkSize: defaultWorldOptions.chunkSize,
+    baseHeight: defaultWorldOptions.baseHeight,
+    maxHeight: defaultWorldOptions.maxHeight,
+    waterLevel: defaultWorldOptions.waterLevel,
+    chunk: { size: defaultWorldOptions.chunk.size },
+    water: { level: defaultWorldOptions.water.level },
+    terrain: {
+      baseHeight: defaultWorldOptions.terrain.baseHeight,
+      maxHeight: defaultWorldOptions.terrain.maxHeight,
+      clamp: { ...defaultWorldOptions.terrain.clamp },
+    },
+    biome: { ...defaultWorldOptions.biome },
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object'
+}
+
+function normalizeNumber(value, fallback) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  return value
+}
+
+export const worldOptions = createMutableWorldOptions()
+
+export function getWorldOptions() {
+  return worldOptions
+}
+
+export function applyWorldOptions(overrides = {}) {
+  if (!isObject(overrides)) {
+    return worldOptions
+  }
+
+  if ('seed' in overrides) {
+    worldOptions.seed = normalizeNumber(overrides.seed, worldOptions.seed)
+  }
+
+  const chunkOverrides = isObject(overrides.chunk) ? overrides.chunk : null
+  const resolvedChunkSize = normalizeNumber(
+    chunkOverrides?.size ?? overrides.chunkSize,
+    null,
+  )
+  if (resolvedChunkSize !== null) {
+    const size = Math.max(1, Math.floor(resolvedChunkSize))
+    worldOptions.chunkSize = size
+    worldOptions.chunk.size = size
+  }
+
+  const terrainOverrides = isObject(overrides.terrain) ? overrides.terrain : null
+
+  const resolvedBaseHeight = normalizeNumber(
+    terrainOverrides?.baseHeight ?? overrides.baseHeight,
+    null,
+  )
+  if (resolvedBaseHeight !== null) {
+    worldOptions.baseHeight = resolvedBaseHeight
+    worldOptions.terrain.baseHeight = resolvedBaseHeight
+  }
+
+  const resolvedMaxHeight = normalizeNumber(
+    terrainOverrides?.maxHeight ?? overrides.maxHeight,
+    null,
+  )
+  if (resolvedMaxHeight !== null) {
+    worldOptions.maxHeight = resolvedMaxHeight
+    worldOptions.terrain.maxHeight = resolvedMaxHeight
+    worldOptions.terrain.clamp.max = resolvedMaxHeight
+  }
+
+  const clampOverrides = isObject(terrainOverrides?.clamp)
+    ? terrainOverrides.clamp
+    : null
+  const resolvedClampMin = normalizeNumber(clampOverrides?.min, null)
+  if (resolvedClampMin !== null) {
+    worldOptions.terrain.clamp.min = resolvedClampMin
+  }
+  const resolvedClampMax = normalizeNumber(clampOverrides?.max, null)
+  if (resolvedClampMax !== null) {
+    worldOptions.terrain.clamp.max = resolvedClampMax
+    worldOptions.maxHeight = Math.max(worldOptions.maxHeight, resolvedClampMax)
+  }
+
+  const waterOverrides = isObject(overrides.water) ? overrides.water : null
+  const resolvedWaterLevel = normalizeNumber(
+    waterOverrides?.level ?? overrides.waterLevel,
+    null,
+  )
+  if (resolvedWaterLevel !== null) {
+    worldOptions.waterLevel = resolvedWaterLevel
+    worldOptions.water.level = resolvedWaterLevel
+  }
+
+  if ('biome' in overrides && isObject(overrides.biome)) {
+    Object.entries(overrides.biome).forEach(([key, value]) => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        worldOptions.biome[key] = value
+      }
+    })
+  }
+
+  return worldOptions
+}
+
+export function resetWorldOptions() {
+  const fresh = createMutableWorldOptions()
+
+  worldOptions.seed = fresh.seed
+  worldOptions.chunkSize = fresh.chunkSize
+  worldOptions.baseHeight = fresh.baseHeight
+  worldOptions.maxHeight = fresh.maxHeight
+  worldOptions.waterLevel = fresh.waterLevel
+
+  Object.assign(worldOptions.chunk, fresh.chunk)
+  Object.assign(worldOptions.water, fresh.water)
+  Object.assign(worldOptions.terrain, fresh.terrain)
+  worldOptions.terrain.clamp.min = fresh.terrain.clamp.min
+  worldOptions.terrain.clamp.max = fresh.terrain.clamp.max
+
+  Object.keys(worldOptions.biome).forEach((key) => {
+    delete worldOptions.biome[key]
+  })
+  Object.assign(worldOptions.biome, fresh.biome)
+
+  return worldOptions
+}


### PR DESCRIPTION
## Summary
- add `world/world-settings.js` with mutable world options helpers for applying and resetting overrides
- update world generation and terrain/biome engines to reuse the live options object and dispose previous engine instances during reinitialization
- switch main loop, player controls/dev commands, chunk manager, and fluid registry to read configuration through `getWorldOptions()` so they stay in sync with runtime changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d864ee4258832a984835b14fcb767f