### PR TITLE
Document biome onboarding flow

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -6,6 +6,18 @@ const biomeModuleMap = import.meta.glob('./biomes/*.json', {
   eager: true,
 });
 
+/*
+ * Biome onboarding checklist:
+ * 1. Add the biome JSON definition under ./biomes/ with a unique `id`.
+ * 2. Verify the import.meta.glob call above discovers the new file and that
+ *    downstream registry wiring includes the biome.
+ * 3. Supply voxel object payloads under ../voxel-objects/ so placement logic
+ *    can spawn the new content.
+ * 4. Register any biome-specific fluids, tints, or palette hooks inside the
+ *    ../fluids/ modules.
+ * 5. Extend the world generation tests under ../__tests__/ to cover climate
+ *    sampling and placement expectations for the new biome.
+ */
 const rawBiomeDefinitions = Object.values(biomeModuleMap)
   .filter((definition) => definition && typeof definition === 'object')
   .map((definition) => ({ ...definition }))

--- a/three-demo/src/world/biomes/README.md
+++ b/three-demo/src/world/biomes/README.md
@@ -37,3 +37,13 @@ Some voxel libraries expose an `ignoreBiomeTint` flag so that specific blocks re
 ## Distribution targets
 
 - **Ice Spire Tundra** — aim for at least 12% coverage when sampling 5 000 climate probes within a 2 048 block radius (`/biomes coverage ice_spire_tundra threshold=0.12`). The dedicated developer command reports the exact share so designers can confirm adjustments keep the biome within the intended rarity band.
+
+## How to add a biome
+
+Follow these high-level steps whenever introducing a new biome so the generation stack stays in sync:
+
+1. **Author the definition.** Create a JSON file under this folder with a unique `id` and schema-compliant payload. [`../biome-engine.js`](../biome-engine.js)
+2. **Confirm registry wiring.** Ensure the new file is discovered by the import glob and registered alongside existing biomes in [`../biome-engine.js`](../biome-engine.js).
+3. **Provide voxel objects.** Supply prop payloads inside [`../voxel-objects/`](../voxel-objects/) so placement logic can spawn biome-specific structures, flora, and fungi.
+4. **Hook up fluids and palettes.** Register any liquid or tint behaviour inside [`../fluids/fluid-registry.js`](../fluids/fluid-registry.js) (and related helpers) to keep rendering consistent.
+5. **Extend validation.** Update or add tests within [`../__tests__/`](../__tests__/) to cover climate sampling and placement expectations for the biome.

--- a/three-demo/src/world/biomes/WORK_ORDERS.md
+++ b/three-demo/src/world/biomes/WORK_ORDERS.md
@@ -11,7 +11,7 @@ This document tracks the multi-layer deliverables for integrating the upcoming b
 - Goals:
   - Solar Chroma Steppe ↔ Luminous Tidebloom Marsh: bridge day/night energy cycles by sharing adaptive flora lines that react to light versus tide pulses.
   - Obsidian Mycelium Hollows ↔ Prismarine Vent Plateau: extend subterranean fungal economies into surface vents, emphasizing heat gradients and mineral reclamation.
-- **Import wiring:** once the JSON files ship, extend the import block and biome registry array in `three-demo/src/world/biome-engine.js` so the new IDs can be instantiated.
+- **Import wiring:** once the JSON files ship, extend the import block and biome registry array in `three-demo/src/world/biome-engine.js` so the new IDs can be instantiated. Cross-check the onboarding steps in `README.md` to keep the process documentation aligned with future rollouts.
 
 ## Layer 1 – Voxel Object Coverage
 For each biome JSON above, provide voxel object payloads before enabling spawning. Deliverables should live under `three-demo/src/world/voxel-objects/` in their respective category folders.


### PR DESCRIPTION
## Summary
- document the biome onboarding checklist next to the registry loader
- add a README section that explains how to add a biome and link related modules
- reference the README guidance from the biome work orders to keep future updates aligned

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d984352e20832a8c72e8c755345b94