### PR TITLE
Add exotic block textures and register lumen bloom/abyssal serum fluids

### DIFF
--- a/three-demo/src/rendering/textures.js
+++ b/three-demo/src/rendering/textures.js
@@ -198,6 +198,533 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
         return { ...shade, a: 1 };
       },
     }),
+    cryoshard_glass: engine.createTexture('cryoshard_glass', {
+      size: 128,
+      generator: ({ noise, worley, bands, color, mix, lighten, darken }) => {
+        const base = color('#6fd0ff');
+        const icyShadow = darken(base, 0.45);
+        const highlight = lighten(color('#c6f4ff'), 0.15);
+
+        const shardCells = worley({
+          scale: 9.5,
+          jitter: 0.9,
+          distancePower: 1.6,
+          variant: 'cryoshard:cells',
+        });
+        const fracture = 1 - worley({
+          scale: 12,
+          jitter: 0.4,
+          distancePower: 1.3,
+          variant: 'cryoshard:fracture',
+        });
+        const frost = bands({
+          frequency: 7,
+          angle: 28,
+          thickness: 2.4,
+          turbulence: 0.35,
+          variant: 'cryoshard:frost',
+        });
+        const mist = noise({
+          scale: 18,
+          octaves: 3,
+          persistence: 0.58,
+          variant: 'cryoshard:mist',
+        });
+
+        let shade = mix(base, icyShadow, shardCells * 0.5 + mist * 0.25);
+        shade = mix(shade, highlight, Math.pow(fracture, 1.8) * 0.5);
+        shade = mix(shade, highlight, Math.pow(frost, 1.6) * 0.35);
+
+        return { ...shade, a: 0.55 };
+      },
+    }),
+    frostbloom_moss: engine.createTexture('frostbloom_moss', {
+      size: 128,
+      generator: ({ noise, worley, color, mix, darken, lighten }) => {
+        const base = color('#5bc1a4');
+        const chill = lighten(color('#a0f7ff'), 0.12);
+        const shadow = darken(base, 0.5);
+
+        const tuft = worley({
+          scale: 6.5,
+          jitter: 0.75,
+          variant: 'frostbloom:tuft',
+        });
+        const frost = noise({
+          scale: 16,
+          octaves: 3,
+          persistence: 0.6,
+          variant: 'frostbloom:frost',
+        });
+        const bloom = noise({
+          scale: 9,
+          octaves: 2,
+          persistence: 0.55,
+          variant: 'frostbloom:bloom',
+        });
+
+        let shade = mix(base, shadow, tuft * 0.5 + frost * 0.25);
+        shade = mix(shade, chill, Math.pow(bloom, 2) * 0.45);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    chromatic_sod: engine.createTexture('chromatic_sod', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, darken, lighten }) => {
+        const base = color('#4e8c6f');
+        const accent = color('#8cf294');
+        const magenta = color('#dc6dff');
+        const shadow = darken(base, 0.4);
+
+        const grain = noise({
+          scale: 11,
+          octaves: 4,
+          persistence: 0.6,
+          variant: 'chromatic:grain',
+        });
+        const spectrum = bands({
+          frequency: 5,
+          angle: 18,
+          thickness: 2.8,
+          turbulence: 0.45,
+          variant: 'chromatic:spectrum',
+        });
+
+        let shade = mix(base, shadow, grain * 0.55);
+        shade = mix(shade, accent, Math.pow(spectrum, 1.5) * 0.4);
+        shade = mix(shade, magenta, Math.pow(1 - spectrum, 2) * 0.25);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    spectra_petal: engine.createTexture('spectra_petal', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, lighten }) => {
+        const base = color('#ff82d9');
+        const iridescent = lighten(color('#fff2ff'), 0.1);
+        const glow = color('#ffef9c');
+
+        const striation = bands({
+          frequency: 12,
+          angle: 33,
+          thickness: 2.4,
+          turbulence: 0.3,
+          variant: 'spectra:striation',
+        });
+        const sparkle = noise({
+          scale: 22,
+          octaves: 2,
+          persistence: 0.6,
+          variant: 'spectra:sparkle',
+        });
+
+        let shade = mix(base, iridescent, Math.pow(striation, 1.8) * 0.45);
+        shade = mix(shade, glow, Math.pow(sparkle, 2.4) * 0.35);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    selenite_regolith: engine.createTexture('selenite_regolith', {
+      size: 128,
+      generator: ({ noise, worley, color, mix, darken, lighten }) => {
+        const base = color('#d7dbe6');
+        const highlight = lighten(color('#f6f9ff'), 0.12);
+        const shadow = darken(base, 0.35);
+
+        const fracture = 1 - worley({
+          scale: 8.5,
+          jitter: 0.6,
+          distancePower: 1.1,
+          variant: 'selenite:fracture',
+        });
+        const dust = noise({
+          scale: 14,
+          octaves: 3,
+          persistence: 0.62,
+          variant: 'selenite:dust',
+        });
+
+        let shade = mix(base, shadow, dust * 0.45);
+        shade = mix(shade, highlight, Math.pow(fracture, 2) * 0.35);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    umbra_silt: engine.createTexture('umbra_silt', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, darken }) => {
+        const base = color('#2a1f2b');
+        const shadow = darken(base, 0.5);
+        const cool = color('#3f2e4d');
+
+        const flow = bands({
+          frequency: 6,
+          angle: -22,
+          thickness: 3.2,
+          turbulence: 0.5,
+          variant: 'umbra:flow',
+        });
+        const grit = noise({
+          scale: 15,
+          octaves: 3,
+          persistence: 0.58,
+          variant: 'umbra:grit',
+        });
+
+        let shade = mix(base, shadow, grit * 0.6);
+        shade = mix(shade, cool, Math.pow(flow, 1.5) * 0.4);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    hematite_dust: engine.createTexture('hematite_dust', {
+      size: 128,
+      generator: ({ noise, worley, color, mix, darken, lighten }) => {
+        const base = color('#a13b2e');
+        const highlight = lighten(color('#d66f58'), 0.2);
+        const shadow = darken(base, 0.45);
+
+        const plates = worley({
+          scale: 7,
+          jitter: 0.8,
+          distancePower: 1.6,
+          variant: 'hematite:plates',
+        });
+        const dust = noise({
+          scale: 18,
+          octaves: 2,
+          persistence: 0.55,
+          variant: 'hematite:dust',
+        });
+
+        let shade = mix(base, shadow, plates * 0.5 + dust * 0.35);
+        shade = mix(shade, highlight, Math.pow(1 - plates, 2.2) * 0.4);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    ferroglass_plate: engine.createTexture('ferroglass_plate', {
+      size: 128,
+      generator: ({ noise, worley, bands, color, mix, darken, lighten }) => {
+        const base = color('#536079');
+        const metal = lighten(color('#93a7c7'), 0.05);
+        const patina = color('#2f3f56');
+
+        const pane = worley({
+          scale: 5.2,
+          jitter: 0.65,
+          distancePower: 1.3,
+          variant: 'ferroglass:pane',
+        });
+        const scratches = bands({
+          frequency: 13,
+          angle: 8,
+          thickness: 1.7,
+          turbulence: 0.5,
+          variant: 'ferroglass:scratch',
+        });
+        const shimmer = noise({
+          scale: 20,
+          octaves: 2,
+          persistence: 0.65,
+          variant: 'ferroglass:shimmer',
+        });
+
+        let shade = mix(base, patina, pane * 0.55);
+        shade = mix(shade, metal, Math.pow(shimmer, 2.1) * 0.4);
+        shade = mix(shade, metal, Math.pow(scratches, 1.4) * 0.35);
+
+        return { ...shade, a: 0.88 };
+      },
+    }),
+    nocturne_bark: engine.createTexture('nocturne_bark', {
+      size: 128,
+      generator: ({ noise, bands, rings, color, mix, darken, lighten }) => {
+        const base = color('#1d141f');
+        const glow = lighten(color('#5b3a6f'), 0.18);
+        const shadow = darken(base, 0.55);
+
+        const ridges = bands({
+          frequency: 10,
+          angle: 90,
+          thickness: 2.1,
+          turbulence: 0.45,
+          variant: 'nocturne:ridges',
+        });
+        const veins = rings({
+          frequency: 12,
+          sharpness: 2.6,
+          variant: 'nocturne:veins',
+        });
+        const mote = noise({
+          scale: 14,
+          octaves: 3,
+          persistence: 0.57,
+          variant: 'nocturne:mote',
+        });
+
+        let shade = mix(base, shadow, ridges * 0.6 + mote * 0.2);
+        shade = mix(shade, glow, Math.pow(veins, 1.8) * 0.35);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    cathedral_marble: engine.createTexture('cathedral_marble', {
+      size: 128,
+      generator: ({ noise, bands, worley, color, mix, darken, lighten }) => {
+        const base = color('#f6f1ec');
+        const vein = color('#c9c3bd');
+        const gold = lighten(color('#f7d79b'), 0.05);
+
+        const marbling = bands({
+          frequency: 6.5,
+          angle: 28,
+          thickness: 3.5,
+          turbulence: 0.65,
+          variant: 'marble:bands',
+        });
+        const inclusions = worley({
+          scale: 9,
+          jitter: 0.6,
+          distancePower: 1.2,
+          variant: 'marble:inclusions',
+        });
+        const sparkle = noise({
+          scale: 22,
+          octaves: 2,
+          persistence: 0.6,
+          variant: 'marble:sparkle',
+        });
+
+        let shade = mix(base, vein, marbling * 0.45);
+        shade = mix(shade, gold, Math.pow(sparkle, 2.5) * 0.3);
+        shade = mix(shade, vein, Math.pow(inclusions, 1.8) * 0.2);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    monolith_alloy: engine.createTexture('monolith_alloy', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, darken, lighten }) => {
+        const base = color('#1e222c');
+        const sheen = lighten(color('#4a566e'), 0.12);
+        const patina = color('#272e39');
+
+        const plate = bands({
+          frequency: 4.5,
+          angle: 12,
+          thickness: 5.5,
+          turbulence: 0.35,
+          variant: 'monolith:plate',
+        });
+        const scratches = noise({
+          scale: 21,
+          octaves: 2,
+          persistence: 0.62,
+          variant: 'monolith:scratch',
+        });
+
+        let shade = mix(base, patina, plate * 0.5);
+        shade = mix(shade, sheen, Math.pow(scratches, 1.9) * 0.45);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    resonant_sand: engine.createTexture('resonant_sand', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, darken, lighten }) => {
+        const base = color('#e4d399');
+        const glow = lighten(color('#fff5c7'), 0.15);
+        const shadow = darken(base, 0.35);
+
+        const ripple = bands({
+          frequency: 5.2,
+          angle: -14,
+          thickness: 2.7,
+          turbulence: 0.42,
+          variant: 'resonant:ripple',
+        });
+        const grain = noise({
+          scale: 19,
+          octaves: 2,
+          persistence: 0.65,
+          variant: 'resonant:grain',
+        });
+
+        let shade = mix(base, shadow, grain * 0.55);
+        shade = mix(shade, glow, Math.pow(ripple, 1.4) * 0.48);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    macrovirus_chitin: engine.createTexture('macrovirus_chitin', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, darken, lighten }) => {
+        const base = color('#83423a');
+        const core = lighten(color('#d37b62'), 0.08);
+        const shadow = darken(base, 0.45);
+
+        const plating = bands({
+          frequency: 8.5,
+          angle: 18,
+          thickness: 3,
+          turbulence: 0.5,
+          variant: 'macrovirus:plating',
+        });
+        const pores = noise({
+          scale: 17,
+          octaves: 3,
+          persistence: 0.6,
+          variant: 'macrovirus:pores',
+        });
+
+        let shade = mix(base, shadow, plating * 0.55 + pores * 0.25);
+        shade = mix(shade, core, Math.pow(plating, 1.7) * 0.4);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    nanite_moss: engine.createTexture('nanite_moss', {
+      size: 128,
+      generator: ({ noise, worley, color, mix, lighten, darken }) => {
+        const base = color('#4ca08f');
+        const circuits = lighten(color('#8fffd5'), 0.05);
+        const shadow = darken(base, 0.4);
+
+        const grid = worley({
+          scale: 10.5,
+          jitter: 0.8,
+          distancePower: 1.8,
+          variant: 'nanite:grid',
+        });
+        const signal = noise({
+          scale: 23,
+          octaves: 2,
+          persistence: 0.65,
+          variant: 'nanite:signal',
+        });
+
+        let shade = mix(base, shadow, grid * 0.55);
+        shade = mix(shade, circuits, Math.pow(signal, 2.4) * 0.4);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    ossified_soil: engine.createTexture('ossified_soil', {
+      size: 128,
+      generator: ({ noise, worley, color, mix, darken, lighten }) => {
+        const base = color('#d8b296');
+        const marrow = lighten(color('#f5e3ce'), 0.08);
+        const shadow = darken(base, 0.4);
+
+        const fossil = worley({
+          scale: 6.8,
+          jitter: 0.7,
+          distancePower: 1.5,
+          variant: 'ossified:fossil',
+        });
+        const pores = noise({
+          scale: 13,
+          octaves: 3,
+          persistence: 0.6,
+          variant: 'ossified:pores',
+        });
+
+        let shade = mix(base, shadow, fossil * 0.6 + pores * 0.25);
+        shade = mix(shade, marrow, Math.pow(1 - fossil, 1.8) * 0.35);
+
+        return { ...shade, a: 1 };
+      },
+    }),
+    amber_spine: engine.createTexture('amber_spine', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, lighten, darken }) => {
+        const base = color('#d38832');
+        const glow = lighten(color('#ffd08a'), 0.2);
+        const shadow = darken(base, 0.55);
+
+        const striation = bands({
+          frequency: 9,
+          angle: 34,
+          thickness: 1.8,
+          turbulence: 0.35,
+          variant: 'amber:striation',
+        });
+        const bubbles = noise({
+          scale: 16,
+          octaves: 3,
+          persistence: 0.58,
+          variant: 'amber:bubbles',
+        });
+
+        let shade = mix(base, shadow, striation * 0.35);
+        shade = mix(shade, glow, Math.pow(bubbles, 2.1) * 0.5);
+
+        return { ...shade, a: 0.78 };
+      },
+    }),
+    chromic_mire: engine.createTexture('chromic_mire', {
+      size: 128,
+      generator: ({ noise, bands, color, mix, lighten, darken }) => {
+        const base = color('#5c3145');
+        const sheen = lighten(color('#a75e7a'), 0.12);
+        const shadow = darken(base, 0.5);
+
+        const swirl = bands({
+          frequency: 4.8,
+          angle: -26,
+          thickness: 4.5,
+          turbulence: 0.55,
+          variant: 'chromic:swirl',
+        });
+        const bubbles = noise({
+          scale: 14,
+          octaves: 3,
+          persistence: 0.62,
+          variant: 'chromic:bubble',
+        });
+
+        let shade = mix(base, shadow, swirl * 0.45 + bubbles * 0.35);
+        shade = mix(shade, sheen, Math.pow(swirl, 1.6) * 0.4);
+
+        return { ...shade, a: 0.82 };
+      },
+    }),
+    neon_bark: engine.createTexture('neon_bark', {
+      size: 128,
+      generator: ({ noise, bands, rings, color, mix, lighten, darken }) => {
+        const base = color('#14293f');
+        const glow = lighten(color('#37d8ff'), 0.18);
+        const ember = color('#ff6be4');
+        const shadow = darken(base, 0.45);
+
+        const ridges = bands({
+          frequency: 11,
+          angle: 90,
+          thickness: 1.9,
+          turbulence: 0.4,
+          variant: 'neon:ridges',
+        });
+        const conduits = rings({
+          frequency: 8,
+          sharpness: 2.1,
+          variant: 'neon:conduits',
+        });
+        const sparks = noise({
+          scale: 19,
+          octaves: 2,
+          persistence: 0.65,
+          variant: 'neon:sparks',
+        });
+
+        let shade = mix(base, shadow, ridges * 0.6);
+        shade = mix(shade, glow, Math.pow(conduits, 1.7) * 0.45);
+        shade = mix(shade, ember, Math.pow(sparks, 2.2) * 0.3);
+
+        return { ...shade, a: 1 };
+      },
+    }),
     cloud: engine.createTexture('cloud', {
       size: 128,
       generator: ({ noise, worley, color, mix, lighten, darken }) => {
@@ -336,6 +863,186 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
       {
         tintStrength: 0.4,
         name: 'CloudBiomeMaterial',
+      },
+    ),
+    cryoshard_glass: createStandardBlockMaterial(
+      textures.cryoshard_glass,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.6,
+        roughness: 0.22,
+        metalness: 0.08,
+        envMapIntensity: 0.8,
+        depthWrite: false,
+      },
+      {
+        tintStrength: 0.35,
+        name: 'CryoshardGlassMaterial',
+      },
+    ),
+    frostbloom_moss: createStandardBlockMaterial(
+      textures.frostbloom_moss,
+      { roughness: 0.72 },
+      {
+        tintStrength: 0.9,
+        name: 'FrostbloomMossMaterial',
+      },
+    ),
+    chromatic_sod: createStandardBlockMaterial(
+      textures.chromatic_sod,
+      { roughness: 0.78 },
+      {
+        tintStrength: 0.95,
+        name: 'ChromaticSodMaterial',
+      },
+    ),
+    spectra_petal: createStandardBlockMaterial(
+      textures.spectra_petal,
+      { roughness: 0.68 },
+      {
+        tintStrength: 0.85,
+        name: 'SpectraPetalMaterial',
+      },
+    ),
+    selenite_regolith: createStandardBlockMaterial(
+      textures.selenite_regolith,
+      { roughness: 0.82 },
+      {
+        tintStrength: 0.6,
+        name: 'SeleniteRegolithMaterial',
+      },
+    ),
+    umbra_silt: createStandardBlockMaterial(
+      textures.umbra_silt,
+      { roughness: 0.76 },
+      {
+        tintStrength: 0.55,
+        name: 'UmbraSiltMaterial',
+      },
+    ),
+    hematite_dust: createStandardBlockMaterial(
+      textures.hematite_dust,
+      { roughness: 0.74 },
+      {
+        tintStrength: 0.7,
+        name: 'HematiteDustMaterial',
+      },
+    ),
+    ferroglass_plate: createStandardBlockMaterial(
+      textures.ferroglass_plate,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.9,
+        roughness: 0.32,
+        metalness: 0.45,
+      },
+      {
+        tintStrength: 0.4,
+        name: 'FerroglassPlateMaterial',
+      },
+    ),
+    nocturne_bark: createStandardBlockMaterial(
+      textures.nocturne_bark,
+      { roughness: 0.8 },
+      {
+        tintStrength: 0.75,
+        name: 'NocturneBarkMaterial',
+      },
+    ),
+    cathedral_marble: createStandardBlockMaterial(
+      textures.cathedral_marble,
+      {
+        flatShading: false,
+        roughness: 0.4,
+        metalness: 0.05,
+      },
+      {
+        tintStrength: 0.5,
+        name: 'CathedralMarbleMaterial',
+      },
+    ),
+    monolith_alloy: createStandardBlockMaterial(
+      textures.monolith_alloy,
+      {
+        flatShading: false,
+        roughness: 0.28,
+        metalness: 0.6,
+        envMapIntensity: 0.9,
+      },
+      {
+        tintStrength: 0.45,
+        name: 'MonolithAlloyMaterial',
+      },
+    ),
+    resonant_sand: createStandardBlockMaterial(
+      textures.resonant_sand,
+      { roughness: 0.7 },
+      {
+        tintStrength: 0.65,
+        name: 'ResonantSandMaterial',
+      },
+    ),
+    macrovirus_chitin: createStandardBlockMaterial(
+      textures.macrovirus_chitin,
+      { roughness: 0.66 },
+      {
+        tintStrength: 0.8,
+        name: 'MacrovirusChitinMaterial',
+      },
+    ),
+    nanite_moss: createStandardBlockMaterial(
+      textures.nanite_moss,
+      { roughness: 0.62 },
+      {
+        tintStrength: 0.9,
+        name: 'NaniteMossMaterial',
+      },
+    ),
+    ossified_soil: createStandardBlockMaterial(
+      textures.ossified_soil,
+      { roughness: 0.78 },
+      {
+        tintStrength: 0.6,
+        name: 'OssifiedSoilMaterial',
+      },
+    ),
+    amber_spine: createStandardBlockMaterial(
+      textures.amber_spine,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.82,
+        roughness: 0.38,
+        metalness: 0.1,
+        depthWrite: false,
+      },
+      {
+        tintStrength: 0.5,
+        name: 'AmberSpineMaterial',
+      },
+    ),
+    chromic_mire: createStandardBlockMaterial(
+      textures.chromic_mire,
+      {
+        flatShading: false,
+        transparent: true,
+        opacity: 0.88,
+        roughness: 0.55,
+        metalness: 0.12,
+      },
+      {
+        tintStrength: 0.7,
+        name: 'ChromicMireMaterial',
+      },
+    ),
+    neon_bark: createStandardBlockMaterial(
+      textures.neon_bark,
+      { roughness: 0.58 },
+      {
+        tintStrength: 0.85,
+        name: 'NeonBarkMaterial',
       },
     ),
     damageStages,

--- a/three-demo/src/world/fluids/abyssal-serum-material.js
+++ b/three-demo/src/world/fluids/abyssal-serum-material.js
@@ -1,0 +1,126 @@
+import { SURFACE_ROLES } from './fluid-geometry.js';
+
+const SERUM_SETTINGS = Object.freeze({
+  baseOpacity: 0.92,
+  emissiveBase: 0.22,
+  shimmerStrength: 0.18,
+  distortionScale: 0.15,
+  distortionSpeed: 0.6,
+});
+
+export function createAbyssalSerumMaterial({ THREE }) {
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#1b0d2a'),
+    emissive: new THREE.Color('#3c1647'),
+    emissiveIntensity: SERUM_SETTINGS.emissiveBase,
+    roughness: 0.46,
+    metalness: 0.28,
+    transparent: true,
+    opacity: SERUM_SETTINGS.baseOpacity,
+    vertexColors: true,
+  });
+
+  material.side = THREE.DoubleSide;
+  material.depthWrite = false;
+
+  const uniforms = {
+    uTime: { value: 0 },
+    uDistortionScale: { value: SERUM_SETTINGS.distortionScale },
+    uDistortionSpeed: { value: SERUM_SETTINGS.distortionSpeed },
+    uShimmerStrength: { value: SERUM_SETTINGS.shimmerStrength },
+  };
+
+  material.userData.uniforms = uniforms;
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uTime = uniforms.uTime;
+    shader.uniforms.uDistortionScale = uniforms.uDistortionScale;
+    shader.uniforms.uDistortionSpeed = uniforms.uDistortionSpeed;
+    shader.uniforms.uShimmerStrength = uniforms.uShimmerStrength;
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <common>',
+      `#include <common>\nattribute float surfaceType;\nattribute float surfaceRole;\nattribute vec2 flowDirection;\nattribute float flowStrength;\nattribute float depth;\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nvarying vec2 vFlowDirection;\nvarying float vFlowStrength;\nvarying float vDepth;`,
+    );
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <begin_vertex>',
+      `#include <begin_vertex>\n\tvSurfaceType = surfaceType;\n\tvSurfaceRole = surfaceRole;\n\tvFlowDirection = flowDirection;\n\tvFlowStrength = flowStrength;\n\tvDepth = depth;`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <common>',
+      `#include <common>\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nvarying vec2 vFlowDirection;\nvarying float vFlowStrength;\nvarying float vDepth;\nuniform float uTime;\nuniform float uDistortionScale;\nuniform float uDistortionSpeed;\nuniform float uShimmerStrength;`,
+    );
+
+    const EDGE_TOP_MIN = (SURFACE_ROLES.EDGE_TOP - 0.5).toFixed(1);
+    const EDGE_TOP_MAX = (SURFACE_ROLES.EDGE_TOP + 0.5).toFixed(1);
+    const EDGE_BOTTOM_MIN = (SURFACE_ROLES.EDGE_BOTTOM - 0.5).toFixed(1);
+    const EDGE_BOTTOM_MAX = (SURFACE_ROLES.EDGE_BOTTOM + 0.5).toFixed(1);
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <emissivemap_fragment>',
+      `#include <emissivemap_fragment>\nfloat edgeMask = smoothstep(${EDGE_TOP_MIN}, ${EDGE_TOP_MAX}, vSurfaceRole);\nedgeMask += smoothstep(${EDGE_BOTTOM_MIN}, ${EDGE_BOTTOM_MAX}, vSurfaceRole);\nfloat flowPhase = dot(vFlowDirection, vec2(12.0, -12.0)) * uDistortionScale + uTime * (uDistortionSpeed + vFlowStrength * 0.8);\nfloat viscosity = sin(flowPhase + vSurfaceType * 1.2);\nfloat shimmer = max(0.0, viscosity) * uShimmerStrength;\ntotalEmissiveRadiance += vec3(shimmer + edgeMask * 0.12);`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <output_fragment>',
+      `diffuseColor.rgb = mix(diffuseColor.rgb, diffuseColor.rgb * 0.45, clamp(vFlowStrength * 0.7, 0.0, 1.0));\ndiffuseColor.a = clamp(diffuseColor.a * (0.75 + vDepth * 0.12) + edgeMask * 0.08, 0.0, 1.0);\n#include <output_fragment>`,
+    );
+  };
+
+  material.customProgramCacheKey = () =>
+    `abyssal-serum-fluid-${SERUM_SETTINGS.distortionScale}-${SERUM_SETTINGS.shimmerStrength}`;
+
+  const phaseOffsets = new WeakMap();
+  let elapsed = 0;
+
+  const ensureOffset = (mesh) => {
+    if (phaseOffsets.has(mesh)) {
+      return phaseOffsets.get(mesh);
+    }
+    const offset = Math.random() * Math.PI * 2;
+    phaseOffsets.set(mesh, offset);
+    return offset;
+  };
+
+  const update = (delta, surfaces) => {
+    if (!delta || delta <= 0) {
+      return;
+    }
+    elapsed += delta;
+    uniforms.uTime.value = elapsed;
+
+    if (!surfaces || surfaces.size === 0) {
+      uniforms.uDistortionScale.value = SERUM_SETTINGS.distortionScale;
+      uniforms.uShimmerStrength.value = SERUM_SETTINGS.shimmerStrength;
+      return;
+    }
+
+    let wobbleTotal = 0;
+    let shimmerTotal = 0;
+    surfaces.forEach((mesh) => {
+      const offset = ensureOffset(mesh);
+      wobbleTotal += 1 + Math.sin(elapsed * 0.5 + offset) * 0.05;
+      shimmerTotal += 0.9 + Math.cos(elapsed * 0.7 + offset) * 0.1;
+    });
+    const wobbleAverage = wobbleTotal / surfaces.size;
+    const shimmerAverage = shimmerTotal / surfaces.size;
+    uniforms.uDistortionScale.value =
+      SERUM_SETTINGS.distortionScale * wobbleAverage;
+    uniforms.uShimmerStrength.value =
+      SERUM_SETTINGS.shimmerStrength * shimmerAverage;
+  };
+
+  const onSurfaceDisposed = (mesh) => {
+    phaseOffsets.delete(mesh);
+  };
+
+  return {
+    material,
+    update,
+    onSurfaceDisposed,
+  };
+}
+
+export default createAbyssalSerumMaterial;

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -1,4 +1,6 @@
 import { createHydraWaterMaterial } from './water-material.js';
+import { createLumenBloomMaterial } from './lumen-bloom-material.js';
+import { createAbyssalSerumMaterial } from './abyssal-serum-material.js';
 import { getWorldOptions } from '../world-settings.js';
 
 let THREERef = null;
@@ -24,6 +26,68 @@ let debugBasicMaterial = null;
 const fluidDefinitions = new Map();
 const fluidRuntime = new Map();
 const fluidSurfaceListeners = new Set();
+
+const DEFAULT_FLUID_SEED = 7331;
+
+function pseudoRandom2D(x, z, seed = DEFAULT_FLUID_SEED) {
+  const hash = Math.sin(x * 127.1 + z * 311.7 + seed * 0.001) * 43758.5453;
+  return hash - Math.floor(hash);
+}
+
+function resolveLumenBloomPresence({ x, z, sampleColumnHeight, worldConfig }) {
+  const groundHeight = sampleColumnHeight(x, z);
+  const baseSurface = groundHeight + 0.5;
+  const seed = worldConfig?.seedHash ?? DEFAULT_FLUID_SEED;
+  const cluster = pseudoRandom2D(x * 0.12, z * 0.12, seed * 0.73);
+  const bloom = pseudoRandom2D(x * 0.27 + 11.3, z * 0.27 - 6.1, seed * 0.41);
+  const altitudeBias = Math.max(0, (worldConfig?.waterLevel ?? groundHeight) - groundHeight);
+
+  if (cluster + bloom * 0.4 + altitudeBias * 0.01 < 0.75) {
+    return {
+      hasFluid: false,
+      surfaceY: baseSurface,
+      bottomY: baseSurface,
+    };
+  }
+
+  const surfaceRise = 0.6 + (cluster - 0.5) * 1.2 + bloom * 0.5;
+  const depth = 0.6 + bloom * 0.9;
+  const surfaceY = baseSurface + surfaceRise;
+
+  return {
+    hasFluid: true,
+    surfaceY,
+    bottomY: surfaceY - depth,
+  };
+}
+
+function resolveAbyssalSerumPresence({ x, z, sampleColumnHeight, worldConfig }) {
+  const groundHeight = sampleColumnHeight(x, z);
+  const baseSurface = groundHeight + 0.5;
+  const seed = worldConfig?.seedHash ?? DEFAULT_FLUID_SEED;
+  const caverns = pseudoRandom2D(x * 0.18 - 4.2, z * 0.18 + 3.6, seed * 0.91);
+  const seep = pseudoRandom2D(x * 0.05 + 12.5, z * 0.05 - 2.7, seed * 0.33);
+  const depthBias = Math.max(0, (worldConfig?.waterLevel ?? groundHeight) - groundHeight);
+  const threshold = 0.68 - depthBias * 0.01;
+
+  if (caverns < threshold || seep < 0.45) {
+    return {
+      hasFluid: false,
+      surfaceY: baseSurface,
+      bottomY: baseSurface,
+    };
+  }
+
+  const surfaceDrop = 0.3 + seep * 0.4;
+  const depth = 0.9 + caverns * 1.6;
+  const surfaceY = baseSurface - surfaceDrop;
+
+  return {
+    hasFluid: true,
+    surfaceY,
+    bottomY: surfaceY - depth,
+  };
+}
 
 function notifySurfaceCreated(context) {
   fluidSurfaceListeners.forEach((listener) => {
@@ -79,6 +143,18 @@ export function initializeFluidRegistry({ THREE }) {
         bottomY: surfaceY,
       };
     },
+  });
+
+  registerFluidType('lumen_bloom', {
+    label: 'Lumen Bloom',
+    createMaterial: (context) => createLumenBloomMaterial(context),
+    presenceResolver: resolveLumenBloomPresence,
+  });
+
+  registerFluidType('abyssal_serum', {
+    label: 'Abyssal Serum',
+    createMaterial: (context) => createAbyssalSerumMaterial(context),
+    presenceResolver: resolveAbyssalSerumPresence,
   });
 }
 

--- a/three-demo/src/world/fluids/lumen-bloom-material.js
+++ b/three-demo/src/world/fluids/lumen-bloom-material.js
@@ -1,0 +1,115 @@
+import { SURFACE_ROLES } from './fluid-geometry.js';
+
+const LUMEN_SETTINGS = Object.freeze({
+  baseEmissiveIntensity: 0.85,
+  edgeGlow: 0.55,
+  pulseStrength: 0.5,
+  opacity: 0.82,
+  pulseSpeed: 1.8,
+});
+
+export function createLumenBloomMaterial({ THREE }) {
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#f7fbb4'),
+    emissive: new THREE.Color('#f4ffd2'),
+    emissiveIntensity: LUMEN_SETTINGS.baseEmissiveIntensity,
+    roughness: 0.3,
+    metalness: 0.08,
+    transparent: true,
+    opacity: LUMEN_SETTINGS.opacity,
+    vertexColors: true,
+  });
+
+  material.side = THREE.DoubleSide;
+  material.depthWrite = false;
+
+  const uniforms = {
+    uTime: { value: 0 },
+    uEdgeGlow: { value: LUMEN_SETTINGS.edgeGlow },
+    uPulseStrength: { value: LUMEN_SETTINGS.pulseStrength },
+    uPulseSpeed: { value: LUMEN_SETTINGS.pulseSpeed },
+  };
+
+  material.userData.uniforms = uniforms;
+
+  const EDGE_TOP_MIN = (SURFACE_ROLES.EDGE_TOP - 0.5).toFixed(1);
+  const EDGE_TOP_MAX = (SURFACE_ROLES.EDGE_TOP + 0.5).toFixed(1);
+  const EDGE_BOTTOM_MIN = (SURFACE_ROLES.EDGE_BOTTOM - 0.5).toFixed(1);
+  const EDGE_BOTTOM_MAX = (SURFACE_ROLES.EDGE_BOTTOM + 0.5).toFixed(1);
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uTime = uniforms.uTime;
+    shader.uniforms.uEdgeGlow = uniforms.uEdgeGlow;
+    shader.uniforms.uPulseStrength = uniforms.uPulseStrength;
+    shader.uniforms.uPulseSpeed = uniforms.uPulseSpeed;
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <common>',
+      `#include <common>\nattribute float surfaceType;\nattribute float surfaceRole;\nvarying float vSurfaceType;\nvarying float vSurfaceRole;`,
+    );
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <begin_vertex>',
+      `#include <begin_vertex>\n\tvSurfaceType = surfaceType;\n\tvSurfaceRole = surfaceRole;`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <common>',
+      `#include <common>\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nuniform float uTime;\nuniform float uEdgeGlow;\nuniform float uPulseStrength;\nuniform float uPulseSpeed;`,
+    );
+
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <emissivemap_fragment>',
+      `#include <emissivemap_fragment>\n\nfloat surfaceBand = smoothstep(0.5, 1.5, vSurfaceType);\nfloat roleBand = smoothstep(${EDGE_TOP_MIN}, ${EDGE_TOP_MAX}, vSurfaceRole);\nroleBand += smoothstep(${EDGE_BOTTOM_MIN}, ${EDGE_BOTTOM_MAX}, vSurfaceRole);\nfloat edgeGlow = clamp(surfaceBand + roleBand, 0.0, 2.0);\nfloat pulse = sin(uTime * uPulseSpeed + vSurfaceType * 1.35);\nfloat luminance = max(0.0, pulse) * uPulseStrength + edgeGlow * uEdgeGlow;\ntotalEmissiveRadiance += vec3(luminance);\ndiffuseColor.a = clamp(diffuseColor.a + edgeGlow * 0.12, 0.0, 1.0);`,
+    );
+  };
+
+  material.customProgramCacheKey = () =>
+    `lumen-bloom-fluid-${LUMEN_SETTINGS.edgeGlow}-${LUMEN_SETTINGS.pulseStrength}`;
+
+  const surfacePulseOffsets = new WeakMap();
+  let elapsed = 0;
+
+  const ensureOffset = (mesh) => {
+    if (surfacePulseOffsets.has(mesh)) {
+      return surfacePulseOffsets.get(mesh);
+    }
+    const offset = Math.random() * Math.PI * 2;
+    surfacePulseOffsets.set(mesh, offset);
+    return offset;
+  };
+
+  const update = (delta, surfaces) => {
+    if (!delta || delta <= 0) {
+      return;
+    }
+    elapsed += delta;
+    uniforms.uTime.value = elapsed;
+
+    if (!surfaces || surfaces.size === 0) {
+      material.emissiveIntensity = LUMEN_SETTINGS.baseEmissiveIntensity;
+      return;
+    }
+
+    let biasTotal = 0;
+    surfaces.forEach((mesh) => {
+      const offset = ensureOffset(mesh);
+      biasTotal += 0.85 + Math.sin(elapsed * 0.3 + offset) * 0.08;
+    });
+    const averageBias = biasTotal / surfaces.size;
+    material.emissiveIntensity =
+      LUMEN_SETTINGS.baseEmissiveIntensity * averageBias;
+  };
+
+  const onSurfaceDisposed = (mesh) => {
+    surfacePulseOffsets.delete(mesh);
+  };
+
+  return {
+    material,
+    update,
+    onSurfaceDisposed,
+  };
+}
+
+export default createLumenBloomMaterial;

--- a/three-demo/src/world/procedural/nanovoxel-palette.js
+++ b/three-demo/src/world/procedural/nanovoxel-palette.js
@@ -114,6 +114,208 @@ const NANOVOXEL_DEFINITIONS = [
       },
     ],
   },
+  {
+    id: 'frost_spicule',
+    baseType: 'cryoshard_glass',
+    baseScale: { x: 0.08, y: 0.24, z: 0.08 },
+    defaultTint: '#b5f2ff',
+    accentTint: '#e8ffff',
+    accentStrength: 0.4,
+    inheritTintStrength: 0.3,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.25,
+      },
+      {
+        offset: { right: 0.04, up: 0.2, forward: -0.02 },
+        scale: { right: 0.6, up: 0.85, forward: 0.6 },
+        accentStrength: 0.5,
+      },
+    ],
+  },
+  {
+    id: 'prism_stamen',
+    baseType: 'spectra_petal',
+    baseScale: { x: 0.16, y: 0.08, z: 0.16 },
+    defaultTint: '#ffc8ff',
+    accentTint: '#fffbe3',
+    accentStrength: 0.42,
+    inheritTintStrength: 0.35,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.32,
+      },
+      {
+        offset: { right: 0.14, up: 0.04, forward: 0.12 },
+        scale: { right: 0.7, up: 0.9, forward: 0.72 },
+        accentStrength: 0.45,
+      },
+      {
+        offset: { right: -0.16, up: 0.05, forward: 0.1 },
+        scale: { right: 0.68, up: 0.92, forward: 0.7 },
+        accentStrength: 0.45,
+      },
+    ],
+  },
+  {
+    id: 'lunar_shard',
+    baseType: 'selenite_regolith',
+    baseScale: { x: 0.14, y: 0.12, z: 0.18 },
+    defaultTint: '#f1f7ff',
+    accentTint: '#d6e7ff',
+    accentStrength: 0.28,
+    inheritTintStrength: 0.4,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+      },
+      {
+        offset: { right: -0.08, up: 0.1, forward: 0.16 },
+        scale: { right: 0.72, up: 0.78, forward: 0.85 },
+        accentStrength: 0.32,
+      },
+    ],
+  },
+  {
+    id: 'dust_plume',
+    baseType: 'resonant_sand',
+    baseScale: { x: 0.22, y: 0.14, z: 0.22 },
+    defaultTint: '#ffe8b6',
+    accentTint: '#fff3cd',
+    accentStrength: 0.3,
+    inheritTintStrength: 0.25,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1.1, up: 1, forward: 1.1 },
+        accentStrength: 0.22,
+      },
+      {
+        offset: { right: 0.18, up: 0.08, forward: 0.16 },
+        scale: { right: 0.8, up: 0.85, forward: 0.78 },
+        accentStrength: 0.35,
+      },
+      {
+        offset: { right: -0.18, up: 0.12, forward: 0.18 },
+        scale: { right: 0.76, up: 0.88, forward: 0.74 },
+        accentStrength: 0.35,
+      },
+    ],
+  },
+  {
+    id: 'gothic_briar',
+    baseType: 'nocturne_bark',
+    baseScale: { x: 0.14, y: 0.24, z: 0.14 },
+    defaultTint: '#3c1f44',
+    accentTint: '#7c4aa8',
+    accentStrength: 0.38,
+    inheritTintStrength: 0.3,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+      },
+      {
+        offset: { right: 0.12, up: 0.2, forward: 0.1 },
+        scale: { right: 0.65, up: 0.7, forward: 0.62 },
+        accentStrength: 0.45,
+      },
+    ],
+  },
+  {
+    id: 'monolith_sigil',
+    baseType: 'monolith_alloy',
+    baseScale: { x: 0.18, y: 0.18, z: 0.02 },
+    defaultTint: '#384056',
+    accentTint: '#6b7bb0',
+    accentStrength: 0.5,
+    inheritTintStrength: 0.2,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1.2, up: 1.2, forward: 1 },
+        accentStrength: 0.45,
+      },
+      {
+        offset: { right: -0.04, up: 0.04, forward: 0.02 },
+        scale: { right: 0.7, up: 0.7, forward: 1 },
+        accentStrength: 0.55,
+      },
+    ],
+  },
+  {
+    id: 'viral_spore',
+    baseType: 'macrovirus_chitin',
+    baseScale: { x: 0.12, y: 0.12, z: 0.12 },
+    defaultTint: '#f1a37a',
+    accentTint: '#ffe2c8',
+    accentStrength: 0.48,
+    inheritTintStrength: 0.32,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.38,
+      },
+      {
+        offset: { right: 0.08, up: 0.06, forward: 0.1 },
+        scale: { right: 0.75, up: 0.85, forward: 0.78 },
+        accentStrength: 0.52,
+      },
+    ],
+  },
+  {
+    id: 'ossuary_filament',
+    baseType: 'ossified_soil',
+    baseScale: { x: 0.18, y: 0.06, z: 0.18 },
+    defaultTint: '#f2d9c6',
+    accentTint: '#fff3e6',
+    accentStrength: 0.34,
+    inheritTintStrength: 0.28,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1.1, up: 0.95, forward: 1.1 },
+        accentStrength: 0.3,
+      },
+      {
+        offset: { right: 0.2, up: 0.06, forward: 0.18 },
+        scale: { right: 0.78, up: 0.9, forward: 0.76 },
+        accentStrength: 0.4,
+      },
+      {
+        offset: { right: -0.18, up: 0.08, forward: 0.16 },
+        scale: { right: 0.76, up: 0.88, forward: 0.74 },
+        accentStrength: 0.4,
+      },
+    ],
+  },
+  {
+    id: 'neon_drop',
+    baseType: 'neon_bark',
+    baseScale: { x: 0.1, y: 0.18, z: 0.1 },
+    defaultTint: '#38d6ff',
+    accentTint: '#ff6df5',
+    accentStrength: 0.55,
+    inheritTintStrength: 0.35,
+    elements: [
+      {
+        offset: { right: 0, up: 0, forward: 0 },
+        scale: { right: 1, up: 1, forward: 1 },
+        accentStrength: 0.45,
+      },
+      {
+        offset: { right: -0.06, up: 0.16, forward: -0.02 },
+        scale: { right: 0.6, up: 0.7, forward: 0.6 },
+        accentStrength: 0.6,
+      },
+    ],
+  },
 ];
 
 const NANOVOXEL_MAP = new Map(NANOVOXEL_DEFINITIONS.map((definition) => [definition.id, definition]));


### PR DESCRIPTION
## Summary
- generate material textures for crystalline, fungal, metallic, and luminous block families and wire them into the block material map
- extend the nanovoxel palette with biome-aligned accent pieces for new micro-props
- introduce lumen bloom and abyssal serum fluid material factories and register their presence resolvers in the fluid registry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c725d4f0832a95d88ea788cc8c8a