### PR TITLE
Integrate water particle effects and VFX tooling

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -15,8 +15,13 @@ import { initializeMusicSystem } from './audio/music-system.js'
 import {
   initializeFluidRegistry,
   updateFluids,
+  registerFluidSurfaceLifecycle,
 } from './world/fluids/fluid-registry.js'
-import { createParticleSystem } from './rendering/particle-system.js'
+import {
+  createParticleSystem,
+  computeFluidSurfaceAnchor,
+} from './rendering/particle-system.js'
+import { createWaterSurfaceMistEmitter } from './rendering/particles/water-effects.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -168,6 +173,29 @@ try {
 
   particleSystem = createParticleSystem({ THREE, scene })
 
+  registerFluidSurfaceLifecycle({
+    onCreated: ({ type, mesh, runtime }) =>
+      particleSystem.notifyFluidSurfaceCreated({ type, mesh, runtime }),
+    onDisposed: ({ type, mesh, runtime }) =>
+      particleSystem.notifyFluidSurfaceDisposed({ type, mesh, runtime }),
+  })
+
+  particleSystem.registerFluidSurfaceEffect('water', ({ mesh, emit }) => {
+    const anchor = computeFluidSurfaceAnchor({ THREE, mesh, surfaceOffset: 0.6 })
+    if (!anchor) {
+      return null
+    }
+    const handle = emit(
+      createWaterSurfaceMistEmitter({
+        position: anchor,
+        intensity: 1.05,
+      }),
+    )
+    return {
+      dispose: () => handle?.stop?.(),
+    }
+  })
+
   playerControls = createPlayerControls({
     THREE,
     PointerLockControls,
@@ -181,6 +209,7 @@ try {
     softBlocks: chunkManager.softBlocks,
     waterColumns: chunkManager.waterColumns,
     chunkManager,
+    particleSystem,
     damageMaterials: blockMaterials.damageStages,
     onStateChange: updateHud,
   })
@@ -257,6 +286,7 @@ try {
     scene,
     THREE,
     registerDiagnosticOverlay,
+    particleSystem,
   })
 
   commandConsole.log(

--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -1,4 +1,9 @@
 import { getWorldOptions } from '../world/world-settings.js';
+import { computeFluidContactPoints } from '../rendering/particle-system.js';
+import {
+  createWaterBubbleBurst,
+  createWaterSplashBurst,
+} from '../rendering/particles/water-effects.js';
 
 function blockKey(x, y, z) {
   return `${x}|${y}|${z}`;
@@ -38,6 +43,7 @@ export function createPlayerControls({
   softBlocks,
   waterColumns,
   chunkManager,
+  particleSystem = null,
   damageMaterials = [],
   onStateChange = () => {},
 }) {
@@ -1031,6 +1037,42 @@ export function createPlayerControls({
     if (playerState.isInWater !== feetInWater) {
       playerState.isInWater = feetInWater;
       markStateDirty();
+      if (particleSystem?.emit) {
+        try {
+          const contact = computeFluidContactPoints({
+            THREE,
+            feetPosition: { x: position.x, y: feetY, z: position.z },
+            surfaceY: effectiveWaterSurface,
+            surfaceOffset: 0.08,
+            subsurfaceDepth: 0.45,
+          });
+          const speed = Math.abs(verticalVelocity);
+          const intensity = THREE.MathUtils.clamp(speed / 6 + 0.45, 0.35, 2.25);
+          if (feetInWater) {
+            particleSystem.emit(
+              createWaterSplashBurst({
+                position: contact.surface,
+                intensity,
+              }),
+            );
+            particleSystem.emit(
+              createWaterBubbleBurst({
+                position: contact.subsurface,
+                intensity: Math.max(0.5, intensity * 0.75),
+              }),
+            );
+          } else {
+            particleSystem.emit(
+              createWaterSplashBurst({
+                position: contact.surface,
+                intensity: Math.max(0.35, intensity * 0.6),
+              }),
+            );
+          }
+        } catch (error) {
+          console.error('Failed to trigger water transition particles:', error);
+        }
+      }
     }
 
     const previousOxygen = playerState.oxygen;

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -11,6 +11,7 @@ export function registerDeveloperCommands({
   scene,
   THREE,
   registerDiagnosticOverlay,
+  particleSystem = null,
 }) {
   if (!commandConsole) {
     throw new Error('registerDeveloperCommands requires a commandConsole instance.');
@@ -56,6 +57,13 @@ export function registerDeveloperCommands({
     disposer: null,
     options: null,
     lastKey: null,
+  };
+
+  const vfxOverlayState = {
+    disposer: null,
+    helpers: new Map(),
+    group: null,
+    element: null,
   };
 
   const getDebugSnapshot = () => window.__VOXEL_DEBUG__?.chunkSnapshot;
@@ -536,6 +544,133 @@ export function registerDeveloperCommands({
     });
   };
 
+  const disposeVfxOverlayHelpers = () => {
+    if (vfxOverlayState.group) {
+      vfxOverlayState.helpers.forEach((entry) => {
+        entry.helper.geometry?.dispose?.();
+        entry.helper.material?.dispose?.();
+      });
+      scene.remove(vfxOverlayState.group);
+      vfxOverlayState.group = null;
+    }
+    vfxOverlayState.helpers.clear();
+  };
+
+  const disableVfxOverlay = ({ silent = false } = {}) => {
+    if (vfxOverlayState.disposer) {
+      try {
+        vfxOverlayState.disposer();
+      } catch (error) {
+        console.error('Failed to dispose VFX overlay callback:', error);
+      }
+      vfxOverlayState.disposer = null;
+    }
+    disposeVfxOverlayHelpers();
+    if (vfxOverlayState.element) {
+      vfxOverlayState.element.remove();
+      vfxOverlayState.element = null;
+    }
+    if (!silent) {
+      commandConsole.log('VFX overlay disabled.');
+    }
+  };
+
+  const enableVfxOverlay = () => {
+    if (!particleSystem?.getDebugInfo) {
+      commandConsole.log('Particle system debugging is unavailable.');
+      return;
+    }
+    if (typeof registerDiagnosticOverlay !== 'function') {
+      commandConsole.log('Diagnostic overlay loop is unavailable; cannot enable VFX overlay.');
+      return;
+    }
+    if (vfxOverlayState.disposer) {
+      commandConsole.log('VFX overlay is already enabled.');
+      return;
+    }
+
+    const element = document.createElement('div');
+    element.className = 'vfx-debug-overlay';
+    element.textContent = 'VFX overlay active…';
+    document.body.appendChild(element);
+    vfxOverlayState.element = element;
+
+    const group = new THREE.Group();
+    group.name = 'VfxDebugOverlay';
+    scene.add(group);
+    vfxOverlayState.group = group;
+    vfxOverlayState.helpers = new Map();
+
+    const syncHelpers = (surfaces = []) => {
+      const seen = new Set();
+      surfaces.forEach((surface) => {
+        const { mesh, type, attachmentCount } = surface;
+        if (!mesh?.isObject3D) {
+          return;
+        }
+        let entry = vfxOverlayState.helpers.get(mesh);
+        if (!entry) {
+          const box = new THREE.Box3().setFromObject(mesh);
+          const helper = new THREE.Box3Helper(
+            box,
+            attachmentCount > 0 ? 0x4aa3ff : 0xffa64d,
+          );
+          helper.name = `VfxSurfaceHelper(${type ?? 'unknown'})`;
+          group.add(helper);
+          entry = { helper, box };
+          vfxOverlayState.helpers.set(mesh, entry);
+        } else {
+          entry.box.setFromObject(mesh);
+          entry.helper.material?.color?.set(
+            attachmentCount > 0 ? 0x4aa3ff : 0xffa64d,
+          );
+        }
+        seen.add(mesh);
+      });
+      vfxOverlayState.helpers.forEach((entry, mesh) => {
+        if (seen.has(mesh)) {
+          return;
+        }
+        group.remove(entry.helper);
+        entry.helper.geometry?.dispose?.();
+        entry.helper.material?.dispose?.();
+        vfxOverlayState.helpers.delete(mesh);
+      });
+    };
+
+    const updateOverlay = () => {
+      if (!vfxOverlayState.element) {
+        return;
+      }
+      const info = particleSystem.getDebugInfo?.();
+      if (!info) {
+        vfxOverlayState.element.textContent = 'No VFX data available.';
+        return;
+      }
+      const lines = [
+        `Emitters: ${info.emitterCount}`,
+        `Active Particles: ${info.totalActiveParticles}`,
+      ];
+      const emitterSummaries = info.emitters.slice(0, 6);
+      emitterSummaries.forEach((emitter, index) => {
+        const flag = emitter.pendingRemoval ? ' *' : '';
+        lines.push(`  #${index + 1} ${emitter.label} — ${emitter.activeParticles}${flag}`);
+      });
+      if (info.emitters.length > emitterSummaries.length) {
+        lines.push(`  (+${info.emitters.length - emitterSummaries.length} more…)`);
+      }
+      lines.push('', `Fluid surfaces: ${info.fluidSurfaces.length}`);
+      vfxOverlayState.element.textContent = lines.join('\n');
+      syncHelpers(info.fluidSurfaces);
+    };
+
+    vfxOverlayState.disposer = registerDiagnosticOverlay(() => {
+      updateOverlay();
+    });
+    updateOverlay();
+    commandConsole.log('VFX overlay enabled. Use /vfx overlay off to disable.');
+  };
+
   registerCommand({
     name: 'look',
     description:
@@ -638,6 +773,53 @@ export function registerDeveloperCommands({
       const options = normalizeScanOptions({ distance, yaw, pitch });
       const result = performScan(options);
       logScanResult(result, { label: 'scan' });
+    },
+  });
+
+  registerCommand({
+    name: 'vfx',
+    description: 'Inspect and control particle visual effects.',
+    usage: '/vfx overlay [on|off|toggle] | /vfx list',
+    handler: ({ args, toggle }) => {
+      if (!particleSystem) {
+        commandConsole.log('Particle system is not available.');
+        return;
+      }
+      if (args.length === 0) {
+        throw new Error('Usage: /vfx overlay [on|off|toggle] | /vfx list.');
+      }
+      const mode = args[0].toLowerCase();
+      if (mode === 'overlay') {
+        const desired = toggle(args[1], Boolean(vfxOverlayState.disposer));
+        if (desired) {
+          enableVfxOverlay();
+        } else {
+          disableVfxOverlay();
+        }
+        return;
+      }
+      if (mode === 'list') {
+        const info = particleSystem.getDebugInfo?.();
+        if (!info) {
+          commandConsole.log('Particle system did not provide debug info.');
+          return;
+        }
+        commandConsole.log(`Emitters (${info.emitterCount} total):`);
+        info.emitters.forEach((emitter, index) => {
+          const status = emitter.pendingRemoval ? ' (pending removal)' : '';
+          commandConsole.log(
+            `  #${index + 1} ${emitter.label} — particles=${emitter.activeParticles}${status}`,
+          );
+        });
+        commandConsole.log(`Fluid surfaces tracked: ${info.fluidSurfaces.length}`);
+        info.fluidSurfaces.forEach((surface, index) => {
+          commandConsole.log(
+            `  #${index + 1} type=${surface.type} attachments=${surface.attachmentCount}`,
+          );
+        });
+        return;
+      }
+      throw new Error('Usage: /vfx overlay [on|off|toggle] | /vfx list.');
     },
   });
 

--- a/three-demo/src/rendering/particle-system.js
+++ b/three-demo/src/rendering/particle-system.js
@@ -18,6 +18,83 @@
 
 const DEFAULT_POOL_CAPACITY = 128;
 
+function toVector3(THREE, value) {
+  if (value?.isVector3) {
+    return value.clone();
+  }
+  const vector = new THREE.Vector3();
+  if (Array.isArray(value)) {
+    vector.fromArray(value);
+    return vector;
+  }
+  const source = value ?? {};
+  vector.set(
+    Number.isFinite(source.x) ? source.x : 0,
+    Number.isFinite(source.y) ? source.y : 0,
+    Number.isFinite(source.z) ? source.z : 0,
+  );
+  return vector;
+}
+
+/**
+ * Computes a set of world-space anchor points around a fluid contact based on
+ * the player's feet position and the resolved surface height.
+ */
+export function computeFluidContactPoints({
+  THREE,
+  feetPosition,
+  surfaceY,
+  surfaceOffset = 0.12,
+  subsurfaceDepth = 0.4,
+} = {}) {
+  if (!THREE) {
+    throw new Error('computeFluidContactPoints requires a THREE instance.');
+  }
+  if (!Number.isFinite(surfaceY)) {
+    throw new Error('computeFluidContactPoints requires a numeric surfaceY.');
+  }
+  if (!feetPosition) {
+    throw new Error('computeFluidContactPoints requires a feetPosition.');
+  }
+  const feet = toVector3(THREE, feetPosition);
+  feet.y = Number.isFinite(feet.y) ? feet.y : surfaceY;
+  const surfacePoint = feet.clone();
+  surfacePoint.y = surfaceY + surfaceOffset;
+  const subsurfacePoint = feet.clone();
+  subsurfacePoint.y = surfaceY - subsurfaceDepth;
+  return {
+    feet,
+    surface: surfacePoint,
+    subsurface: subsurfacePoint,
+  };
+}
+
+/**
+ * Approximates a representative spawn anchor for a fluid surface mesh by
+ * sampling its world-space bounding box.
+ */
+export function computeFluidSurfaceAnchor({
+  THREE,
+  mesh,
+  surfaceOffset = 0.45,
+} = {}) {
+  if (!THREE) {
+    throw new Error('computeFluidSurfaceAnchor requires a THREE instance.');
+  }
+  if (!mesh?.isObject3D) {
+    return null;
+  }
+  const boundingBox = new THREE.Box3();
+  boundingBox.setFromObject(mesh);
+  if (!Number.isFinite(boundingBox.min.y) || !Number.isFinite(boundingBox.max.y)) {
+    return null;
+  }
+  const center = new THREE.Vector3();
+  boundingBox.getCenter(center);
+  center.y = boundingBox.max.y + surfaceOffset;
+  return center;
+}
+
 function cloneBufferAttribute(THREE, attribute) {
   const cloned = attribute.clone();
   if (cloned.isInterleavedBufferAttribute) {
@@ -263,6 +340,9 @@ export function createParticleSystem({ THREE, scene }) {
 
   /** @type {Set<EmitterState>} */
   const activeEmitters = new Set();
+  const fluidSurfaceFactories = new Map();
+  const fluidSurfaceState = new Map();
+  let emitterIdCounter = 0;
 
   function disposeEmitterState(state) {
     if (state.disposed) {
@@ -294,6 +374,8 @@ export function createParticleSystem({ THREE, scene }) {
       shouldRemove: false,
       disposed: false,
       instancedPools: new Set(),
+      debugLabel: null,
+      debugId: (emitterIdCounter += 1),
     };
 
     function createPool(options) {
@@ -316,6 +398,13 @@ export function createParticleSystem({ THREE, scene }) {
         getElapsedTime: () => elapsedTime,
         root,
       });
+      const label =
+        typeof emitter.debugLabel === 'string'
+          ? emitter.debugLabel
+          : typeof emitter.label === 'string'
+          ? emitter.label
+          : null;
+      state.debugLabel = label;
     } catch (error) {
       console.error('Particle emitter initialize failed:', error);
       state.shouldRemove = true;
@@ -336,6 +425,154 @@ export function createParticleSystem({ THREE, scene }) {
         }
         return count;
       },
+    };
+  }
+
+  function attachFactoryToSurface(info, factory) {
+    if (!info || typeof factory !== 'function') {
+      return;
+    }
+    let attachment = null;
+    try {
+      attachment = factory({
+        mesh: info.mesh,
+        type: info.type,
+        emit,
+        THREE,
+        getElapsedTime: () => elapsedTime,
+      });
+    } catch (error) {
+      console.error('Fluid surface effect factory failed:', error);
+      attachment = null;
+    }
+    if (!attachment) {
+      return;
+    }
+    info.attachments.set(factory, attachment);
+  }
+
+  function detachFactoryFromSurface(info, factory) {
+    if (!info) {
+      return;
+    }
+    const attachment = info.attachments.get(factory);
+    if (!attachment) {
+      return;
+    }
+    info.attachments.delete(factory);
+    try {
+      attachment.dispose?.();
+    } catch (error) {
+      console.error('Fluid surface effect dispose failed:', error);
+    }
+  }
+
+  function notifyFluidSurfaceCreated({ type, mesh, runtime } = {}) {
+    if (!mesh || !type) {
+      return;
+    }
+    const normalizedType = String(type);
+    const info = {
+      type: normalizedType,
+      mesh,
+      runtime: runtime ?? null,
+      attachments: new Map(),
+    };
+    fluidSurfaceState.set(mesh, info);
+    const factories = fluidSurfaceFactories.get(normalizedType);
+    if (!factories) {
+      return;
+    }
+    factories.forEach((factory) => {
+      if (!info.attachments.has(factory)) {
+        attachFactoryToSurface(info, factory);
+      }
+    });
+  }
+
+  function notifyFluidSurfaceDisposed({ mesh } = {}) {
+    if (!mesh) {
+      return;
+    }
+    const info = fluidSurfaceState.get(mesh);
+    if (!info) {
+      return;
+    }
+    const factories = Array.from(info.attachments.keys());
+    factories.forEach((factory) => {
+      detachFactoryFromSurface(info, factory);
+    });
+    fluidSurfaceState.delete(mesh);
+  }
+
+  function registerFluidSurfaceEffect(type, factory) {
+    if (!type) {
+      throw new Error('registerFluidSurfaceEffect requires a fluid type.');
+    }
+    if (typeof factory !== 'function') {
+      throw new Error('registerFluidSurfaceEffect expects a factory function.');
+    }
+    const normalizedType = String(type);
+    let factories = fluidSurfaceFactories.get(normalizedType);
+    if (!factories) {
+      factories = new Set();
+      fluidSurfaceFactories.set(normalizedType, factories);
+    }
+    factories.add(factory);
+    fluidSurfaceState.forEach((info) => {
+      if (info.type === normalizedType && !info.attachments.has(factory)) {
+        attachFactoryToSurface(info, factory);
+      }
+    });
+    return () => {
+      const registered = fluidSurfaceFactories.get(normalizedType);
+      if (registered) {
+        registered.delete(factory);
+        if (registered.size === 0) {
+          fluidSurfaceFactories.delete(normalizedType);
+        }
+      }
+      fluidSurfaceState.forEach((info) => {
+        if (info.type === normalizedType && info.attachments.has(factory)) {
+          detachFactoryFromSurface(info, factory);
+        }
+      });
+    };
+  }
+
+  function getDebugInfo() {
+    const emitters = [];
+    let totalActiveParticles = 0;
+    activeEmitters.forEach((state) => {
+      if (state.disposed) {
+        return;
+      }
+      let activeParticles = 0;
+      state.instancedPools.forEach((pool) => {
+        activeParticles += pool.getActiveCount();
+      });
+      totalActiveParticles += activeParticles;
+      emitters.push({
+        id: state.debugId,
+        label: state.debugLabel ?? `Emitter #${state.debugId}`,
+        activeParticles,
+        pendingRemoval: Boolean(state.shouldRemove),
+      });
+    });
+    emitters.sort((a, b) => a.id - b.id);
+    const fluidSurfaces = [];
+    fluidSurfaceState.forEach((info) => {
+      fluidSurfaces.push({
+        type: info.type,
+        mesh: info.mesh,
+        attachmentCount: info.attachments.size,
+      });
+    });
+    return {
+      emitterCount: emitters.length,
+      totalActiveParticles,
+      emitters,
+      fluidSurfaces,
     };
   }
 
@@ -408,6 +645,15 @@ export function createParticleSystem({ THREE, scene }) {
       disposeEmitterState(state);
     }
 
+    fluidSurfaceState.forEach((info) => {
+      const factories = Array.from(info.attachments.keys());
+      factories.forEach((factory) => {
+        detachFactoryFromSurface(info, factory);
+      });
+    });
+    fluidSurfaceState.clear();
+    fluidSurfaceFactories.clear();
+
     scene.remove(root);
     root.children.length = 0;
   }
@@ -416,6 +662,10 @@ export function createParticleSystem({ THREE, scene }) {
     emit,
     update,
     dispose,
+    getDebugInfo,
+    registerFluidSurfaceEffect,
+    notifyFluidSurfaceCreated,
+    notifyFluidSurfaceDisposed,
     root,
   };
 }

--- a/three-demo/src/rendering/particles/gpu-billboard-emitter.js
+++ b/three-demo/src/rendering/particles/gpu-billboard-emitter.js
@@ -424,6 +424,10 @@ export function createGpuBillboardEmitter(options = {}) {
       return liveParticles.length > 0 || spawnRate > 0
     },
 
+    getActiveParticleCount() {
+      return pool ? pool.getActiveCount() : 0
+    },
+
     dispose() {
       liveParticles.length = 0
       pool = null

--- a/three-demo/src/rendering/particles/water-effects.js
+++ b/three-demo/src/rendering/particles/water-effects.js
@@ -1,0 +1,137 @@
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js'
+
+function createBurstWrapper(baseEmitter, { duration = 0.35, label } = {}) {
+  let stopTime = 0
+  let started = false
+  const burstLabel = label ?? baseEmitter?.debugLabel ?? 'BurstEmitter'
+  return {
+    debugLabel: burstLabel,
+    initialize(context) {
+      baseEmitter.initialize?.(context)
+      const now = context.getElapsedTime?.() ?? 0
+      stopTime = now + Math.max(0.05, duration)
+      started = true
+    },
+    update(context) {
+      if (!started) {
+        return false
+      }
+      const now = context.getElapsedTime?.() ?? 0
+      if (now >= stopTime) {
+        const { delta: _ignored, ...rest } = context
+        baseEmitter.update?.({ ...rest, delta: 0 })
+        const activeCount = baseEmitter.getActiveParticleCount?.() ?? 0
+        return activeCount > 0
+      }
+      return baseEmitter.update?.(context) ?? false
+    },
+    dispose() {
+      baseEmitter.dispose?.()
+    },
+  }
+}
+
+export function createWaterSplashBurst({ position, intensity = 1, duration } = {}) {
+  const power = Math.min(Math.max(intensity, 0.35), 3.2)
+  const baseEmitter = createGpuBillboardEmitter({
+    spawnRate: 180 * power,
+    maxParticles: Math.ceil(48 * power),
+    lifetime: { min: 0.45, max: 0.9 },
+    baseColor: '#ffffff',
+    colorRamp: [
+      { time: 0, color: '#87cfff' },
+      { time: 0.35, color: '#d8f0ff' },
+      { time: 1, color: '#ffffff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.45 * power },
+      { time: 0.4, size: 0.92 * power },
+      { time: 1, size: 0 },
+    ],
+    position,
+    positionJitter: { x: 0.45 * power, y: 0.2, z: 0.45 * power },
+    velocity: { x: 0, y: 4.6 * power, z: 0 },
+    velocityJitter: { x: 2.1 * power, y: 1.25 * power, z: 2.1 * power },
+    size: { min: 0.4 * power, max: 0.95 * power },
+    gravity: { x: 0, y: -9.81, z: 0 },
+    drag: 1.6,
+    fadeIn: 0.05,
+    fadeOut: 0.4,
+    opacity: 0.85,
+    depthWrite: false,
+  })
+  baseEmitter.debugLabel = 'WaterSplashParticles'
+  return createBurstWrapper(baseEmitter, {
+    duration: duration ?? 0.42,
+    label: 'WaterSplashBurst',
+  })
+}
+
+export function createWaterBubbleBurst({ position, intensity = 1, duration } = {}) {
+  const strength = Math.min(Math.max(intensity, 0.3), 2.2)
+  const baseEmitter = createGpuBillboardEmitter({
+    spawnRate: 80 * strength,
+    maxParticles: Math.ceil(36 * strength),
+    lifetime: { min: 0.8, max: 1.6 },
+    baseColor: '#8ecbff',
+    colorRamp: [
+      { time: 0, color: '#6eb9ff' },
+      { time: 0.6, color: '#c3ecff' },
+      { time: 1, color: '#ffffff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.18 * strength },
+      { time: 0.7, size: 0.36 * strength },
+      { time: 1, size: 0.04 },
+    ],
+    position,
+    positionJitter: { x: 0.32 * strength, y: 0.24, z: 0.32 * strength },
+    velocity: { x: 0, y: 1.4 + 0.6 * strength, z: 0 },
+    velocityJitter: { x: 0.5, y: 0.38, z: 0.5 },
+    size: { min: 0.16 * strength, max: 0.3 * strength },
+    gravity: { x: 0, y: 1.8, z: 0 },
+    drag: 1.05,
+    fadeIn: 0.1,
+    fadeOut: 0.25,
+    opacity: 0.9,
+    depthWrite: false,
+  })
+  baseEmitter.debugLabel = 'WaterBubbleParticles'
+  return createBurstWrapper(baseEmitter, {
+    duration: duration ?? 0.55,
+    label: 'WaterBubbleBurst',
+  })
+}
+
+export function createWaterSurfaceMistEmitter({ position, intensity = 1 } = {}) {
+  const mistStrength = Math.min(Math.max(intensity, 0.25), 2.5)
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 28 * mistStrength,
+    maxParticles: Math.ceil(90 * mistStrength),
+    lifetime: { min: 1.6, max: 2.6 },
+    baseColor: '#a7d7ff',
+    colorRamp: [
+      { time: 0, color: '#72b9ff' },
+      { time: 0.5, color: '#d9f1ff' },
+      { time: 1, color: '#ffffff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.6 * mistStrength },
+      { time: 0.55, size: 1.35 * mistStrength },
+      { time: 1, size: 1.8 * mistStrength },
+    ],
+    position,
+    positionJitter: { x: 1.6 * mistStrength, y: 0.2, z: 1.6 * mistStrength },
+    velocity: { x: 0, y: 0.38 + 0.18 * mistStrength, z: 0 },
+    velocityJitter: { x: 0.24, y: 0.32, z: 0.24 },
+    size: { min: 0.82 * mistStrength, max: 1.8 * mistStrength },
+    gravity: { x: 0, y: 0.58, z: 0 },
+    drag: 0.85,
+    fadeIn: 0.2,
+    fadeOut: 0.35,
+    opacity: 0.48,
+    depthWrite: false,
+  })
+  emitter.debugLabel = 'WaterSurfaceMist'
+  return emitter
+}

--- a/three-demo/src/style.css
+++ b/three-demo/src/style.css
@@ -175,6 +175,26 @@ button:focus-visible {
 
 }
 
+.vfx-debug-overlay {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(10, 14, 22, 0.78);
+  color: #e4f0ff;
+  border: 1px solid rgba(150, 184, 255, 0.28);
+  border-radius: 8px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.34);
+  font-family: 'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.74rem;
+  line-height: 1.45;
+  pointer-events: none;
+  z-index: 82;
+  white-space: pre;
+  max-width: 260px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -23,6 +23,27 @@ let debugBasicMaterial = null;
 
 const fluidDefinitions = new Map();
 const fluidRuntime = new Map();
+const fluidSurfaceListeners = new Set();
+
+function notifySurfaceCreated(context) {
+  fluidSurfaceListeners.forEach((listener) => {
+    try {
+      listener.onCreated?.(context);
+    } catch (error) {
+      console.error('Fluid surface creation listener failed:', error);
+    }
+  });
+}
+
+function notifySurfaceDisposed(context) {
+  fluidSurfaceListeners.forEach((listener) => {
+    try {
+      listener.onDisposed?.(context);
+    } catch (error) {
+      console.error('Fluid surface disposal listener failed:', error);
+    }
+  });
+}
 
 export function initializeFluidRegistry({ THREE }) {
   if (!THREE) {
@@ -59,6 +80,24 @@ export function initializeFluidRegistry({ THREE }) {
       };
     },
   });
+}
+
+export function registerFluidSurfaceLifecycle(callbacks = {}) {
+  const entry = {
+    onCreated:
+      typeof callbacks.onCreated === 'function' ? callbacks.onCreated : null,
+    onDisposed:
+      typeof callbacks.onDisposed === 'function' ? callbacks.onDisposed : null,
+  };
+  if (!entry.onCreated && !entry.onDisposed) {
+    throw new Error(
+      'registerFluidSurfaceLifecycle requires at least one lifecycle callback.',
+    );
+  }
+  fluidSurfaceListeners.add(entry);
+  return () => {
+    fluidSurfaceListeners.delete(entry);
+  };
 }
 
 export function registerFluidType(id, definition) {
@@ -137,6 +176,7 @@ export function createFluidSurface({ type, geometry }) {
   if (runtime.handleSurfaceCreated) {
     runtime.handleSurfaceCreated(mesh);
   }
+  notifySurfaceCreated({ type, mesh, runtime });
   return mesh;
 }
 
@@ -173,6 +213,7 @@ export function disposeFluidSurface(mesh) {
   if (runtime.handleSurfaceDisposed) {
     runtime.handleSurfaceDisposed(mesh);
   }
+  notifySurfaceDisposed({ type, mesh, runtime });
 }
 
 export function updateFluids(delta) {


### PR DESCRIPTION
## Summary
- expose fluid contact helpers and lifecycle hooks in the particle system so surfaces can drive ambient effects
- trigger splash and bubble emitters from player water transitions and register ambient mist on water chunks
- add developer console commands and overlay styling to inspect particle emitters during tuning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ae1539a0832aaabe214d8ee250b3