### PR TITLE
Add terrain tuning knobs to world options

### DIFF
--- a/three-demo/src/world/terrain-engine.js
+++ b/three-demo/src/world/terrain-engine.js
@@ -1,14 +1,70 @@
 import { ValueNoise2D } from './noise.js';
 import { createBiomeEngine } from './biome-engine.js';
+import { defaultWorldOptions } from './world-settings.js';
 
 export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {}) {
   if (!THREE) {
     throw new Error('createTerrainEngine requires a THREE instance');
   }
 
+  const defaults = defaultWorldOptions.terrain;
+  const terrainConfig = worldConfig.terrain ?? {};
+
+  const baseHeight = Number.isFinite(worldConfig.baseHeight)
+    ? worldConfig.baseHeight
+    : Number.isFinite(terrainConfig.baseHeight)
+      ? terrainConfig.baseHeight
+      : defaults.baseHeight;
+
+  const maxHeight = Number.isFinite(worldConfig.maxHeight)
+    ? worldConfig.maxHeight
+    : Number.isFinite(terrainConfig.maxHeight)
+      ? terrainConfig.maxHeight
+      : defaults.maxHeight;
+
   const config = {
-    baseHeight: worldConfig.baseHeight ?? 6,
-    maxHeight: worldConfig.maxHeight ?? 20,
+    baseHeight,
+    maxHeight,
+    primaryFrequency:
+      Number.isFinite(terrainConfig.primaryFrequency)
+        ? terrainConfig.primaryFrequency
+        : defaults.primaryFrequency,
+    primaryAmplitude:
+      Number.isFinite(terrainConfig.primaryAmplitude)
+        ? terrainConfig.primaryAmplitude
+        : defaults.primaryAmplitude,
+    primaryOffset:
+      Number.isFinite(terrainConfig.primaryOffset)
+        ? terrainConfig.primaryOffset
+        : defaults.primaryOffset,
+    detailFrequency:
+      Number.isFinite(terrainConfig.detailFrequency)
+        ? terrainConfig.detailFrequency
+        : defaults.detailFrequency,
+    detailAmplitude:
+      Number.isFinite(terrainConfig.detailAmplitude)
+        ? terrainConfig.detailAmplitude
+        : defaults.detailAmplitude,
+    detailOffset:
+      Number.isFinite(terrainConfig.detailOffset)
+        ? terrainConfig.detailOffset
+        : defaults.detailOffset,
+    ridgeFrequency:
+      Number.isFinite(terrainConfig.ridgeFrequency)
+        ? terrainConfig.ridgeFrequency
+        : defaults.ridgeFrequency,
+    ridgeStrength:
+      Number.isFinite(terrainConfig.ridgeStrength)
+        ? terrainConfig.ridgeStrength
+        : defaults.ridgeStrength,
+    ridgeOffset:
+      Number.isFinite(terrainConfig.ridgeOffset)
+        ? terrainConfig.ridgeOffset
+        : defaults.ridgeOffset,
+    climateHeightInfluence:
+      Number.isFinite(terrainConfig.climateHeightInfluence)
+        ? terrainConfig.climateHeightInfluence
+        : defaults.climateHeightInfluence,
   };
 
   const elevationNoise = new ValueNoise2D(seed * 1.11 + 67);
@@ -22,17 +78,32 @@ export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {
   });
 
   function computeElevation(x, z) {
-    const n1 = elevationNoise.noise(x * 0.06, z * 0.06);
-    const n2 = detailNoise.noise(x * 0.12 + 100, z * 0.12 + 100);
-    const ridges = ridgeNoise.noise(x * 0.02 + 220, z * 0.02 + 220);
-    const ridgeInfluence = (ridges - 0.5) * 2.4;
-    return config.baseHeight + n1 * 8 + n2 * 3 + ridgeInfluence;
+    const n1 = elevationNoise.noise(
+      x * config.primaryFrequency + config.primaryOffset,
+      z * config.primaryFrequency + config.primaryOffset,
+    );
+    const n2 = detailNoise.noise(
+      x * config.detailFrequency + config.detailOffset,
+      z * config.detailFrequency + config.detailOffset,
+    );
+    const ridges = ridgeNoise.noise(
+      x * config.ridgeFrequency + config.ridgeOffset,
+      z * config.ridgeFrequency + config.ridgeOffset,
+    );
+    const ridgeInfluence = (ridges - 0.5) * config.ridgeStrength;
+    return (
+      config.baseHeight +
+      n1 * config.primaryAmplitude +
+      n2 * config.detailAmplitude +
+      ridgeInfluence
+    );
   }
 
   function sampleColumn(x, z) {
     const biomeSample = biomeEngine.getBiomeAt(x, z);
     let height = computeElevation(x, z);
-    const climateAdjustment = (biomeSample.climate.moisture - 0.5) * 1.2;
+    const climateAdjustment =
+      (biomeSample.climate.moisture - 0.5) * config.climateHeightInfluence;
     height += climateAdjustment + (biomeSample.biome.terrain.heightOffset ?? 0);
     return {
       ...biomeSample,

--- a/three-demo/src/world/world-settings.js
+++ b/three-demo/src/world/world-settings.js
@@ -3,6 +3,22 @@ const defaultTerrainClamp = Object.freeze({
   max: 20,
 })
 
+const defaultTerrainOptions = Object.freeze({
+  baseHeight: 6,
+  maxHeight: 20,
+  clamp: defaultTerrainClamp,
+  primaryFrequency: 0.06,
+  primaryAmplitude: 8,
+  primaryOffset: 0,
+  detailFrequency: 0.12,
+  detailAmplitude: 3,
+  detailOffset: 100,
+  ridgeFrequency: 0.02,
+  ridgeStrength: 2.4,
+  ridgeOffset: 220,
+  climateHeightInfluence: 1.2,
+})
+
 const defaultBiomeTuning = Object.freeze({
   scale: 0.003,
   detailMultiplier: 2.15,
@@ -52,8 +68,8 @@ export const biomeOptionMetadata = Object.freeze({
 export const defaultWorldOptions = Object.freeze({
   seed: 1337,
   chunkSize: 48,
-  baseHeight: 6,
-  maxHeight: 20,
+  baseHeight: defaultTerrainOptions.baseHeight,
+  maxHeight: defaultTerrainOptions.maxHeight,
   waterLevel: 9,
   chunk: Object.freeze({
     size: 48,
@@ -61,11 +77,7 @@ export const defaultWorldOptions = Object.freeze({
   water: Object.freeze({
     level: 9,
   }),
-  terrain: Object.freeze({
-    baseHeight: 6,
-    maxHeight: 20,
-    clamp: defaultTerrainClamp,
-  }),
+  terrain: defaultTerrainOptions,
   biomes: defaultBiomeTuning,
 })
 
@@ -79,9 +91,19 @@ function createMutableWorldOptions() {
     chunk: { size: defaultWorldOptions.chunk.size },
     water: { level: defaultWorldOptions.water.level },
     terrain: {
-      baseHeight: defaultWorldOptions.terrain.baseHeight,
-      maxHeight: defaultWorldOptions.terrain.maxHeight,
-      clamp: { ...defaultWorldOptions.terrain.clamp },
+      baseHeight: defaultTerrainOptions.baseHeight,
+      maxHeight: defaultTerrainOptions.maxHeight,
+      clamp: { ...defaultTerrainOptions.clamp },
+      primaryFrequency: defaultTerrainOptions.primaryFrequency,
+      primaryAmplitude: defaultTerrainOptions.primaryAmplitude,
+      primaryOffset: defaultTerrainOptions.primaryOffset,
+      detailFrequency: defaultTerrainOptions.detailFrequency,
+      detailAmplitude: defaultTerrainOptions.detailAmplitude,
+      detailOffset: defaultTerrainOptions.detailOffset,
+      ridgeFrequency: defaultTerrainOptions.ridgeFrequency,
+      ridgeStrength: defaultTerrainOptions.ridgeStrength,
+      ridgeOffset: defaultTerrainOptions.ridgeOffset,
+      climateHeightInfluence: defaultTerrainOptions.climateHeightInfluence,
     },
     biomes: { ...defaultWorldOptions.biomes },
   }
@@ -96,6 +118,38 @@ function normalizeNumber(value, fallback) {
     return fallback
   }
   return value
+}
+
+const TERRAIN_OPTION_BOUNDS = Object.freeze({
+  baseHeight: Object.freeze({ min: 0, max: 512 }),
+  maxHeight: Object.freeze({ min: 1, max: 1024 }),
+  clampMin: Object.freeze({ min: 0, max: 1024 }),
+  clampMax: Object.freeze({ min: 1, max: 1024 }),
+  primaryFrequency: Object.freeze({ min: 0.0001, max: 1 }),
+  primaryAmplitude: Object.freeze({ min: 0, max: 256 }),
+  primaryOffset: Object.freeze({ min: -10000, max: 10000 }),
+  detailFrequency: Object.freeze({ min: 0.0001, max: 2 }),
+  detailAmplitude: Object.freeze({ min: 0, max: 128 }),
+  detailOffset: Object.freeze({ min: -10000, max: 10000 }),
+  ridgeFrequency: Object.freeze({ min: 0.0001, max: 1 }),
+  ridgeStrength: Object.freeze({ min: 0, max: 64 }),
+  ridgeOffset: Object.freeze({ min: -10000, max: 10000 }),
+  climateHeightInfluence: Object.freeze({ min: -10, max: 10 }),
+})
+
+function normalizeWithBounds(value, fallback, boundsKey) {
+  const bounds = TERRAIN_OPTION_BOUNDS[boundsKey] ?? {}
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  let normalized = value
+  if (Number.isFinite(bounds.min)) {
+    normalized = Math.max(bounds.min, normalized)
+  }
+  if (Number.isFinite(bounds.max)) {
+    normalized = Math.min(bounds.max, normalized)
+  }
+  return normalized
 }
 
 export const worldOptions = createMutableWorldOptions()
@@ -131,8 +185,13 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedBaseHeight !== null) {
-    worldOptions.baseHeight = resolvedBaseHeight
-    worldOptions.terrain.baseHeight = resolvedBaseHeight
+    const baseHeight = normalizeWithBounds(
+      resolvedBaseHeight,
+      worldOptions.terrain.baseHeight,
+      'baseHeight',
+    )
+    worldOptions.baseHeight = baseHeight
+    worldOptions.terrain.baseHeight = baseHeight
   }
 
   const resolvedMaxHeight = normalizeNumber(
@@ -140,9 +199,17 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedMaxHeight !== null) {
-    worldOptions.maxHeight = resolvedMaxHeight
-    worldOptions.terrain.maxHeight = resolvedMaxHeight
-    worldOptions.terrain.clamp.max = resolvedMaxHeight
+    const maxHeight = normalizeWithBounds(
+      resolvedMaxHeight,
+      worldOptions.terrain.maxHeight,
+      'maxHeight',
+    )
+    worldOptions.maxHeight = maxHeight
+    worldOptions.terrain.maxHeight = maxHeight
+    worldOptions.terrain.clamp.max = Math.max(
+      worldOptions.terrain.clamp.max,
+      maxHeight,
+    )
   }
 
   const clampOverrides = isObject(terrainOverrides?.clamp)
@@ -150,13 +217,106 @@ export function applyWorldOptions(overrides = {}) {
     : null
   const resolvedClampMin = normalizeNumber(clampOverrides?.min, null)
   if (resolvedClampMin !== null) {
-    worldOptions.terrain.clamp.min = resolvedClampMin
+    worldOptions.terrain.clamp.min = normalizeWithBounds(
+      resolvedClampMin,
+      worldOptions.terrain.clamp.min,
+      'clampMin',
+    )
   }
   const resolvedClampMax = normalizeNumber(clampOverrides?.max, null)
   if (resolvedClampMax !== null) {
-    worldOptions.terrain.clamp.max = resolvedClampMax
-    worldOptions.maxHeight = Math.max(worldOptions.maxHeight, resolvedClampMax)
+    const clampMax = normalizeWithBounds(
+      resolvedClampMax,
+      worldOptions.terrain.clamp.max,
+      'clampMax',
+    )
+    worldOptions.terrain.clamp.max = clampMax
+    worldOptions.maxHeight = Math.max(worldOptions.maxHeight, clampMax)
   }
+
+  const terrainOptionKeys = [
+    'primaryFrequency',
+    'primaryAmplitude',
+    'primaryOffset',
+    'detailFrequency',
+    'detailAmplitude',
+    'detailOffset',
+    'ridgeFrequency',
+    'ridgeStrength',
+    'ridgeOffset',
+    'climateHeightInfluence',
+  ]
+
+  terrainOptionKeys.forEach((key) => {
+    if (key in (terrainOverrides ?? {})) {
+      worldOptions.terrain[key] = normalizeWithBounds(
+        terrainOverrides[key],
+        worldOptions.terrain[key],
+        key,
+      )
+    }
+  })
+
+  worldOptions.baseHeight = normalizeWithBounds(
+    worldOptions.baseHeight,
+    defaultTerrainOptions.baseHeight,
+    'baseHeight',
+  )
+  worldOptions.terrain.baseHeight = worldOptions.baseHeight
+
+  const minimumMaxHeight = Math.max(
+    worldOptions.baseHeight,
+    worldOptions.terrain.baseHeight,
+  )
+  worldOptions.terrain.maxHeight = Math.max(
+    normalizeWithBounds(
+      worldOptions.terrain.maxHeight,
+      defaultTerrainOptions.maxHeight,
+      'maxHeight',
+    ),
+    minimumMaxHeight,
+  )
+  worldOptions.maxHeight = Math.max(
+    normalizeWithBounds(
+      worldOptions.maxHeight,
+      defaultTerrainOptions.maxHeight,
+      'maxHeight',
+    ),
+    worldOptions.terrain.maxHeight,
+  )
+
+  const ridgeContribution = Math.max(0, worldOptions.terrain.ridgeStrength)
+  const estimatedTerrainMax =
+    worldOptions.terrain.baseHeight +
+    worldOptions.terrain.primaryAmplitude +
+    worldOptions.terrain.detailAmplitude +
+    ridgeContribution
+
+  if (worldOptions.terrain.maxHeight < estimatedTerrainMax) {
+    worldOptions.terrain.maxHeight = estimatedTerrainMax
+  }
+  if (worldOptions.maxHeight < estimatedTerrainMax) {
+    worldOptions.maxHeight = estimatedTerrainMax
+  }
+
+  worldOptions.terrain.clamp.min = normalizeWithBounds(
+    worldOptions.terrain.clamp.min,
+    defaultTerrainOptions.clamp.min,
+    'clampMin',
+  )
+  worldOptions.terrain.clamp.max = Math.max(
+    normalizeWithBounds(
+      worldOptions.terrain.clamp.max,
+      defaultTerrainOptions.clamp.max,
+      'clampMax',
+    ),
+    worldOptions.terrain.clamp.min,
+    worldOptions.maxHeight,
+  )
+  worldOptions.maxHeight = Math.max(
+    worldOptions.maxHeight,
+    worldOptions.terrain.clamp.max,
+  )
 
   const waterOverrides = isObject(overrides.water) ? overrides.water : null
   const resolvedWaterLevel = normalizeNumber(


### PR DESCRIPTION
## Summary
- add detailed terrain noise controls (frequency, amplitude, offsets, climate influence) to the default world options and mutable copy
- normalize new terrain overrides and keep derived max-height/clamp values in sync so downstream systems stay within bounds
- drive terrain engine noise sampling and climate adjustments directly from the sanitized configuration values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87f0d4420832aab8becb9de5f3296