### PR TITLE
Track underwater state changes in player controls

### DIFF
--- a/three-demo/src/player/controls.js
+++ b/three-demo/src/player/controls.js
@@ -255,6 +255,7 @@ export function createPlayerControls({
     oxygen: 12,
     maxOxygen: 12,
     isInWater: false,
+    isUnderwater: false,
     statusMessage: 'Click or tap the game view to look around. Use WASD to move.',
   };
   let statusTimer = Number.POSITIVE_INFINITY;
@@ -1073,6 +1074,11 @@ export function createPlayerControls({
           console.error('Failed to trigger water transition particles:', error);
         }
       }
+    }
+
+    if (playerState.isUnderwater !== headUnderwater) {
+      playerState.isUnderwater = headUnderwater;
+      markStateDirty();
     }
 
     const previousOxygen = playerState.oxygen;


### PR DESCRIPTION
## Summary
- add an `isUnderwater` flag to the player state
- notify listeners when underwater state changes via the existing state push flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8b62a5da8832abf825583c7f81be4