### PR TITLE
Add ice spire tundra biome and frostbound props

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -14,6 +14,7 @@ import auroral from './biomes/auroral_glass_reef.json' with { type: 'json' };
 import noctilucent from './biomes/noctilucent_fungus_glade.json' with {
   type: 'json',
 };
+import iceSpireTundra from './biomes/ice_spire_tundra.json' with { type: 'json' };
 
 
 const rawBiomeDefinitions = [
@@ -24,6 +25,7 @@ const rawBiomeDefinitions = [
   vaporwave,
   auroral,
   noctilucent,
+  iceSpireTundra,
 ];
 
 const NEUTRAL_BASE_PALETTE = {

--- a/three-demo/src/world/biomes/ice_spire_tundra.json
+++ b/three-demo/src/world/biomes/ice_spire_tundra.json
@@ -1,0 +1,66 @@
+{
+  "id": "ice_spire_tundra",
+  "label": "Ice Spire Tundra",
+  "tags": ["frozen", "hazard_frostbite", "windswept"],
+  "climate": {
+    "temperature": 0.04,
+    "moisture": 0.18,
+    "weight": 0.9
+  },
+  "terrain": {
+    "surfaceBlock": "stone",
+    "shoreBlock": "stone",
+    "subSurfaceBlock": "stone",
+    "subSurfaceDepth": 4,
+    "deepBlock": "stone",
+    "treeDensity": 0.0,
+    "shrubChance": 0.02,
+    "flowerChance": 0.01,
+    "rockChance": 0.22,
+    "fungiChance": 0.0,
+    "waterPlantChance": 0.0,
+    "structureChance": 0.28,
+    "objectDensityMultiplier": 0.55,
+    "objectDensityMultipliers": {
+      "structures": 2.4,
+      "rocks": 1.8,
+      "shrubs": 0.4,
+      "flowers": 0.35
+    },
+    "treeHeight": {
+      "min": 1,
+      "max": 2
+    },
+    "heightOffset": 1.5
+  },
+  "palette": {
+    "grass": "#d0f6ff",
+    "dirt": "#8aa3b4",
+    "stone": "#b5c9d6",
+    "water": "#5aa0c9",
+    "cloud": "#edf8ff",
+    "leaf": "#e7fbff",
+    "log": "#9fb2be",
+    "cryoshard_glass": "#bce6ff",
+    "frostbloom_moss": "#9de0d8"
+  },
+  "shader": {
+    "fogColor": "#c0dfff",
+    "tintColor": "#e0f4ff",
+    "tintStrength": 0.68,
+    "effects": {
+      "blizzardHaze": {
+        "intensity": 0.85,
+        "windShear": 0.7,
+        "particleColor": "#f1fbff"
+      }
+    },
+    "hazards": {
+      "frostbite": {
+        "severity": 0.9,
+        "exposureWindowSeconds": 18,
+        "description": "Supercooled squalls sap body heat within moments of exposure."
+      }
+    }
+  }
+}

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -34,13 +34,30 @@ function pseudoRandom2D(x, z, seed = DEFAULT_FLUID_SEED) {
   return hash - Math.floor(hash);
 }
 
-function resolveLumenBloomPresence({ x, z, sampleColumnHeight, worldConfig }) {
+function resolveLumenBloomPresence({
+  x,
+  z,
+  sampleColumnHeight,
+  worldConfig,
+  sampleBiomeAt,
+}) {
   const groundHeight = sampleColumnHeight(x, z);
   const baseSurface = groundHeight + 0.5;
   const seed = worldConfig?.seedHash ?? DEFAULT_FLUID_SEED;
   const cluster = pseudoRandom2D(x * 0.12, z * 0.12, seed * 0.73);
   const bloom = pseudoRandom2D(x * 0.27 + 11.3, z * 0.27 - 6.1, seed * 0.41);
   const altitudeBias = Math.max(0, (worldConfig?.waterLevel ?? groundHeight) - groundHeight);
+
+  const biomeSample =
+    sampleBiomeAt?.(x, z) ?? worldConfig?.biomeEngine?.getBiomeAt?.(x, z);
+  const biomeId = biomeSample?.biome?.id ?? biomeSample?.id ?? null;
+  if (biomeId === 'ice_spire_tundra') {
+    return {
+      hasFluid: false,
+      surfaceY: baseSurface,
+      bottomY: baseSurface,
+    };
+  }
 
   if (cluster + bloom * 0.4 + altitudeBias * 0.01 < 0.75) {
     return {
@@ -61,7 +78,13 @@ function resolveLumenBloomPresence({ x, z, sampleColumnHeight, worldConfig }) {
   };
 }
 
-function resolveAbyssalSerumPresence({ x, z, sampleColumnHeight, worldConfig }) {
+function resolveAbyssalSerumPresence({
+  x,
+  z,
+  sampleColumnHeight,
+  worldConfig,
+  sampleBiomeAt,
+}) {
   const groundHeight = sampleColumnHeight(x, z);
   const baseSurface = groundHeight + 0.5;
   const seed = worldConfig?.seedHash ?? DEFAULT_FLUID_SEED;
@@ -69,6 +92,17 @@ function resolveAbyssalSerumPresence({ x, z, sampleColumnHeight, worldConfig }) 
   const seep = pseudoRandom2D(x * 0.05 + 12.5, z * 0.05 - 2.7, seed * 0.33);
   const depthBias = Math.max(0, (worldConfig?.waterLevel ?? groundHeight) - groundHeight);
   const threshold = 0.68 - depthBias * 0.01;
+
+  const biomeSample =
+    sampleBiomeAt?.(x, z) ?? worldConfig?.biomeEngine?.getBiomeAt?.(x, z);
+  const biomeId = biomeSample?.biome?.id ?? biomeSample?.id ?? null;
+  if (biomeId === 'ice_spire_tundra') {
+    return {
+      hasFluid: false,
+      surfaceY: baseSurface,
+      bottomY: baseSurface,
+    };
+  }
 
   if (caverns < threshold || seep < 0.45) {
     return {
@@ -314,6 +348,7 @@ export function resolveFluidPresence({
   z,
   sampleColumnHeight,
   worldConfig,
+  sampleBiomeAt,
 }) {
   const config = worldConfig ?? getWorldOptions();
   const definition = fluidDefinitions.get(type);
@@ -331,6 +366,7 @@ export function resolveFluidPresence({
       z,
       sampleColumnHeight,
       worldConfig: config,
+      sampleBiomeAt,
     });
   }
   const groundHeight = sampleColumnHeight(x, z);

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1020,6 +1020,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
             z: nz,
             sampleColumnHeight: getColumnHeight,
             worldConfig: worldOptions,
+            sampleBiomeAt: sampleColumnCached,
           });
           neighborInfo = {
             hasFluid: Boolean(presence?.hasFluid),

--- a/three-demo/src/world/voxel-objects/flowers/vented_ice_bloom.json
+++ b/three-demo/src/world/voxel-objects/flowers/vented_ice_bloom.json
@@ -1,0 +1,75 @@
+{
+  "id": "vented_ice_bloom",
+  "label": "Vented Ice Bloom",
+  "category": "flowers",
+  "author": "system",
+  "description": "Frostbloom rosette with cryoshard vents that whistle in polar gusts.",
+  "collision": "soft",
+  "voxelScale": 0.26,
+  "attachment": {
+    "groundOffset": 0.12
+  },
+  "placement": {
+    "biomes": ["ice_spire_tundra"],
+    "weight": 1.9,
+    "maxSlope": 0.58,
+    "minSlope": 0.02,
+    "minHeight": 5,
+    "maxHeight": 50,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.8,
+    "maxInstancesPerColumn": 3
+  },
+  "voxels": [
+    {
+      "type": "frostbloom_moss",
+      "position": [0, -0.1, 0],
+      "size": [1.8, 0.3, 1.8],
+      "tint": "#9be6da",
+      "isSolid": false
+    },
+    {
+      "type": "frostbloom_moss",
+      "position": [0, 0.2, 0],
+      "size": [1.2, 0.4, 1.2],
+      "tint": "#aef3e8",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 8,
+            "radius": 0.42,
+            "arcTurns": 1.05,
+            "offset": [0, 0.2, 0],
+            "scale": [0.85, 0.5, 0.85],
+            "jitter": 0.06,
+            "accentTint": "#f3ffff",
+            "inheritTintStrength": 0.48
+          }
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0.5, 0],
+      "size": [0.5, 1.1, 0.5],
+      "tint": "#c3f4ff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 5,
+            "radius": 0.24,
+            "arcTurns": 0.7,
+            "offset": [0, 0.5, 0],
+            "scale": [0.55, 0.9, 0.55],
+            "jitter": 0.04,
+            "accentTint": "#ecfdff",
+            "inheritTintStrength": 0.56
+          }
+        }
+      }
+    }
+  ]
+}

--- a/three-demo/src/world/voxel-objects/structures/cryospire_cluster.json
+++ b/three-demo/src/world/voxel-objects/structures/cryospire_cluster.json
@@ -1,0 +1,93 @@
+{
+  "id": "cryospire_cluster",
+  "label": "Cryospire Cluster",
+  "category": "structures",
+  "author": "system",
+  "description": "Conjoined cryoshard spires crusted with frostbloom moss.",
+  "collision": "solid",
+  "voxelScale": 0.42,
+  "attachment": {
+    "groundOffset": 0.18
+  },
+  "placement": {
+    "biomes": ["ice_spire_tundra"],
+    "weight": 1.6,
+    "maxSlope": 0.65,
+    "minHeight": 6,
+    "maxHeight": 52,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.55
+  },
+  "voxels": [
+    {
+      "type": "frostbloom_moss",
+      "position": [0, -0.2, 0],
+      "size": [2.4, 0.5, 2.0],
+      "tint": "#9fe9df",
+      "isSolid": false
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0, 0],
+      "size": [0.9, 3.6, 0.9],
+      "tint": "#c9f5ff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 7,
+            "radius": 0.34,
+            "arcTurns": 0.75,
+            "offset": [0, 1.2, 0],
+            "scale": [0.72, 1.08, 0.72],
+            "jitter": 0.06,
+            "accentTint": "#f4ffff",
+            "inheritTintStrength": 0.55
+          }
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [-0.9, 0.2, 0.6],
+      "size": [0.7, 2.8, 0.7],
+      "tint": "#bdefff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 5,
+            "radius": 0.28,
+            "arcTurns": 0.6,
+            "offset": [0, 0.9, 0],
+            "scale": [0.64, 0.95, 0.64],
+            "jitter": 0.05,
+            "accentTint": "#e6fbff",
+            "inheritTintStrength": 0.5
+          }
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0.8, -0.1, -0.8],
+      "size": [0.8, 2.3, 0.8],
+      "tint": "#b7ebff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 4,
+            "radius": 0.26,
+            "arcTurns": 0.5,
+            "offset": [0, 0.7, 0],
+            "scale": [0.62, 0.88, 0.62],
+            "jitter": 0.05,
+            "accentTint": "#e2f6ff",
+            "inheritTintStrength": 0.48
+          }
+        }
+      }
+    }
+  ]
+}

--- a/three-demo/src/world/voxel-objects/structures/frostsignal_totem.json
+++ b/three-demo/src/world/voxel-objects/structures/frostsignal_totem.json
@@ -1,0 +1,93 @@
+{
+  "id": "frostsignal_totem",
+  "label": "Frostsignal Totem",
+  "category": "structures",
+  "author": "system",
+  "description": "Signal totem carved from permafrost and ringing with cryoshard chimes.",
+  "collision": "solid",
+  "voxelScale": 0.36,
+  "attachment": {
+    "groundOffset": 0.16
+  },
+  "placement": {
+    "biomes": ["ice_spire_tundra"],
+    "weight": 1.1,
+    "maxSlope": 0.52,
+    "minSlope": 0.05,
+    "minHeight": 4,
+    "maxHeight": 58,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.45
+  },
+  "voxels": [
+    {
+      "type": "frostbloom_moss",
+      "position": [0, -0.24, 0],
+      "size": [1.8, 0.4, 1.8],
+      "tint": "#9ee3da",
+      "isSolid": false
+    },
+    {
+      "type": "stone",
+      "position": [0, 0, 0],
+      "size": [0.9, 1.2, 0.9],
+      "tint": "#aac2cf"
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 1.2, 0],
+      "size": [0.7, 2.4, 0.7],
+      "tint": "#c7f2ff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "frost_spicule",
+              "count": 6,
+              "radius": 0.32,
+              "arcTurns": 0.85,
+              "offset": [0, 0.8, 0],
+              "scale": [0.66, 0.98, 0.66],
+              "jitter": 0.05,
+              "accentTint": "#edfaff",
+              "inheritTintStrength": 0.52
+            },
+            {
+              "id": "frost_spicule",
+              "count": 4,
+              "radius": 0.26,
+              "arcTurns": 0.45,
+              "offset": [0, 1.6, 0],
+              "scale": [0.58, 0.9, 0.58],
+              "jitter": 0.04,
+              "accentTint": "#f6feff",
+              "inheritTintStrength": 0.6
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 2.9, 0],
+      "size": [1.2, 0.4, 1.2],
+      "tint": "#dcf7ff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 8,
+            "radius": 0.4,
+            "arcTurns": 1.2,
+            "offset": [0, 0.1, 0],
+            "scale": [0.8, 0.4, 0.8],
+            "jitter": 0.07,
+            "accentTint": "#ffffff",
+            "inheritTintStrength": 0.45
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the ice spire tundra biome with blizzard shader metadata and register it with the biome engine
- create cryospire cluster and frostsignal totem structures plus a vented ice bloom flower using frost materials and nanovoxel accents
- update fluid presence sampling so lumen bloom and abyssal serum skip spawning within the new biome

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c98d271c832aa14eaa75d0b08fa8