### PR TITLE
Treat snow as solid terrain

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -196,7 +196,7 @@ export function sampleBiomeCoverage({
   };
 }
 
-const solidTypes = new Set(['grass', 'dirt', 'stone', 'sand', 'leaf', 'log']);
+const solidTypes = new Set(['grass', 'dirt', 'stone', 'sand', 'leaf', 'log', 'snow']);
 
 function blockKey(x, y, z) {
   return `${x}|${y}|${z}`;


### PR DESCRIPTION
## Summary
- add the snow voxel type to the solidTypes collision set so it uses the solid path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d5d82868832aa3fad9f5ad121c89