### PR TITLE
Seed-aware world generation

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -79,7 +79,11 @@ function normalizeCategoryMultipliers(definition) {
   );
 }
 
-export function createBiomeEngine({ THREE, seed = 1337, biomeOptions = null } = {}) {
+export function createBiomeEngine({
+  THREE,
+  seed = defaultWorldOptions.seedHash,
+  biomeOptions = null,
+} = {}) {
   if (!THREE) {
     throw new Error('createBiomeEngine requires a THREE instance');
   }

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1,5 +1,8 @@
 import { createTerrainEngine } from './terrain-engine.js';
-import { populateColumnWithVoxelObjects } from './voxel-object-placement.js';
+import {
+  configureVoxelObjectPlacement,
+  populateColumnWithVoxelObjects,
+} from './voxel-object-placement.js';
 import {
   createFluidSurface,
   isFluidType,
@@ -16,6 +19,7 @@ import {
 } from './voxel-object-decoration-mesh.js';
 import { resolveBiomeTintMultiplier } from './color-utils.js';
 import { worldOptions, applyWorldOptions } from './world-settings.js';
+import { configureSectorObjectPlanner } from './sector-object-planner.js';
 export { worldOptions, getWorldOptions } from './world-settings.js';
 
 initializeFluidDebug({ defaultEnabled: false, persistDefault: true, forceDefault: true });
@@ -27,6 +31,7 @@ function clamp(value, min, max) {
 let THREERef = null;
 let blockGeometry = null;
 let terrainEngine = null;
+let worldSeedHash = worldOptions.seedHash >>> 0;
 
 function ensureThree() {
   if (!THREERef) {
@@ -61,6 +66,8 @@ export function initializeWorldGeneration({ THREE, worldOptions: overrides } = {
     applyWorldOptions(overrides);
   }
 
+  worldSeedHash = worldOptions.seedHash >>> 0;
+
   if (terrainEngine) {
     disposeTerrainEngineInstance(terrainEngine);
   }
@@ -68,9 +75,11 @@ export function initializeWorldGeneration({ THREE, worldOptions: overrides } = {
   blockGeometry = new THREE.BoxGeometry(1, 1, 1);
   terrainEngine = createTerrainEngine({
     THREE,
-    seed: worldOptions.seed,
+    seed: worldSeedHash,
     worldConfig: worldOptions,
   });
+  configureVoxelObjectPlacement({ seedHash: worldSeedHash });
+  configureSectorObjectPlanner({ seedHash: worldSeedHash });
 }
 
 export function terrainHeight(x, z) {
@@ -88,19 +97,27 @@ export function sampleBiomeAt(x, z) {
   return engine.getBiomeAt(x, z);
 }
 
-function hashCoordinate(x, z, offset = 0) {
-  let h = Math.imul(x | 0, 374761393);
-  h = Math.imul(h + Math.imul(z | 0, 668265263), 1274126177);
+function hashCoordinate(x, z, offset = 0, seed = worldSeedHash) {
+  const seedLow = seed & 0xffff;
+  const seedHigh = (seed >>> 16) & 0xffff;
+  let h = Math.imul((x | 0) ^ (seedLow || 1), 374761393);
+  h = Math.imul(h + Math.imul((z | 0) ^ (seedHigh || 1), 668265263), 1274126177);
   h ^= h >>> 15;
-  h = Math.imul(h + Math.imul(offset | 0, 1597334677), 2246822519);
+  const seedMix = ((seed >>> 1) | 1) & 0x7fffffff;
+  h = Math.imul(h + Math.imul((offset | 0) ^ seedMix, 1597334677), 2246822519);
   h ^= h >>> 13;
-  h = Math.imul(h, 3266489917);
+  h = Math.imul(h ^ seed, 3266489917);
   h ^= h >>> 16;
   return h >>> 0;
 }
 
 export function randomAt(x, z, offset = 0) {
-  const hashed = hashCoordinate(Math.floor(x), Math.floor(z), Math.floor(offset));
+  const hashed = hashCoordinate(
+    Math.floor(x),
+    Math.floor(z),
+    Math.floor(offset),
+    worldSeedHash,
+  );
   return hashed / 4294967296;
 }
 

--- a/three-demo/src/world/sector-object-planner.js
+++ b/three-demo/src/world/sector-object-planner.js
@@ -1,4 +1,42 @@
 const SECTOR_SIZE = 32;
+const DEFAULT_PLANNER_SEED = 1337;
+const MAX_16_BIT = 0xffff;
+
+const sectorCache = new Map();
+
+let plannerSeedHash = DEFAULT_PLANNER_SEED >>> 0;
+let pseudoAngleScale = 157.31;
+let pseudoAxisScale = 311.7;
+let pseudoOffsetScale = 37.912;
+let pseudoBias = 0;
+
+function normalize16Bit(value) {
+  return (value & MAX_16_BIT) / MAX_16_BIT;
+}
+
+function updatePlannerSeed(hash) {
+  plannerSeedHash = hash >>> 0;
+  const low = normalize16Bit(plannerSeedHash);
+  const high = normalize16Bit(plannerSeedHash >>> 16);
+  const mix = plannerSeedHash ^ 0x9e3779b9;
+  const mixLow = normalize16Bit(mix);
+  const mixHigh = normalize16Bit(mix >>> 16);
+  pseudoAngleScale = 157.31 + 0.17 + low * 0.83;
+  pseudoAxisScale = 311.7 + 0.21 + high * 0.91;
+  pseudoOffsetScale = 37.912 + 0.11 + mixLow * 0.77;
+  pseudoBias = mixHigh * Math.PI * 2 + SECTOR_SIZE * 0.73;
+}
+
+updatePlannerSeed(DEFAULT_PLANNER_SEED);
+
+export function configureSectorObjectPlanner({ seedHash } = {}) {
+  const normalizedSeed =
+    typeof seedHash === 'number' && Number.isFinite(seedHash)
+      ? seedHash >>> 0
+      : DEFAULT_PLANNER_SEED;
+  updatePlannerSeed(normalizedSeed);
+  sectorCache.clear();
+}
 
 function sectorKey(sectorX, sectorZ) {
   return `${sectorX}|${sectorZ}`;
@@ -6,10 +44,10 @@ function sectorKey(sectorX, sectorZ) {
 
 function pseudoRandom(sectorX, sectorZ, offset = 0) {
   const value = Math.sin(
-    sectorX * 157.31 +
-      sectorZ * 311.7 +
-      offset * 37.912 +
-      SECTOR_SIZE * 0.73,
+    sectorX * pseudoAngleScale +
+      sectorZ * pseudoAxisScale +
+      offset * pseudoOffsetScale +
+      pseudoBias,
   );
   return value - Math.floor(value);
 }
@@ -1504,8 +1542,6 @@ function buildPlacements(sectorX, sectorZ) {
     cells,
   };
 }
-
-const sectorCache = new Map();
 
 function ensureSector(sectorX, sectorZ) {
   const key = sectorKey(sectorX, sectorZ);

--- a/three-demo/src/world/terrain-engine.js
+++ b/three-demo/src/world/terrain-engine.js
@@ -2,7 +2,11 @@ import { ValueNoise2D } from './noise.js';
 import { createBiomeEngine } from './biome-engine.js';
 import { defaultWorldOptions } from './world-settings.js';
 
-export function createTerrainEngine({ THREE, seed = 1337, worldConfig = {} } = {}) {
+export function createTerrainEngine({
+  THREE,
+  seed = defaultWorldOptions.seedHash,
+  worldConfig = {},
+} = {}) {
   if (!THREE) {
     throw new Error('createTerrainEngine requires a THREE instance');
   }

--- a/three-demo/src/world/voxel-object-placement.js
+++ b/three-demo/src/world/voxel-object-placement.js
@@ -19,7 +19,17 @@ import {
   getDecorationMeshTemplate,
 } from './voxel-object-decoration-mesh.js';
 
-const objectDensityField = new ValueNoise2D(9103);
+const DEFAULT_DENSITY_SEED = 9103;
+let objectDensityField = new ValueNoise2D(DEFAULT_DENSITY_SEED);
+
+export function configureVoxelObjectPlacement({ seedHash } = {}) {
+  const normalizedSeed =
+    typeof seedHash === 'number' && Number.isFinite(seedHash)
+      ? seedHash >>> 0
+      : DEFAULT_DENSITY_SEED;
+  const mixedSeed = ((normalizedSeed ^ 0x85ebca6b) >>> 0) * 1.21 + DEFAULT_DENSITY_SEED;
+  objectDensityField = new ValueNoise2D(mixedSeed);
+}
 
 function ensureRandomSource(randomSource) {
   if (typeof randomSource === 'function') {

--- a/three-demo/src/world/world-settings.js
+++ b/three-demo/src/world/world-settings.js
@@ -1,3 +1,30 @@
+function computeSeedHash(value) {
+  const str = String(value ?? '')
+  let hash = 2166136261
+  for (let index = 0; index < str.length; index += 1) {
+    hash ^= str.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function resolveSeed(value, fallbackValue, fallbackHash) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const normalized = Math.trunc(value)
+    return { value: normalized, hash: computeSeedHash(normalized) }
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length > 0) {
+      return { value: trimmed, hash: computeSeedHash(trimmed) }
+    }
+  }
+  return { value: fallbackValue, hash: fallbackHash }
+}
+
+const DEFAULT_SEED_VALUE = 1337
+const DEFAULT_SEED_HASH = computeSeedHash(DEFAULT_SEED_VALUE)
+
 const defaultTerrainClamp = Object.freeze({
   min: 2,
   max: 20,
@@ -66,7 +93,8 @@ export const biomeOptionMetadata = Object.freeze({
 })
 
 export const defaultWorldOptions = Object.freeze({
-  seed: 1337,
+  seed: DEFAULT_SEED_VALUE,
+  seedHash: DEFAULT_SEED_HASH,
   chunkSize: 48,
   baseHeight: defaultTerrainOptions.baseHeight,
   maxHeight: defaultTerrainOptions.maxHeight,
@@ -82,8 +110,14 @@ export const defaultWorldOptions = Object.freeze({
 })
 
 function createMutableWorldOptions() {
+  const seedInfo = resolveSeed(
+    DEFAULT_SEED_VALUE,
+    DEFAULT_SEED_VALUE,
+    DEFAULT_SEED_HASH,
+  )
   return {
-    seed: defaultWorldOptions.seed,
+    seed: seedInfo.value,
+    seedHash: seedInfo.hash,
     chunkSize: defaultWorldOptions.chunkSize,
     baseHeight: defaultWorldOptions.baseHeight,
     maxHeight: defaultWorldOptions.maxHeight,
@@ -164,7 +198,13 @@ export function applyWorldOptions(overrides = {}) {
   }
 
   if ('seed' in overrides) {
-    worldOptions.seed = normalizeNumber(overrides.seed, worldOptions.seed)
+    const seedInfo = resolveSeed(
+      overrides.seed,
+      worldOptions.seed,
+      worldOptions.seedHash,
+    )
+    worldOptions.seed = seedInfo.value
+    worldOptions.seedHash = seedInfo.hash
   }
 
   const chunkOverrides = isObject(overrides.chunk) ? overrides.chunk : null
@@ -347,6 +387,7 @@ export function resetWorldOptions() {
   const fresh = createMutableWorldOptions()
 
   worldOptions.seed = fresh.seed
+  worldOptions.seedHash = fresh.seedHash
   worldOptions.chunkSize = fresh.chunkSize
   worldOptions.baseHeight = fresh.baseHeight
   worldOptions.maxHeight = fresh.maxHeight


### PR DESCRIPTION
## Summary
- hash incoming world seeds into a stable numeric `seedHash` that is tracked in world settings
- propagate the hashed seed through world initialization, terrain/biome engines, coordinate hashing, and seeded helpers
- rebuild voxel object density fields and sector object planning noise whenever the world seed changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d895a59b04832a888ece923e37a56b