### PR TITLE
Add descriptor metadata for world options and enforce validation

### DIFF
--- a/three-demo/src/world/__tests__/world-settings.test.js
+++ b/three-demo/src/world/__tests__/world-settings.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applyWorldOptions,
+  getWorldOptionDescriptor,
+  getWorldOptions,
+  resetWorldOptions,
+} from '../world-settings.js'
+
+test('applyWorldOptions clamps terrain height overrides to descriptor bounds', () => {
+  resetWorldOptions()
+  const baseHeightDescriptor = getWorldOptionDescriptor('terrain.baseHeight')
+  assert(baseHeightDescriptor)
+
+  applyWorldOptions({
+    terrain: {
+      baseHeight: baseHeightDescriptor.min - 10,
+      maxHeight: baseHeightDescriptor.min - 5,
+    },
+  })
+
+  const options = getWorldOptions()
+  assert.equal(options.terrain.baseHeight, baseHeightDescriptor.min)
+  assert.equal(options.baseHeight, baseHeightDescriptor.min)
+  assert(options.terrain.maxHeight >= options.terrain.baseHeight)
+})
+
+test('applyWorldOptions clamps excessive overrides using descriptor maxima', () => {
+  resetWorldOptions()
+  const detailDescriptor = getWorldOptionDescriptor('terrain.detailAmplitude')
+  const chunkDescriptor = getWorldOptionDescriptor('chunk.size')
+  const waterDescriptor = getWorldOptionDescriptor('water.level')
+  assert(detailDescriptor && chunkDescriptor && waterDescriptor)
+
+  applyWorldOptions({
+    terrain: {
+      detailAmplitude: detailDescriptor.max + 100,
+    },
+    chunkSize: chunkDescriptor.max * 4,
+    water: { level: waterDescriptor.max + 50 },
+  })
+
+  const options = getWorldOptions()
+  assert.equal(options.terrain.detailAmplitude, detailDescriptor.max)
+  assert.equal(options.chunk.size, chunkDescriptor.max)
+  assert.equal(options.chunkSize, chunkDescriptor.max)
+  assert.equal(options.water.level, waterDescriptor.max)
+  assert.equal(options.waterLevel, waterDescriptor.max)
+})
+
+test('applyWorldOptions clamps biome overrides to descriptor ranges', () => {
+  resetWorldOptions()
+  const biomeScaleDescriptor = getWorldOptionDescriptor('biomes.scale')
+  assert(biomeScaleDescriptor)
+
+  applyWorldOptions({
+    biomes: {
+      scale: biomeScaleDescriptor.max * 10,
+      varianceMultiplier: -100,
+    },
+  })
+
+  const options = getWorldOptions()
+  assert.equal(options.biomes.scale, biomeScaleDescriptor.max)
+  const varianceDescriptor = getWorldOptionDescriptor('biomes.varianceMultiplier')
+  assert(varianceDescriptor)
+  assert.equal(options.biomes.varianceMultiplier, varianceDescriptor.min)
+})

--- a/three-demo/src/world/world-option-descriptors.js
+++ b/three-demo/src/world/world-option-descriptors.js
@@ -1,0 +1,408 @@
+// Each descriptor describes a configurable world-generation option.
+//
+// Leaf descriptors provide:
+// - `id`: unique stable identifier for UI/forms.
+// - `label` & `description`: strings for presentation.
+// - `type`: primitive type or the string 'group' for nested nodes.
+// - `default`: default value used by world-settings.
+// - `min`/`max`/`step`: numeric constraints for sliders/inputs.
+// - `path`: Array path pointing into the live world options object.
+//
+// Group descriptors only include `children` and serve for logical grouping.
+
+const numberType = 'number'
+const groupType = 'group'
+
+const seedDescriptor = Object.freeze({
+  id: 'seed',
+  label: 'World Seed',
+  description:
+    'Seed value used to deterministically generate terrain, biomes, and structures.',
+  type: 'seed',
+  default: 1337,
+  path: Object.freeze(['seed']),
+})
+
+const chunkGroup = Object.freeze({
+  id: 'chunk',
+  label: 'Chunk',
+  description: 'Chunk layout controls for the voxel world.',
+  type: groupType,
+  children: Object.freeze([
+    Object.freeze({
+      id: 'chunk.size',
+      label: 'Chunk Size',
+      description: 'Voxel width/height/depth of each generated chunk.',
+      type: numberType,
+      min: 1,
+      max: 512,
+      step: 1,
+      default: 48,
+      path: Object.freeze(['chunk', 'size']),
+    }),
+  ]),
+})
+
+const legacyChunkSizeDescriptor = Object.freeze({
+  id: 'chunkSize',
+  label: 'Chunk Size (alias)',
+  description: 'Legacy top-level alias that mirrors the chunk size setting.',
+  type: numberType,
+  min: 1,
+  max: 512,
+  step: 1,
+  default: 48,
+  path: Object.freeze(['chunkSize']),
+})
+
+const waterGroup = Object.freeze({
+  id: 'water',
+  label: 'Water',
+  description: 'Water simulation configuration.',
+  type: groupType,
+  children: Object.freeze([
+    Object.freeze({
+      id: 'water.level',
+      label: 'Water Level',
+      description: 'Absolute voxel height for the ocean surface.',
+      type: numberType,
+      min: -128,
+      max: 256,
+      step: 1,
+      default: 9,
+      path: Object.freeze(['water', 'level']),
+    }),
+  ]),
+})
+
+const legacyWaterLevelDescriptor = Object.freeze({
+  id: 'waterLevel',
+  label: 'Water Level (alias)',
+  description: 'Legacy top-level alias that mirrors the water level setting.',
+  type: numberType,
+  min: -128,
+  max: 256,
+  step: 1,
+  default: 9,
+  path: Object.freeze(['waterLevel']),
+})
+
+const terrainGroup = Object.freeze({
+  id: 'terrain',
+  label: 'Terrain',
+  description: 'Primary terrain shape controls.',
+  type: groupType,
+  children: Object.freeze([
+    Object.freeze({
+      id: 'terrain.baseHeight',
+      label: 'Base Height',
+      description: 'Average terrain elevation before noise-based variation.',
+      type: numberType,
+      min: 0,
+      max: 512,
+      step: 1,
+      default: 6,
+      path: Object.freeze(['terrain', 'baseHeight']),
+    }),
+    Object.freeze({
+      id: 'terrain.maxHeight',
+      label: 'Maximum Height',
+      description:
+        'Hard cap on how tall terrain columns may grow before clamping to a ceiling.',
+      type: numberType,
+      min: 1,
+      max: 1024,
+      step: 1,
+      default: 20,
+      path: Object.freeze(['terrain', 'maxHeight']),
+    }),
+    Object.freeze({
+      id: 'terrain.clamp.min',
+      label: 'Clamp Minimum',
+      description:
+        'Lower clamp bound applied after noise sampling to prevent deep pits.',
+      type: numberType,
+      min: 0,
+      max: 1024,
+      step: 1,
+      default: 2,
+      path: Object.freeze(['terrain', 'clamp', 'min']),
+    }),
+    Object.freeze({
+      id: 'terrain.clamp.max',
+      label: 'Clamp Maximum',
+      description:
+        'Upper clamp bound applied after noise sampling to prevent towering spikes.',
+      type: numberType,
+      min: 1,
+      max: 1024,
+      step: 1,
+      default: 20,
+      path: Object.freeze(['terrain', 'clamp', 'max']),
+    }),
+    Object.freeze({
+      id: 'terrain.primaryFrequency',
+      label: 'Primary Frequency',
+      description:
+        'Base frequency for macro terrain variation. Lower values create large landforms.',
+      type: numberType,
+      min: 0.0001,
+      max: 1,
+      step: 0.0001,
+      default: 0.06,
+      path: Object.freeze(['terrain', 'primaryFrequency']),
+    }),
+    Object.freeze({
+      id: 'terrain.primaryAmplitude',
+      label: 'Primary Amplitude',
+      description:
+        'Strength of the macro terrain wave. Higher values exaggerate hills and valleys.',
+      type: numberType,
+      min: 0,
+      max: 256,
+      step: 0.1,
+      default: 8,
+      path: Object.freeze(['terrain', 'primaryAmplitude']),
+    }),
+    Object.freeze({
+      id: 'terrain.primaryOffset',
+      label: 'Primary Offset',
+      description: 'Phase offset applied to the macro terrain noise field.',
+      type: numberType,
+      min: -10000,
+      max: 10000,
+      step: 1,
+      default: 0,
+      path: Object.freeze(['terrain', 'primaryOffset']),
+    }),
+    Object.freeze({
+      id: 'terrain.detailFrequency',
+      label: 'Detail Frequency',
+      description: 'Frequency of secondary detail used to break up flat areas.',
+      type: numberType,
+      min: 0.0001,
+      max: 2,
+      step: 0.0001,
+      default: 0.12,
+      path: Object.freeze(['terrain', 'detailFrequency']),
+    }),
+    Object.freeze({
+      id: 'terrain.detailAmplitude',
+      label: 'Detail Amplitude',
+      description: 'Strength of the secondary detail contribution.',
+      type: numberType,
+      min: 0,
+      max: 128,
+      step: 0.1,
+      default: 3,
+      path: Object.freeze(['terrain', 'detailAmplitude']),
+    }),
+    Object.freeze({
+      id: 'terrain.detailOffset',
+      label: 'Detail Offset',
+      description: 'Phase offset for the detail terrain noise.',
+      type: numberType,
+      min: -10000,
+      max: 10000,
+      step: 1,
+      default: 100,
+      path: Object.freeze(['terrain', 'detailOffset']),
+    }),
+    Object.freeze({
+      id: 'terrain.ridgeFrequency',
+      label: 'Ridge Frequency',
+      description: 'Frequency controlling how often sharp ridgelines occur.',
+      type: numberType,
+      min: 0.0001,
+      max: 1,
+      step: 0.0001,
+      default: 0.02,
+      path: Object.freeze(['terrain', 'ridgeFrequency']),
+    }),
+    Object.freeze({
+      id: 'terrain.ridgeStrength',
+      label: 'Ridge Strength',
+      description: 'Strength multiplier for ridge contributions on top of base terrain.',
+      type: numberType,
+      min: 0,
+      max: 64,
+      step: 0.1,
+      default: 2.4,
+      path: Object.freeze(['terrain', 'ridgeStrength']),
+    }),
+    Object.freeze({
+      id: 'terrain.ridgeOffset',
+      label: 'Ridge Offset',
+      description: 'Phase offset for the ridge noise sampler.',
+      type: numberType,
+      min: -10000,
+      max: 10000,
+      step: 1,
+      default: 220,
+      path: Object.freeze(['terrain', 'ridgeOffset']),
+    }),
+    Object.freeze({
+      id: 'terrain.climateHeightInfluence',
+      label: 'Climate Height Influence',
+      description:
+        'How strongly biome climate data affects the perceived terrain elevation.',
+      type: numberType,
+      min: -10,
+      max: 10,
+      step: 0.05,
+      default: 1.2,
+      path: Object.freeze(['terrain', 'climateHeightInfluence']),
+    }),
+  ]),
+})
+
+const legacyBaseHeightDescriptor = Object.freeze({
+  id: 'baseHeight',
+  label: 'Base Height (alias)',
+  description:
+    'Legacy top-level alias mirroring the terrain base height for compatibility.',
+  type: numberType,
+  min: 0,
+  max: 512,
+  step: 1,
+  default: 6,
+  path: Object.freeze(['baseHeight']),
+})
+
+const legacyMaxHeightDescriptor = Object.freeze({
+  id: 'maxHeight',
+  label: 'Max Height (alias)',
+  description:
+    'Legacy top-level alias mirroring the terrain max height for compatibility.',
+  type: numberType,
+  min: 1,
+  max: 1024,
+  step: 1,
+  default: 20,
+  path: Object.freeze(['maxHeight']),
+})
+
+const biomesGroup = Object.freeze({
+  id: 'biomes',
+  label: 'Biomes',
+  description: 'Controls for procedural biome sampling and distribution.',
+  type: groupType,
+  children: Object.freeze([
+    Object.freeze({
+      id: 'biomes.scale',
+      label: 'Biome Scale',
+      description:
+        'Base frequency for the temperature/moisture noise fields. Lower values produce larger biome continents.',
+      type: numberType,
+      min: 0.0005,
+      max: 0.02,
+      step: 0.0001,
+      default: 0.003,
+      path: Object.freeze(['biomes', 'scale']),
+    }),
+    Object.freeze({
+      id: 'biomes.detailMultiplier',
+      label: 'Detail Multiplier',
+      description:
+        'Multiplier applied to the base scale for secondary climate detail noise.',
+      type: numberType,
+      min: 0.1,
+      max: 10,
+      step: 0.01,
+      default: 2.15,
+      path: Object.freeze(['biomes', 'detailMultiplier']),
+    }),
+    Object.freeze({
+      id: 'biomes.moistureDetailMultiplier',
+      label: 'Moisture Detail Multiplier',
+      description:
+        'Multiplier that adjusts the moisture detail scale relative to the temperature field.',
+      type: numberType,
+      min: 0.1,
+      max: 4,
+      step: 0.01,
+      default: 1.18,
+      path: Object.freeze(['biomes', 'moistureDetailMultiplier']),
+    }),
+    Object.freeze({
+      id: 'biomes.varianceMultiplier',
+      label: 'Variance Multiplier',
+      description: 'Controls how strongly biome variance noise distorts the climate map.',
+      type: numberType,
+      min: 0,
+      max: 2,
+      step: 0.01,
+      default: 0.45,
+      path: Object.freeze(['biomes', 'varianceMultiplier']),
+    }),
+    Object.freeze({
+      id: 'biomes.variationStrength',
+      label: 'Variation Strength',
+      description: 'Strength of the random jitter applied when selecting the closest biome.',
+      type: numberType,
+      min: 0,
+      max: 1,
+      step: 0.01,
+      default: 0.18,
+      path: Object.freeze(['biomes', 'variationStrength']),
+    }),
+  ]),
+})
+
+export const worldOptionDescriptors = Object.freeze([
+  seedDescriptor,
+  chunkGroup,
+  legacyChunkSizeDescriptor,
+  waterGroup,
+  legacyWaterLevelDescriptor,
+  terrainGroup,
+  legacyBaseHeightDescriptor,
+  legacyMaxHeightDescriptor,
+  biomesGroup,
+])
+
+export function worldOptionPathToKey(path) {
+  return Array.isArray(path) ? path.join('.') : ''
+}
+
+export function createWorldOptionDescriptorIndex(
+  descriptors = worldOptionDescriptors,
+) {
+  const index = new Map()
+
+  const stack = [...descriptors]
+  while (stack.length > 0) {
+    const descriptor = stack.pop()
+    if (!descriptor) {
+      continue
+    }
+    if (Array.isArray(descriptor.children)) {
+      descriptor.children.forEach((child) => stack.push(child))
+    }
+    if (Array.isArray(descriptor.path)) {
+      index.set(worldOptionPathToKey(descriptor.path), descriptor)
+    }
+  }
+
+  return index
+}
+
+export function flattenWorldOptionDescriptors(
+  descriptors = worldOptionDescriptors,
+) {
+  const flattened = []
+  const stack = [...descriptors]
+  while (stack.length > 0) {
+    const descriptor = stack.pop()
+    if (!descriptor) {
+      continue
+    }
+    if (Array.isArray(descriptor.children)) {
+      descriptor.children.forEach((child) => stack.push(child))
+    }
+    if (Array.isArray(descriptor.path)) {
+      flattened.push(descriptor)
+    }
+  }
+  return flattened
+}

--- a/three-demo/src/world/world-settings.js
+++ b/three-demo/src/world/world-settings.js
@@ -1,3 +1,35 @@
+import {
+  createWorldOptionDescriptorIndex,
+  worldOptionDescriptors,
+  worldOptionPathToKey,
+} from './world-option-descriptors.js'
+
+export { worldOptionDescriptors } from './world-option-descriptors.js'
+
+const descriptorIndex = createWorldOptionDescriptorIndex(worldOptionDescriptors)
+
+export function getWorldOptionDescriptor(pathKey) {
+  return descriptorIndex.get(pathKey) ?? null
+}
+
+function getDescriptorForPath(path) {
+  if (Array.isArray(path)) {
+    return descriptorIndex.get(worldOptionPathToKey(path)) ?? null
+  }
+  if (typeof path === 'string') {
+    return descriptorIndex.get(path) ?? null
+  }
+  return null
+}
+
+function getDescriptorDefault(path) {
+  const descriptor = getDescriptorForPath(path)
+  if (!descriptor) {
+    throw new Error(`Missing world option descriptor for path: ${path.join('.')}`)
+  }
+  return descriptor.default
+}
+
 function computeSeedHash(value) {
   const str = String(value ?? '')
   let hash = 2166136261
@@ -22,88 +54,81 @@ function resolveSeed(value, fallbackValue, fallbackHash) {
   return { value: fallbackValue, hash: fallbackHash }
 }
 
-const DEFAULT_SEED_VALUE = 1337
+const DEFAULT_SEED_VALUE = getDescriptorDefault(['seed'])
 const DEFAULT_SEED_HASH = computeSeedHash(DEFAULT_SEED_VALUE)
 
 const defaultTerrainClamp = Object.freeze({
-  min: 2,
-  max: 20,
+  min: getDescriptorDefault(['terrain', 'clamp', 'min']),
+  max: getDescriptorDefault(['terrain', 'clamp', 'max']),
 })
 
 const defaultTerrainOptions = Object.freeze({
-  baseHeight: 6,
-  maxHeight: 20,
+  baseHeight: getDescriptorDefault(['terrain', 'baseHeight']),
+  maxHeight: getDescriptorDefault(['terrain', 'maxHeight']),
   clamp: defaultTerrainClamp,
-  primaryFrequency: 0.06,
-  primaryAmplitude: 8,
-  primaryOffset: 0,
-  detailFrequency: 0.12,
-  detailAmplitude: 3,
-  detailOffset: 100,
-  ridgeFrequency: 0.02,
-  ridgeStrength: 2.4,
-  ridgeOffset: 220,
-  climateHeightInfluence: 1.2,
+  primaryFrequency: getDescriptorDefault(['terrain', 'primaryFrequency']),
+  primaryAmplitude: getDescriptorDefault(['terrain', 'primaryAmplitude']),
+  primaryOffset: getDescriptorDefault(['terrain', 'primaryOffset']),
+  detailFrequency: getDescriptorDefault(['terrain', 'detailFrequency']),
+  detailAmplitude: getDescriptorDefault(['terrain', 'detailAmplitude']),
+  detailOffset: getDescriptorDefault(['terrain', 'detailOffset']),
+  ridgeFrequency: getDescriptorDefault(['terrain', 'ridgeFrequency']),
+  ridgeStrength: getDescriptorDefault(['terrain', 'ridgeStrength']),
+  ridgeOffset: getDescriptorDefault(['terrain', 'ridgeOffset']),
+  climateHeightInfluence: getDescriptorDefault([
+    'terrain',
+    'climateHeightInfluence',
+  ]),
 })
 
 const defaultBiomeTuning = Object.freeze({
-  scale: 0.003,
-  detailMultiplier: 2.15,
-  moistureDetailMultiplier: 1.18,
-  varianceMultiplier: 0.45,
-  variationStrength: 0.18,
+  scale: getDescriptorDefault(['biomes', 'scale']),
+  detailMultiplier: getDescriptorDefault(['biomes', 'detailMultiplier']),
+  moistureDetailMultiplier: getDescriptorDefault([
+    'biomes',
+    'moistureDetailMultiplier',
+  ]),
+  varianceMultiplier: getDescriptorDefault(['biomes', 'varianceMultiplier']),
+  variationStrength: getDescriptorDefault(['biomes', 'variationStrength']),
 })
 
-export const biomeOptionMetadata = Object.freeze({
-  scale: Object.freeze({
-    default: defaultBiomeTuning.scale,
-    min: 0.0005,
-    max: 0.02,
-    description:
-      'Base frequency for the temperature/moisture noise fields. Lower values produce larger biome continents.',
-  }),
-  detailMultiplier: Object.freeze({
-    default: defaultBiomeTuning.detailMultiplier,
-    min: 0.1,
-    max: 10,
-    description:
-      'Multiplier applied to the base scale for secondary climate detail noise.',
-  }),
-  moistureDetailMultiplier: Object.freeze({
-    default: defaultBiomeTuning.moistureDetailMultiplier,
-    min: 0.1,
-    max: 4,
-    description:
-      'Multiplier that adjusts the moisture detail scale relative to the temperature field.',
-  }),
-  varianceMultiplier: Object.freeze({
-    default: defaultBiomeTuning.varianceMultiplier,
-    min: 0,
-    max: 2,
-    description:
-      'Controls how strongly biome variance noise distorts the climate map.',
-  }),
-  variationStrength: Object.freeze({
-    default: defaultBiomeTuning.variationStrength,
-    min: 0,
-    max: 1,
-    description:
-      'Strength of the random jitter applied when selecting the closest biome.',
-  }),
-})
+const biomeDescriptorKeys = [
+  'scale',
+  'detailMultiplier',
+  'moistureDetailMultiplier',
+  'varianceMultiplier',
+  'variationStrength',
+]
+
+export const biomeOptionMetadata = Object.freeze(
+  Object.fromEntries(
+    biomeDescriptorKeys.map((key) => {
+      const descriptor = getDescriptorForPath(['biomes', key])
+      return [
+        key,
+        Object.freeze({
+          default: defaultBiomeTuning[key],
+          min: descriptor?.min,
+          max: descriptor?.max,
+          description: descriptor?.description,
+        }),
+      ]
+    }),
+  ),
+)
 
 export const defaultWorldOptions = Object.freeze({
   seed: DEFAULT_SEED_VALUE,
   seedHash: DEFAULT_SEED_HASH,
-  chunkSize: 48,
-  baseHeight: defaultTerrainOptions.baseHeight,
-  maxHeight: defaultTerrainOptions.maxHeight,
-  waterLevel: 9,
+  chunkSize: getDescriptorDefault(['chunkSize']),
+  baseHeight: getDescriptorDefault(['baseHeight']),
+  maxHeight: getDescriptorDefault(['maxHeight']),
+  waterLevel: getDescriptorDefault(['waterLevel']),
   chunk: Object.freeze({
-    size: 48,
+    size: getDescriptorDefault(['chunk', 'size']),
   }),
   water: Object.freeze({
-    level: 9,
+    level: getDescriptorDefault(['water', 'level']),
   }),
   terrain: defaultTerrainOptions,
   biomes: defaultBiomeTuning,
@@ -154,34 +179,17 @@ function normalizeNumber(value, fallback) {
   return value
 }
 
-const TERRAIN_OPTION_BOUNDS = Object.freeze({
-  baseHeight: Object.freeze({ min: 0, max: 512 }),
-  maxHeight: Object.freeze({ min: 1, max: 1024 }),
-  clampMin: Object.freeze({ min: 0, max: 1024 }),
-  clampMax: Object.freeze({ min: 1, max: 1024 }),
-  primaryFrequency: Object.freeze({ min: 0.0001, max: 1 }),
-  primaryAmplitude: Object.freeze({ min: 0, max: 256 }),
-  primaryOffset: Object.freeze({ min: -10000, max: 10000 }),
-  detailFrequency: Object.freeze({ min: 0.0001, max: 2 }),
-  detailAmplitude: Object.freeze({ min: 0, max: 128 }),
-  detailOffset: Object.freeze({ min: -10000, max: 10000 }),
-  ridgeFrequency: Object.freeze({ min: 0.0001, max: 1 }),
-  ridgeStrength: Object.freeze({ min: 0, max: 64 }),
-  ridgeOffset: Object.freeze({ min: -10000, max: 10000 }),
-  climateHeightInfluence: Object.freeze({ min: -10, max: 10 }),
-})
-
-function normalizeWithBounds(value, fallback, boundsKey) {
-  const bounds = TERRAIN_OPTION_BOUNDS[boundsKey] ?? {}
+function normalizeWithDescriptor(value, fallback, path) {
+  const descriptor = getDescriptorForPath(path)
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return fallback
   }
   let normalized = value
-  if (Number.isFinite(bounds.min)) {
-    normalized = Math.max(bounds.min, normalized)
+  if (descriptor && Number.isFinite(descriptor.min)) {
+    normalized = Math.max(descriptor.min, normalized)
   }
-  if (Number.isFinite(bounds.max)) {
-    normalized = Math.min(bounds.max, normalized)
+  if (descriptor && Number.isFinite(descriptor.max)) {
+    normalized = Math.min(descriptor.max, normalized)
   }
   return normalized
 }
@@ -213,9 +221,19 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedChunkSize !== null) {
-    const size = Math.max(1, Math.floor(resolvedChunkSize))
-    worldOptions.chunkSize = size
-    worldOptions.chunk.size = size
+    const floored = Math.floor(resolvedChunkSize)
+    const positive = Math.max(1, floored)
+    const normalizedChunkSize = normalizeWithDescriptor(
+      positive,
+      worldOptions.chunk.size,
+      ['chunk', 'size'],
+    )
+    worldOptions.chunk.size = normalizedChunkSize
+    worldOptions.chunkSize = normalizeWithDescriptor(
+      normalizedChunkSize,
+      worldOptions.chunkSize,
+      ['chunkSize'],
+    )
   }
 
   const terrainOverrides = isObject(overrides.terrain) ? overrides.terrain : null
@@ -225,10 +243,10 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedBaseHeight !== null) {
-    const baseHeight = normalizeWithBounds(
+    const baseHeight = normalizeWithDescriptor(
       resolvedBaseHeight,
       worldOptions.terrain.baseHeight,
-      'baseHeight',
+      ['terrain', 'baseHeight'],
     )
     worldOptions.baseHeight = baseHeight
     worldOptions.terrain.baseHeight = baseHeight
@@ -239,10 +257,10 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedMaxHeight !== null) {
-    const maxHeight = normalizeWithBounds(
+    const maxHeight = normalizeWithDescriptor(
       resolvedMaxHeight,
       worldOptions.terrain.maxHeight,
-      'maxHeight',
+      ['terrain', 'maxHeight'],
     )
     worldOptions.maxHeight = maxHeight
     worldOptions.terrain.maxHeight = maxHeight
@@ -257,18 +275,18 @@ export function applyWorldOptions(overrides = {}) {
     : null
   const resolvedClampMin = normalizeNumber(clampOverrides?.min, null)
   if (resolvedClampMin !== null) {
-    worldOptions.terrain.clamp.min = normalizeWithBounds(
+    worldOptions.terrain.clamp.min = normalizeWithDescriptor(
       resolvedClampMin,
       worldOptions.terrain.clamp.min,
-      'clampMin',
+      ['terrain', 'clamp', 'min'],
     )
   }
   const resolvedClampMax = normalizeNumber(clampOverrides?.max, null)
   if (resolvedClampMax !== null) {
-    const clampMax = normalizeWithBounds(
+    const clampMax = normalizeWithDescriptor(
       resolvedClampMax,
       worldOptions.terrain.clamp.max,
-      'clampMax',
+      ['terrain', 'clamp', 'max'],
     )
     worldOptions.terrain.clamp.max = clampMax
     worldOptions.maxHeight = Math.max(worldOptions.maxHeight, clampMax)
@@ -289,18 +307,18 @@ export function applyWorldOptions(overrides = {}) {
 
   terrainOptionKeys.forEach((key) => {
     if (key in (terrainOverrides ?? {})) {
-      worldOptions.terrain[key] = normalizeWithBounds(
+      worldOptions.terrain[key] = normalizeWithDescriptor(
         terrainOverrides[key],
         worldOptions.terrain[key],
-        key,
+        ['terrain', key],
       )
     }
   })
 
-  worldOptions.baseHeight = normalizeWithBounds(
+  worldOptions.baseHeight = normalizeWithDescriptor(
     worldOptions.baseHeight,
     defaultTerrainOptions.baseHeight,
-    'baseHeight',
+    ['baseHeight'],
   )
   worldOptions.terrain.baseHeight = worldOptions.baseHeight
 
@@ -309,18 +327,18 @@ export function applyWorldOptions(overrides = {}) {
     worldOptions.terrain.baseHeight,
   )
   worldOptions.terrain.maxHeight = Math.max(
-    normalizeWithBounds(
+    normalizeWithDescriptor(
       worldOptions.terrain.maxHeight,
       defaultTerrainOptions.maxHeight,
-      'maxHeight',
+      ['terrain', 'maxHeight'],
     ),
     minimumMaxHeight,
   )
   worldOptions.maxHeight = Math.max(
-    normalizeWithBounds(
+    normalizeWithDescriptor(
       worldOptions.maxHeight,
       defaultTerrainOptions.maxHeight,
-      'maxHeight',
+      ['maxHeight'],
     ),
     worldOptions.terrain.maxHeight,
   )
@@ -339,16 +357,16 @@ export function applyWorldOptions(overrides = {}) {
     worldOptions.maxHeight = estimatedTerrainMax
   }
 
-  worldOptions.terrain.clamp.min = normalizeWithBounds(
+  worldOptions.terrain.clamp.min = normalizeWithDescriptor(
     worldOptions.terrain.clamp.min,
     defaultTerrainOptions.clamp.min,
-    'clampMin',
+    ['terrain', 'clamp', 'min'],
   )
   worldOptions.terrain.clamp.max = Math.max(
-    normalizeWithBounds(
+    normalizeWithDescriptor(
       worldOptions.terrain.clamp.max,
       defaultTerrainOptions.clamp.max,
-      'clampMax',
+      ['terrain', 'clamp', 'max'],
     ),
     worldOptions.terrain.clamp.min,
     worldOptions.maxHeight,
@@ -364,19 +382,33 @@ export function applyWorldOptions(overrides = {}) {
     null,
   )
   if (resolvedWaterLevel !== null) {
-    worldOptions.waterLevel = resolvedWaterLevel
-    worldOptions.water.level = resolvedWaterLevel
+    const normalizedWaterLevel = normalizeWithDescriptor(
+      resolvedWaterLevel,
+      worldOptions.water.level,
+      ['water', 'level'],
+    )
+    worldOptions.water.level = normalizedWaterLevel
+    worldOptions.waterLevel = normalizeWithDescriptor(
+      normalizedWaterLevel,
+      worldOptions.waterLevel,
+      ['waterLevel'],
+    )
   }
 
   if ('biomes' in overrides && isObject(overrides.biomes)) {
     Object.entries(overrides.biomes).forEach(([key, value]) => {
-      if (
-        Object.prototype.hasOwnProperty.call(worldOptions.biomes, key) &&
-        typeof value === 'number' &&
-        Number.isFinite(value)
-      ) {
-        worldOptions.biomes[key] = value
+      if (!Object.prototype.hasOwnProperty.call(worldOptions.biomes, key)) {
+        return
       }
+      const normalizedInput = normalizeNumber(value, null)
+      if (normalizedInput === null) {
+        return
+      }
+      worldOptions.biomes[key] = normalizeWithDescriptor(
+        normalizedInput,
+        worldOptions.biomes[key],
+        ['biomes', key],
+      )
     })
   }
 


### PR DESCRIPTION
## Summary
- add a descriptor catalog for world-generation options including defaults and bounds
- update world settings to source defaults from descriptors and clamp overrides accordingly
- add unit tests that verify applyWorldOptions respects descriptor constraints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d898a504e8832ab30080c113d1b6b9