### PR TITLE
Expose biome tuning knobs for terrain generation

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -1,4 +1,5 @@
 import { ValueNoise2D } from './noise.js';
+import { defaultWorldOptions, biomeOptionMetadata } from './world-settings.js';
 
 import temperate from './biomes/temperate.json' with { type: 'json' };
 import desert from './biomes/desert.json' with { type: 'json' };
@@ -51,6 +52,22 @@ function normalizeMultiplier(value, fallback = 1) {
   return Math.max(0, value);
 }
 
+function resolveBiomeOption(option, value) {
+  const defaults = defaultWorldOptions.biomes;
+  const fallback = defaults[option];
+  const metadata = biomeOptionMetadata[option] ?? {};
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  const min = Number.isFinite(metadata.min) ? metadata.min : Number.NEGATIVE_INFINITY;
+  const max = Number.isFinite(metadata.max) ? metadata.max : Number.POSITIVE_INFINITY;
+  const clamped = Math.min(Math.max(value, min), max);
+  if (option === 'scale' && clamped === 0) {
+    return fallback;
+  }
+  return clamped;
+}
+
 function normalizeCategoryMultipliers(definition) {
   if (!definition || typeof definition !== 'object' || Array.isArray(definition)) {
     return {};
@@ -62,7 +79,7 @@ function normalizeCategoryMultipliers(definition) {
   );
 }
 
-export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
+export function createBiomeEngine({ THREE, seed = 1337, biomeOptions = null } = {}) {
   if (!THREE) {
     throw new Error('createBiomeEngine requires a THREE instance');
   }
@@ -73,9 +90,26 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
   const moistureDetailNoise = new ValueNoise2D(seed * 2.03 + 311);
   const varianceNoise = new ValueNoise2D(seed * 1.73 + 443);
 
-  const climateScale = 0.003;
-  const detailScale = climateScale * 2.15;
-  const varianceScale = climateScale * 0.45;
+  const climateScale = resolveBiomeOption('scale', biomeOptions?.scale);
+  const detailMultiplier = resolveBiomeOption(
+    'detailMultiplier',
+    biomeOptions?.detailMultiplier,
+  );
+  const moistureDetailMultiplier = resolveBiomeOption(
+    'moistureDetailMultiplier',
+    biomeOptions?.moistureDetailMultiplier,
+  );
+  const varianceMultiplier = resolveBiomeOption(
+    'varianceMultiplier',
+    biomeOptions?.varianceMultiplier,
+  );
+  const variationStrength = resolveBiomeOption(
+    'variationStrength',
+    biomeOptions?.variationStrength,
+  );
+
+  const detailScale = climateScale * detailMultiplier;
+  const varianceScale = climateScale * varianceMultiplier;
 
   const defaultColor = new THREE.Color(0xffffff);
   const basePaletteColors = Object.fromEntries(
@@ -176,7 +210,7 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
       x,
       z,
       climateScale,
-      detailScale * 1.18,
+      detailScale * moistureDetailMultiplier,
     );
 
     return { temperature, moisture };
@@ -194,7 +228,7 @@ export function createBiomeEngine({ THREE, seed = 1337 } = {}) {
         x * varianceScale + index * 17.13,
         z * varianceScale + index * 31.17,
       );
-      const adjustedDistance = distance - (variation - 0.5) * 0.18;
+      const adjustedDistance = distance - (variation - 0.5) * variationStrength;
       if (adjustedDistance < bestScore) {
         bestScore = adjustedDistance;
         selected = biome;

--- a/three-demo/src/world/terrain-engine.js
+++ b/three-demo/src/world/terrain-engine.js
@@ -15,7 +15,11 @@ export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {
   const detailNoise = new ValueNoise2D(seed * 1.59 + 139);
   const ridgeNoise = new ValueNoise2D(seed * 2.03 + 211);
 
-  const biomeEngine = createBiomeEngine({ THREE, seed: seed * 1.37 + 19 });
+  const biomeEngine = createBiomeEngine({
+    THREE,
+    seed: seed * 1.37 + 19,
+    biomeOptions: worldConfig.biomes,
+  });
 
   function computeElevation(x, z) {
     const n1 = elevationNoise.noise(x * 0.06, z * 0.06);

--- a/three-demo/src/world/world-settings.js
+++ b/three-demo/src/world/world-settings.js
@@ -3,6 +3,52 @@ const defaultTerrainClamp = Object.freeze({
   max: 20,
 })
 
+const defaultBiomeTuning = Object.freeze({
+  scale: 0.003,
+  detailMultiplier: 2.15,
+  moistureDetailMultiplier: 1.18,
+  varianceMultiplier: 0.45,
+  variationStrength: 0.18,
+})
+
+export const biomeOptionMetadata = Object.freeze({
+  scale: Object.freeze({
+    default: defaultBiomeTuning.scale,
+    min: 0.0005,
+    max: 0.02,
+    description:
+      'Base frequency for the temperature/moisture noise fields. Lower values produce larger biome continents.',
+  }),
+  detailMultiplier: Object.freeze({
+    default: defaultBiomeTuning.detailMultiplier,
+    min: 0.1,
+    max: 10,
+    description:
+      'Multiplier applied to the base scale for secondary climate detail noise.',
+  }),
+  moistureDetailMultiplier: Object.freeze({
+    default: defaultBiomeTuning.moistureDetailMultiplier,
+    min: 0.1,
+    max: 4,
+    description:
+      'Multiplier that adjusts the moisture detail scale relative to the temperature field.',
+  }),
+  varianceMultiplier: Object.freeze({
+    default: defaultBiomeTuning.varianceMultiplier,
+    min: 0,
+    max: 2,
+    description:
+      'Controls how strongly biome variance noise distorts the climate map.',
+  }),
+  variationStrength: Object.freeze({
+    default: defaultBiomeTuning.variationStrength,
+    min: 0,
+    max: 1,
+    description:
+      'Strength of the random jitter applied when selecting the closest biome.',
+  }),
+})
+
 export const defaultWorldOptions = Object.freeze({
   seed: 1337,
   chunkSize: 48,
@@ -20,11 +66,7 @@ export const defaultWorldOptions = Object.freeze({
     maxHeight: 20,
     clamp: defaultTerrainClamp,
   }),
-  biome: Object.freeze({
-    climateScale: 0.003,
-    detailScaleMultiplier: 2.15,
-    varianceScaleMultiplier: 0.45,
-  }),
+  biomes: defaultBiomeTuning,
 })
 
 function createMutableWorldOptions() {
@@ -41,7 +83,7 @@ function createMutableWorldOptions() {
       maxHeight: defaultWorldOptions.terrain.maxHeight,
       clamp: { ...defaultWorldOptions.terrain.clamp },
     },
-    biome: { ...defaultWorldOptions.biome },
+    biomes: { ...defaultWorldOptions.biomes },
   }
 }
 
@@ -126,10 +168,14 @@ export function applyWorldOptions(overrides = {}) {
     worldOptions.water.level = resolvedWaterLevel
   }
 
-  if ('biome' in overrides && isObject(overrides.biome)) {
-    Object.entries(overrides.biome).forEach(([key, value]) => {
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        worldOptions.biome[key] = value
+  if ('biomes' in overrides && isObject(overrides.biomes)) {
+    Object.entries(overrides.biomes).forEach(([key, value]) => {
+      if (
+        Object.prototype.hasOwnProperty.call(worldOptions.biomes, key) &&
+        typeof value === 'number' &&
+        Number.isFinite(value)
+      ) {
+        worldOptions.biomes[key] = value
       }
     })
   }
@@ -152,10 +198,10 @@ export function resetWorldOptions() {
   worldOptions.terrain.clamp.min = fresh.terrain.clamp.min
   worldOptions.terrain.clamp.max = fresh.terrain.clamp.max
 
-  Object.keys(worldOptions.biome).forEach((key) => {
-    delete worldOptions.biome[key]
+  Object.keys(worldOptions.biomes).forEach((key) => {
+    delete worldOptions.biomes[key]
   })
-  Object.assign(worldOptions.biome, fresh.biome)
+  Object.assign(worldOptions.biomes, fresh.biomes)
 
   return worldOptions
 }


### PR DESCRIPTION
## Summary
- add documented biome tuning defaults to the world options module for future GUI use
- clamp biome noise parameters using configurable options within the biome engine
- forward world biome configuration into the terrain engine

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d868f9e578832a9178369f7e01e6d7