### PR TITLE
Gate lumen bloom ribbons to aurora ridges

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -22,6 +22,7 @@ import {
   computeFluidSurfaceAnchor,
 } from './rendering/particle-system.js'
 import { createWaterSurfaceMistEmitter } from './rendering/particles/water-effects.js'
+import { createAuroraRibbonEmitter } from './rendering/particles/aurora-effects.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -238,6 +239,48 @@ try {
       dispose: () => handle?.stop?.(),
     }
   })
+
+  particleSystem.registerFluidSurfaceEffect(
+    'lumen_bloom',
+    ({ mesh, emit, metadata, cues }) => {
+      const cueSource = Array.isArray(cues) && cues.length > 0
+        ? cues
+        : Array.isArray(metadata?.lifecycleCues)
+        ? metadata.lifecycleCues
+        : mesh.userData?.lifecycleCues
+      if (!Array.isArray(cueSource) || !cueSource.includes('aurora_ribbon')) {
+        return null
+      }
+      const anchor = computeFluidSurfaceAnchor({ THREE, mesh, surfaceOffset: 0.9 })
+      if (!anchor) {
+        return null
+      }
+      const geometry = mesh.geometry
+      if (geometry && !geometry.boundingBox) {
+        geometry.computeBoundingBox?.()
+      }
+      const bounds = geometry?.boundingBox ?? null
+      let span = 4.6
+      if (bounds) {
+        span = Math.max(span, bounds.max.x - bounds.min.x, bounds.max.z - bounds.min.z)
+      }
+      const intensityValue = metadata?.auroraIntensity ?? mesh.userData?.auroraIntensity
+      const orientationValue = metadata?.ribbonOrientation ?? mesh.userData?.ribbonOrientation
+      const intensity = Number.isFinite(intensityValue) ? intensityValue : 1
+      const orientation = Number.isFinite(orientationValue) ? orientationValue : 0
+      const handle = emit(
+        createAuroraRibbonEmitter({
+          position: anchor,
+          span,
+          intensity,
+          orientation,
+        }),
+      )
+      return {
+        dispose: () => handle?.stop?.(),
+      }
+    },
+  )
 
   playerControls = createPlayerControls({
     THREE,

--- a/three-demo/src/rendering/particle-system.js
+++ b/three-demo/src/rendering/particle-system.js
@@ -440,6 +440,10 @@ export function createParticleSystem({ THREE, scene }) {
         emit,
         THREE,
         getElapsedTime: () => elapsedTime,
+        cues: Array.isArray(info.mesh.userData?.lifecycleCues)
+          ? info.mesh.userData.lifecycleCues.map((cue) => String(cue))
+          : [],
+        metadata: info.metadata,
       });
     } catch (error) {
       console.error('Fluid surface effect factory failed:', error);
@@ -477,6 +481,7 @@ export function createParticleSystem({ THREE, scene }) {
       mesh,
       runtime: runtime ?? null,
       attachments: new Map(),
+      metadata: mesh.userData ?? {},
     };
     fluidSurfaceState.set(mesh, info);
     const factories = fluidSurfaceFactories.get(normalizedType);

--- a/three-demo/src/rendering/particles/aurora-effects.js
+++ b/three-demo/src/rendering/particles/aurora-effects.js
@@ -1,0 +1,54 @@
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js';
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function createAuroraRibbonEmitter({
+  position,
+  span = 6,
+  intensity = 1,
+  orientation = 0,
+} = {}) {
+  const ribbonSpan = Math.max(1.2, span);
+  const energy = clamp(intensity, 0.35, 3.2);
+  const drift = 0.18 + energy * 0.12;
+  const dirX = Math.cos(orientation);
+  const dirZ = Math.sin(orientation);
+
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 26 * energy,
+    maxParticles: Math.ceil(140 * energy),
+    lifetime: { min: 2.2, max: 4.6 },
+    baseColor: '#ffe4ff',
+    colorRamp: [
+      { time: 0, color: '#6ffcff' },
+      { time: 0.35, color: '#ff96f6' },
+      { time: 0.7, color: '#ffe4ff' },
+      { time: 1, color: '#7fd4ff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 1.05 * energy },
+      { time: 0.55, size: 1.8 * energy },
+      { time: 1, size: 0.45 * energy },
+    ],
+    position,
+    positionJitter: { x: ribbonSpan * 0.62, y: 0.55, z: ribbonSpan * 0.62 },
+    velocity: {
+      x: dirX * drift,
+      y: 0.38 + energy * 0.12,
+      z: dirZ * drift,
+    },
+    velocityJitter: { x: 0.28, y: 0.24, z: 0.28 },
+    size: { min: 0.9 * energy, max: 1.9 * energy },
+    gravity: { x: 0, y: 0.12, z: 0 },
+    drag: 0.64,
+    fadeIn: 0.2,
+    fadeOut: 0.42,
+    opacity: 0.6,
+    renderOrder: 6,
+  });
+
+  emitter.debugLabel = 'AuroraRibbonEmitter';
+  return emitter;
+}

--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -89,6 +89,17 @@ function normalizeCategoryMultipliers(definition) {
   );
 }
 
+function cloneShaderMetadata(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_error) {
+    return { ...value };
+  }
+}
+
 export function createBiomeEngine({
   THREE,
   seed = defaultWorldOptions.seedHash,
@@ -212,6 +223,9 @@ export function createBiomeEngine({
         fogColor: new THREE.Color(shaderDefinition.fogColor ?? '#a9d6ff'),
         tintColor: new THREE.Color(shaderDefinition.tintColor ?? '#ffffff'),
         tintStrength: clamp01(shaderDefinition.tintStrength ?? 0),
+        effects: cloneShaderMetadata(shaderDefinition.effects),
+        hazards: cloneShaderMetadata(shaderDefinition.hazards),
+        references: cloneShaderMetadata(shaderDefinition.references),
       },
     };
   });

--- a/three-demo/src/world/biomes/aurora_shard_expanse.json
+++ b/three-demo/src/world/biomes/aurora_shard_expanse.json
@@ -1,0 +1,82 @@
+{
+  "id": "aurora_shard_expanse",
+  "label": "Aurora Shard Expanse",
+  "tags": ["frozen", "luminous", "aurora_channel"],
+  "climate": {
+    "temperature": 0.18,
+    "moisture": 0.38,
+    "weight": 1.12
+  },
+  "terrain": {
+    "surfaceBlock": "stone",
+    "shoreBlock": "snow",
+    "subSurfaceBlock": "stone",
+    "subSurfaceDepth": 4,
+    "deepBlock": "stone",
+    "treeDensity": 0.0,
+    "shrubChance": 0.08,
+    "flowerChance": 0.46,
+    "rockChance": 0.2,
+    "fungiChance": 0.03,
+    "waterPlantChance": 0.0,
+    "structureChance": 0.34,
+    "objectDensityMultiplier": 1.22,
+    "objectDensityMultipliers": {
+      "flowers": 2.5,
+      "structures": 2.1,
+      "rocks": 1.35
+    },
+    "treeHeight": {
+      "min": 1,
+      "max": 2
+    },
+    "heightOffset": 3.4
+  },
+  "palette": {
+    "grass": "#def3ff",
+    "dirt": "#9fb9c8",
+    "stone": "#b5cad9",
+    "sand": "#f2e8ff",
+    "water": "#7cc4ff",
+    "cloud": "#f4f9ff",
+    "leaf": "#d3e9ff",
+    "log": "#a2b8c7",
+    "cryoshard_glass": "#ffd0ff",
+    "lumen_bloom": "#ffb2ff",
+    "frostbloom_moss": "#b3f6eb"
+  },
+  "shader": {
+    "fogColor": "#d8f0ff",
+    "tintColor": "#ffe5ff",
+    "tintStrength": 0.64,
+    "effects": {
+      "auroraRibbons": {
+        "gradientStops": [
+          { "offset": 0.0, "color": "#6ff9ff" },
+          { "offset": 0.38, "color": "#ff8bf6" },
+          { "offset": 0.72, "color": "#ffe4ff" },
+          { "offset": 1.0, "color": "#86d6ff" }
+        ],
+        "scrollSpeed": 0.48,
+        "ribbonDensity": 0.88,
+        "pulse": 0.35
+      },
+      "electromagneticGusts": {
+        "strength": 0.68,
+        "gustColor": "#ffb9ff",
+        "shear": 0.52
+      }
+    },
+    "hazards": {
+      "electromagnetic_gusts": {
+        "severity": 0.74,
+        "exposureWindowSeconds": 14,
+        "description": "Charged gusts arc across cryoshard ridges, scrambling guidance instruments."
+      }
+    },
+    "references": {
+      "auroraGradient": "aurora_shard_expanse:ribbons",
+      "gustField": "aurora_shard_expanse:electromagnetic"
+    }
+  }
+}

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -1,7 +1,11 @@
 import * as THREE from 'three';
 
 import { generateChunk, getWorldOptions } from './generation.js';
-import { createFluidSurface, disposeFluidSurface } from './fluids/fluid-registry.js';
+import {
+  createFluidSurface,
+  disposeFluidSurface,
+  applyFluidSurfaceMetadata,
+} from './fluids/fluid-registry.js';
 import { buildFluidGeometry } from './fluids/fluid-geometry.js';
 
 const worldConfig = getWorldOptions();
@@ -211,6 +215,7 @@ export function createChunkManager({
       mesh.userData = mesh.userData || {};
       mesh.userData.type = `fluid:${type}`;
       mesh.userData.chunkKey = chunkKey(chunk.chunkX, chunk.chunkZ);
+      applyFluidSurfaceMetadata(mesh, geometry);
       chunk.fluidSurfaces.push(mesh);
       chunk.group?.add(mesh);
       return true;
@@ -218,6 +223,7 @@ export function createChunkManager({
 
     const previousGeometry = surface.geometry;
     surface.geometry = geometry;
+    applyFluidSurfaceMetadata(surface, geometry);
     if (previousGeometry) {
       previousGeometry.dispose();
     }

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -59,22 +59,96 @@ function resolveLumenBloomPresence({
     };
   }
 
+  if (biomeId === 'aurora_shard_expanse') {
+    const neighborOffsets = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ];
+    const neighborHeights = neighborOffsets.map(([dx, dz]) =>
+      sampleColumnHeight(x + dx, z + dz),
+    );
+    const ridgeDiffs = neighborHeights.map((height) => groundHeight - height);
+    const positiveDiffs = ridgeDiffs.filter((diff) => Number.isFinite(diff) && diff > 0);
+    const ridgeStrength =
+      positiveDiffs.length > 0
+        ? positiveDiffs.reduce((sum, value) => sum + value, 0) / positiveDiffs.length
+        : 0;
+    const plateauStrength = Math.max(0, ridgeStrength - 0.32);
+    const plateauInfluence = Math.min(1, plateauStrength / 1.4);
+    const ribbonNoise = pseudoRandom2D(x * 0.31 + 5.8, z * 0.31 - 8.9, seed * 1.11);
+    const ridgeNoise = pseudoRandom2D(x * 0.18 - 9.7, z * 0.18 + 6.4, seed * 0.67);
+
+    const slopeX = neighborHeights[0] - neighborHeights[1];
+    const slopeZ = neighborHeights[2] - neighborHeights[3];
+    let ribbonOrientation = Math.atan2(slopeZ, slopeX);
+    if (!Number.isFinite(ribbonOrientation)) {
+      ribbonOrientation = 0;
+    }
+    ribbonOrientation += Math.PI / 2;
+
+    const ridgeGate = ridgeStrength > 0.32;
+    const combinedNoise =
+      cluster * 0.34 + bloom * 0.32 + ribbonNoise * 0.42 + ridgeNoise * 0.22;
+    const spawnThreshold = 0.68 - plateauInfluence * 0.42 + altitudeBias * 0.002;
+
+    if (ridgeGate && combinedNoise >= spawnThreshold) {
+      const ribbonLift = 1.12 + ridgeStrength * 0.45 + ribbonNoise * 0.24;
+      const surfaceY = baseSurface + ribbonLift;
+      const depth = Math.max(0.14, 0.2 + bloom * 0.18 + plateauInfluence * 0.22);
+      const intensity = Math.min(
+        3,
+        0.88 + plateauInfluence * 1.25 + ribbonNoise * 0.4 + ridgeNoise * 0.25,
+      );
+
+      return {
+        hasFluid: true,
+        surfaceY,
+        bottomY: surfaceY - depth,
+        metadata: {
+          lifecycleCues: ['aurora_ribbon'],
+          auroraIntensity: intensity,
+          ribbonOrientation,
+          ridgeStrength,
+        },
+      };
+    }
+
+    return {
+      hasFluid: false,
+      surfaceY: baseSurface,
+      bottomY: baseSurface,
+      metadata: {
+        ribbonOrientation,
+        ridgeStrength,
+      },
+    };
+  }
+
   if (cluster + bloom * 0.4 + altitudeBias * 0.01 < 0.75) {
     return {
       hasFluid: false,
       surfaceY: baseSurface,
       bottomY: baseSurface,
+      metadata: {
+        nonRendered: true,
+      },
     };
   }
 
   const surfaceRise = 0.6 + (cluster - 0.5) * 1.2 + bloom * 0.5;
   const depth = 0.6 + bloom * 0.9;
-  const surfaceY = baseSurface + surfaceRise;
 
   return {
-    hasFluid: true,
-    surfaceY,
-    bottomY: surfaceY - depth,
+    hasFluid: false,
+    surfaceY: baseSurface,
+    bottomY: baseSurface,
+    metadata: {
+      nonRendered: true,
+      surfaceHint: baseSurface + surfaceRise,
+      depthHint: depth,
+    },
   };
 }
 
@@ -229,6 +303,36 @@ export function registerFluidType(id, definition) {
   fluidRuntime.delete(id);
 }
 
+export function applyFluidSurfaceMetadata(mesh, geometry) {
+  if (!mesh || typeof mesh !== 'object') {
+    return;
+  }
+  mesh.userData = mesh.userData || {};
+  const fluidType = mesh.userData.fluidType ?? null;
+  const metadata = geometry?.userData;
+
+  const cues = Array.isArray(metadata?.lifecycleCues)
+    ? Array.from(new Set(metadata.lifecycleCues.map((cue) => String(cue))))
+    : [];
+  if (cues.length > 0) {
+    mesh.userData.lifecycleCues = cues;
+  } else if (fluidType === 'lumen_bloom') {
+    mesh.userData.lifecycleCues = [];
+  }
+
+  if (metadata && Number.isFinite(metadata.auroraIntensity)) {
+    mesh.userData.auroraIntensity = metadata.auroraIntensity;
+  } else if (fluidType === 'lumen_bloom') {
+    delete mesh.userData.auroraIntensity;
+  }
+
+  if (metadata && Number.isFinite(metadata.ribbonOrientation)) {
+    mesh.userData.ribbonOrientation = metadata.ribbonOrientation;
+  } else if (fluidType === 'lumen_bloom') {
+    delete mesh.userData.ribbonOrientation;
+  }
+}
+
 export function isFluidType(id) {
   return fluidDefinitions.has(id);
 }
@@ -282,6 +386,7 @@ export function createFluidSurface({ type, geometry }) {
   mesh.castShadow = false;
   mesh.receiveShadow = true;
   mesh.userData.fluidType = type;
+  applyFluidSurfaceMetadata(mesh, geometry);
   runtime.surfaces.add(mesh);
   if (runtime.handleSurfaceCreated) {
     runtime.handleSurfaceCreated(mesh);

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -625,6 +625,80 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     return entry;
   };
 
+  const registerFluidPresence = ({ type, x, z, presence, biome }) => {
+    if (!type || !presence || !presence.hasFluid) {
+      return;
+    }
+    if (!fluidColumnsByType.has(type)) {
+      fluidColumnsByType.set(type, new Map());
+    }
+    const columns = fluidColumnsByType.get(type);
+    const columnKey = `${x}|${z}`;
+    const THREE = ensureThree();
+    const surfaceY = Number.isFinite(presence.surfaceY)
+      ? presence.surfaceY
+      : getColumnHeight(x, z) + 0.5;
+    const bottomY = Number.isFinite(presence.bottomY)
+      ? presence.bottomY
+      : surfaceY;
+    const minY = Math.min(surfaceY, bottomY);
+    const maxY = Math.max(surfaceY, bottomY);
+
+    let column = columns.get(columnKey);
+    if (!column) {
+      const palette = biome?.palette ?? {};
+      const paletteHex =
+        palette[type] ??
+        palette.lumen_bloom ??
+        palette.water ??
+        palette.cloud ??
+        '#3a79c5';
+      column = {
+        key: columnKey,
+        x,
+        z,
+        minY,
+        maxY,
+        color: new THREE.Color(paletteHex),
+        biome,
+        lifecycleCues: new Set(),
+        auroraIntensitySum: 0,
+        auroraIntensitySamples: 0,
+        orientationVector: { x: 0, z: 0 },
+        orientationSamples: 0,
+      };
+      columns.set(columnKey, column);
+    } else {
+      column.minY = Math.min(column.minY, minY);
+      column.maxY = Math.max(column.maxY, maxY);
+      const palette = biome?.palette;
+      if (palette) {
+        const paletteHex =
+          palette[type] ?? palette.lumen_bloom ?? palette.water ?? null;
+        if (paletteHex) {
+          column.color = new THREE.Color(paletteHex);
+        }
+      }
+    }
+
+    const metadata = presence.metadata ?? {};
+    if (Array.isArray(metadata.lifecycleCues)) {
+      metadata.lifecycleCues.forEach((cue) => {
+        column.lifecycleCues.add(String(cue));
+      });
+    }
+    if (Number.isFinite(metadata.auroraIntensity)) {
+      column.auroraIntensitySum += metadata.auroraIntensity;
+      column.auroraIntensitySamples += 1;
+    }
+    if (Number.isFinite(metadata.ribbonOrientation)) {
+      const angle = metadata.ribbonOrientation;
+      column.orientationVector.x += Math.cos(angle);
+      column.orientationVector.z += Math.sin(angle);
+      column.orientationSamples += 1;
+    }
+  };
+
   const addDecorationInstance = (type, x, y, z, biome, options = {}) => {
     const normalizedOptions = { ...options };
     if (typeof normalizedOptions.destructible !== 'boolean') {
@@ -998,6 +1072,30 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         }
       }
 
+      const lumenPresence = resolveFluidPresence({
+        type: 'lumen_bloom',
+        x: worldX,
+        z: worldZ,
+        sampleColumnHeight: getColumnHeight,
+        worldConfig: worldOptions,
+        sampleBiomeAt: sampleColumnCached,
+      });
+      const lumenCues = Array.isArray(lumenPresence?.metadata?.lifecycleCues)
+        ? lumenPresence.metadata.lifecycleCues
+        : null;
+      const hasAuroraRibbonCue = Boolean(
+        lumenCues && lumenCues.includes('aurora_ribbon'),
+      );
+      if (hasAuroraRibbonCue) {
+        registerFluidPresence({
+          type: 'lumen_bloom',
+          x: worldX,
+          z: worldZ,
+          presence: lumenPresence,
+          biome,
+        });
+      }
+
       populateColumnWithVoxelObjects({
         addBlock,
         addDecorationInstance,
@@ -1137,10 +1235,56 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       column.shoreline = shoreline;
     });
 
+    const columnValues = Array.from(columns.values());
+    const aggregatedCues = new Set();
+    let auroraIntensityTotal = 0;
+    let auroraIntensitySamples = 0;
+    let orientationVectorX = 0;
+    let orientationVectorZ = 0;
+    let orientationSamples = 0;
+
+    columnValues.forEach((column) => {
+      if (column.lifecycleCues instanceof Set) {
+        column.lifecycleCues.forEach((cue) => aggregatedCues.add(cue));
+      }
+      if (
+        Number.isFinite(column.auroraIntensitySum) &&
+        Number.isFinite(column.auroraIntensitySamples) &&
+        column.auroraIntensitySamples > 0
+      ) {
+        auroraIntensityTotal += column.auroraIntensitySum;
+        auroraIntensitySamples += column.auroraIntensitySamples;
+      }
+      if (column.orientationSamples > 0 && column.orientationVector) {
+        orientationVectorX += column.orientationVector.x;
+        orientationVectorZ += column.orientationVector.z;
+        orientationSamples += column.orientationSamples;
+      }
+    });
+
+    const hasAuroraRibbonCue = aggregatedCues.has('aurora_ribbon');
+    if (type === 'lumen_bloom' && !hasAuroraRibbonCue) {
+      return;
+    }
+
     const geometry = buildFluidGeometry({
       THREE,
-      columns: Array.from(columns.values()),
+      columns: columnValues,
     });
+    geometry.userData = geometry.userData || {};
+    if (aggregatedCues.size > 0) {
+      geometry.userData.lifecycleCues = Array.from(aggregatedCues);
+    }
+    if (auroraIntensitySamples > 0) {
+      geometry.userData.auroraIntensity =
+        auroraIntensityTotal / auroraIntensitySamples;
+    }
+    if (orientationSamples > 0) {
+      geometry.userData.ribbonOrientation = Math.atan2(
+        orientationVectorZ,
+        orientationVectorX,
+      );
+    }
     if (!geometry.getAttribute('position') || geometry.getAttribute('position').count === 0) {
       if (type === 'water') {
         logFluidDebug('water geometry has no vertices');

--- a/three-demo/src/world/voxel-objects/flowers/ion_blush_bloom.json
+++ b/three-demo/src/world/voxel-objects/flowers/ion_blush_bloom.json
@@ -1,0 +1,93 @@
+{
+  "id": "ion_blush_bloom",
+  "label": "Ion Blush Bloom",
+  "category": "flowers",
+  "author": "system",
+  "description": "Auroral rosette sipping lumen bloom currents atop cryoshard pedestals.",
+  "collision": "soft",
+  "voxelScale": 0.26,
+  "attachment": {
+    "groundOffset": 0.18
+  },
+  "placement": {
+    "biomes": ["aurora_shard_expanse"],
+    "tags": ["aurora_channel"],
+    "weight": 2.4,
+    "minSlope": 0.0,
+    "maxSlope": 0.38,
+    "minHeight": 8,
+    "maxHeight": 86,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.58,
+    "maxInstancesPerColumn": 3
+  },
+  "voxels": [
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0, 0],
+      "size": [0.8, 0.8, 0.8],
+      "tint": "#ffccff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 4,
+            "radius": 0.32,
+            "arcTurns": 1.1,
+            "offset": [0, 0.22, 0],
+            "scale": [0.62, 0.7, 0.62],
+            "jitter": 0.05,
+            "accentTint": "#f7feff",
+            "inheritTintStrength": 0.52
+          }
+        }
+      }
+    },
+    {
+      "type": "leaf",
+      "position": [0, 0.62, 0],
+      "size": [1.4, 0.6, 1.4],
+      "tint": "#ff96f1",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 9,
+              "radius": 0.78,
+              "arcTurns": 1.2,
+              "offset": [0, 0.12, 0],
+              "scale": [1.1, 0.4, 1.1],
+              "jitter": 0.12,
+              "accentTint": "#ffd9ff",
+              "inheritTintStrength": 0.46
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "leaf",
+      "position": [0, 1.1, 0],
+      "size": [1.1, 0.5, 1.1],
+      "tint": "#ffe3ff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "halo-spark",
+            "count": 6,
+            "radius": 0.6,
+            "arcTurns": 1.3,
+            "offset": [0, 0.1, 0],
+            "scale": [0.9, 0.36, 0.9],
+            "jitter": 0.1,
+            "accentTint": "#fff2ff",
+            "inheritTintStrength": 0.42
+          }
+        }
+      }
+    }
+  ]
+}

--- a/three-demo/src/world/voxel-objects/structures/shardlight_pylon.json
+++ b/three-demo/src/world/voxel-objects/structures/shardlight_pylon.json
@@ -1,0 +1,113 @@
+{
+  "id": "shardlight_pylon",
+  "label": "Shardlight Pylon",
+  "category": "structures",
+  "author": "system",
+  "description": "Suspended cryoshard pylon channeling auroral current lines.",
+  "collision": "solid",
+  "voxelScale": 0.38,
+  "attachment": {
+    "groundOffset": 0.18
+  },
+  "placement": {
+    "biomes": ["aurora_shard_expanse"],
+    "tags": ["aurora_channel"],
+    "weight": 1.9,
+    "minSlope": 0.02,
+    "maxSlope": 0.44,
+    "minHeight": 12,
+    "maxHeight": 92,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.56
+  },
+  "voxels": [
+    {
+      "type": "stone",
+      "position": [0, -0.22, 0],
+      "size": [1.8, 0.6, 1.8],
+      "tint": "#c6d7e5"
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0.46, 0],
+      "size": [1.1, 0.6, 1.1],
+      "tint": "#ffe2ff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 10,
+              "radius": 0.74,
+              "arcTurns": 1.32,
+              "offset": [0, 0.12, 0],
+              "scale": [1.2, 0.28, 1.2],
+              "jitter": 0.14,
+              "accentTint": "#ffeaff",
+              "inheritTintStrength": 0.42
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0.9, 0],
+      "size": [0.9, 3.1, 0.9],
+      "tint": "#ffc7ff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "frost_spicule",
+              "count": 6,
+              "radius": 0.38,
+              "arcTurns": 0.92,
+              "offset": [0, 0.9, 0],
+              "scale": [0.72, 1.04, 0.72],
+              "jitter": 0.06,
+              "accentTint": "#f5feff",
+              "inheritTintStrength": 0.58
+            },
+            {
+              "id": "halo-spark",
+              "count": 8,
+              "radius": 0.42,
+              "arcTurns": 1.1,
+              "offset": [0, 1.6, 0],
+              "scale": [0.9, 0.46, 0.9],
+              "jitter": 0.1,
+              "accentTint": "#ffd9ff",
+              "inheritTintStrength": 0.4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 3.4, 0],
+      "size": [1.4, 0.5, 1.4],
+      "tint": "#ffeaff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "frost_spicule",
+              "count": 5,
+              "radius": 0.52,
+              "arcTurns": 1.24,
+              "offset": [0, 0.18, 0],
+              "scale": [1.05, 0.42, 1.05],
+              "jitter": 0.08,
+              "accentTint": "#fff0ff",
+              "inheritTintStrength": 0.5
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/three-demo/src/world/voxel-objects/structures/skywave_relay.json
+++ b/three-demo/src/world/voxel-objects/structures/skywave_relay.json
@@ -1,0 +1,124 @@
+{
+  "id": "skywave_relay",
+  "label": "Skywave Relay",
+  "category": "structures",
+  "author": "system",
+  "description": "Cantilevered relay lattice suspending cryoshards for aurora relays.",
+  "collision": "solid",
+  "voxelScale": 0.36,
+  "attachment": {
+    "groundOffset": 0.2
+  },
+  "placement": {
+    "biomes": ["aurora_shard_expanse"],
+    "tags": ["aurora_channel"],
+    "weight": 1.4,
+    "minSlope": 0.01,
+    "maxSlope": 0.4,
+    "minHeight": 10,
+    "maxHeight": 88,
+    "forbidUnderwater": true,
+    "jitterRadius": 0.62
+  },
+  "voxels": [
+    {
+      "type": "stone",
+      "position": [0, -0.16, 0],
+      "size": [2.2, 0.6, 2.2],
+      "tint": "#cad8e4"
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 0.5, 0],
+      "size": [0.9, 2.6, 0.9],
+      "tint": "#ffd7ff",
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "frost_spicule",
+              "count": 5,
+              "radius": 0.34,
+              "arcTurns": 1.18,
+              "offset": [0, 1.1, 0],
+              "scale": [0.68, 0.98, 0.68],
+              "jitter": 0.06,
+              "accentTint": "#f7feff",
+              "inheritTintStrength": 0.56
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [1.2, 2.1, 0],
+      "size": [1.4, 0.5, 3.2],
+      "tint": "#ffe4ff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 12,
+              "radius": 1.2,
+              "arcTurns": 1.1,
+              "offset": [-0.2, 0.18, 0],
+              "scale": [1.6, 0.4, 1.1],
+              "jitter": 0.16,
+              "accentTint": "#ffe7ff",
+              "inheritTintStrength": 0.44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [-1.2, 2.1, 0],
+      "size": [1.4, 0.5, 3.2],
+      "tint": "#ffdfff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": [
+            {
+              "id": "halo-spark",
+              "count": 12,
+              "radius": 1.2,
+              "arcTurns": 1.1,
+              "offset": [0.2, 0.18, 0],
+              "scale": [1.6, 0.4, 1.1],
+              "jitter": 0.16,
+              "accentTint": "#ffe1ff",
+              "inheritTintStrength": 0.44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "cryoshard_glass",
+      "position": [0, 2.4, 1.4],
+      "size": [2.8, 0.4, 1.2],
+      "tint": "#ffcfff",
+      "isSolid": false,
+      "metadata": {
+        "visual": {
+          "nanovoxels": {
+            "id": "frost_spicule",
+            "count": 4,
+            "radius": 0.68,
+            "arcTurns": 0.9,
+            "offset": [0, 0.16, 0],
+            "scale": [1.2, 0.38, 1.2],
+            "jitter": 0.08,
+            "accentTint": "#fff6ff",
+            "inheritTintStrength": 0.46
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- gate lumen bloom registration so only aurora ribbon cue columns spawn geometry in chunk generation
- mark default lumen bloom samples as non-rendered to avoid global fluid spillover while preserving aurora metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a876ad00832a8e3fb0f83a9beae5