### PR TITLE
Improve lumen bloom ribbons around shorelines

### DIFF
--- a/three-demo/src/world/fluids/fluid-geometry.js
+++ b/three-demo/src/world/fluids/fluid-geometry.js
@@ -23,6 +23,8 @@ export function buildFluidGeometry({ THREE, columns }) {
   const edgeFoam = [];
   const depths = [];
   const shorelines = [];
+  const ribbonDirections = [];
+  const auroraGlowValues = [];
 
   const pushVertex = (
     vertex,
@@ -35,6 +37,8 @@ export function buildFluidGeometry({ THREE, columns }) {
     foam,
     depthValue,
     shorelineValue,
+    ribbonDir,
+    auroraGlow,
     surfaceRole,
   ) => {
     positions.push(vertex.x, vertex.y, vertex.z);
@@ -48,6 +52,8 @@ export function buildFluidGeometry({ THREE, columns }) {
     edgeFoam.push(foam);
     depths.push(depthValue);
     shorelines.push(shorelineValue);
+    ribbonDirections.push(ribbonDir?.x ?? 0, ribbonDir?.y ?? 1);
+    auroraGlowValues.push(auroraGlow ?? 0);
   };
 
   const tempColor = new THREE.Color();
@@ -64,6 +70,8 @@ export function buildFluidGeometry({ THREE, columns }) {
     const foam = foamAmount ?? 0;
     const depthValue = depth ?? Math.max(0.05, surfaceY - column.bottomY);
     const shorelineValue = shoreline ?? 0;
+    const ribbonDir = column.ribbonVector ?? flowDir;
+    const auroraGlow = column.localAuroraGlow ?? column.localAuroraIntensity ?? 0;
 
     const tint = tempColor.copy(color);
 
@@ -78,6 +86,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
     pushVertex(
@@ -91,6 +101,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
     pushVertex(
@@ -104,6 +116,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
 
@@ -118,6 +132,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
     pushVertex(
@@ -131,6 +147,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
     pushVertex(
@@ -144,6 +162,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.SURFACE,
     );
   };
@@ -158,6 +178,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       shoreline ?? 0,
       neighborInfo.foamHint ? Math.min(1, neighborInfo.foamHint * 0.75) : 0,
     );
+    const ribbonDir = column.ribbonVector ?? flowDir;
+    const auroraGlow = column.localAuroraGlow ?? column.localAuroraIntensity ?? 0;
 
     const dropSurface = surfaceY;
     const dropBottom = Math.min(bottomY, neighborInfo.bottomY);
@@ -222,6 +244,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_TOP,
     );
     pushVertex(
@@ -235,6 +259,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_BOTTOM,
     );
     pushVertex(
@@ -248,6 +274,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_BOTTOM,
     );
 
@@ -262,6 +290,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_TOP,
     );
     pushVertex(
@@ -275,6 +305,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_BOTTOM,
     );
     pushVertex(
@@ -288,6 +320,8 @@ export function buildFluidGeometry({ THREE, columns }) {
       foam,
       depthValue,
       shorelineValue,
+      ribbonDir,
+      auroraGlow,
       SURFACE_ROLES.EDGE_TOP,
     );
   };
@@ -332,6 +366,14 @@ export function buildFluidGeometry({ THREE, columns }) {
   geometry.setAttribute('edgeFoam', new THREE.Float32BufferAttribute(edgeFoam, 1));
   geometry.setAttribute('depth', new THREE.Float32BufferAttribute(depths, 1));
   geometry.setAttribute('shoreline', new THREE.Float32BufferAttribute(shorelines, 1));
+  geometry.setAttribute(
+    'ribbonVector',
+    new THREE.Float32BufferAttribute(ribbonDirections, 2),
+  );
+  geometry.setAttribute(
+    'auroraGlow',
+    new THREE.Float32BufferAttribute(auroraGlowValues, 1),
+  );
 
   geometry.computeBoundingBox();
   geometry.computeBoundingSphere();

--- a/three-demo/src/world/fluids/fluid-registry.js
+++ b/three-demo/src/world/fluids/fluid-registry.js
@@ -34,6 +34,55 @@ function pseudoRandom2D(x, z, seed = DEFAULT_FLUID_SEED) {
   return hash - Math.floor(hash);
 }
 
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function hueToRgb(p, q, t) {
+  let temp = t;
+  if (temp < 0) temp += 1;
+  if (temp > 1) temp -= 1;
+  if (temp < 1 / 6) return p + (q - p) * 6 * temp;
+  if (temp < 1 / 2) return q;
+  if (temp < 2 / 3) return p + (q - p) * (2 / 3 - temp) * 6;
+  return p;
+}
+
+function hslToHex(h, s, l) {
+  const hue = ((h % 1) + 1) % 1;
+  const saturation = clamp01(s);
+  const lightness = clamp01(l);
+
+  let r;
+  let g;
+  let b;
+
+  if (saturation === 0) {
+    r = g = b = lightness;
+  } else {
+    const q =
+      lightness < 0.5
+        ? lightness * (1 + saturation)
+        : lightness + saturation - lightness * saturation;
+    const p = 2 * lightness - q;
+    r = hueToRgb(p, q, hue + 1 / 3);
+    g = hueToRgb(p, q, hue);
+    b = hueToRgb(p, q, hue - 1 / 3);
+  }
+
+  const toHex = (value) => {
+    const hex = Math.round(clamp01(value) * 255)
+      .toString(16)
+      .padStart(2, '0');
+    return hex;
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
 function resolveLumenBloomPresence({
   x,
   z,
@@ -105,6 +154,16 @@ function resolveLumenBloomPresence({
         3,
         0.82 + plateauInfluence * 0.9 + ribbonNoise * 0.35 + ridgeNoise * 0.24,
       );
+      const normalizedIntensity = clamp01(intensity / 3);
+      const colorHue =
+        (0.45 + ridgeStrength * 0.08 + ribbonNoise * 0.05 + bloom * 0.02) % 1;
+      const colorSaturation = clamp01(0.62 + plateauInfluence * 0.32);
+      const colorLightness = clamp01(0.54 + ridgeStrength * 0.2 + bloom * 0.12);
+      const colorHex = hslToHex(colorHue, colorSaturation, colorLightness);
+      const pulseRate = 1.3 + plateauInfluence * 0.8 + bloom * 0.6;
+      const glowBias = clamp01(
+        0.55 + normalizedIntensity * 0.5 + ridgeStrength * 0.35,
+      );
 
       return {
         hasFluid: true,
@@ -115,6 +174,9 @@ function resolveLumenBloomPresence({
           auroraIntensity: intensity,
           ribbonOrientation,
           ridgeStrength,
+          colorHex,
+          pulseRate,
+          glowBias,
         },
       };
     }
@@ -126,6 +188,7 @@ function resolveLumenBloomPresence({
       metadata: {
         ribbonOrientation,
         ridgeStrength,
+        glowBias: clamp01(ridgeStrength * 0.4),
       },
     };
   }

--- a/three-demo/src/world/fluids/lumen-bloom-material.js
+++ b/three-demo/src/world/fluids/lumen-bloom-material.js
@@ -1,17 +1,17 @@
 import { SURFACE_ROLES } from './fluid-geometry.js';
 
 const LUMEN_SETTINGS = Object.freeze({
-  baseEmissiveIntensity: 0.85,
-  edgeGlow: 0.55,
-  pulseStrength: 0.5,
-  opacity: 0.82,
-  pulseSpeed: 1.8,
+  baseEmissiveIntensity: 1.1,
+  edgeGlow: 0.7,
+  pulseStrength: 0.65,
+  opacity: 0.78,
+  pulseSpeed: 1.9,
 });
 
 export function createLumenBloomMaterial({ THREE }) {
   const material = new THREE.MeshStandardMaterial({
-    color: new THREE.Color('#f7fbb4'),
-    emissive: new THREE.Color('#f4ffd2'),
+    color: new THREE.Color('#4ef0ff'),
+    emissive: new THREE.Color('#b0f7ff'),
     emissiveIntensity: LUMEN_SETTINGS.baseEmissiveIntensity,
     roughness: 0.3,
     metalness: 0.08,
@@ -28,6 +28,8 @@ export function createLumenBloomMaterial({ THREE }) {
     uEdgeGlow: { value: LUMEN_SETTINGS.edgeGlow },
     uPulseStrength: { value: LUMEN_SETTINGS.pulseStrength },
     uPulseSpeed: { value: LUMEN_SETTINGS.pulseSpeed },
+    uAuroraHighlight: { value: 0 },
+    uRibbonOrientation: { value: new THREE.Vector2(0, 1) },
   };
 
   material.userData.uniforms = uniforms;
@@ -42,25 +44,27 @@ export function createLumenBloomMaterial({ THREE }) {
     shader.uniforms.uEdgeGlow = uniforms.uEdgeGlow;
     shader.uniforms.uPulseStrength = uniforms.uPulseStrength;
     shader.uniforms.uPulseSpeed = uniforms.uPulseSpeed;
+    shader.uniforms.uAuroraHighlight = uniforms.uAuroraHighlight;
+    shader.uniforms.uRibbonOrientation = uniforms.uRibbonOrientation;
 
     shader.vertexShader = shader.vertexShader.replace(
       '#include <common>',
-      `#include <common>\nattribute float surfaceType;\nattribute float surfaceRole;\nvarying float vSurfaceType;\nvarying float vSurfaceRole;`,
+      `#include <common>\nattribute float surfaceType;\nattribute float surfaceRole;\nattribute vec2 flowDirection;\nattribute float flowStrength;\nattribute vec2 ribbonVector;\nattribute float auroraGlow;\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nvarying vec2 vFlowDirection;\nvarying float vFlowStrength;\nvarying vec2 vRibbonVector;\nvarying float vAuroraGlow;`,
     );
 
     shader.vertexShader = shader.vertexShader.replace(
       '#include <begin_vertex>',
-      `#include <begin_vertex>\n\tvSurfaceType = surfaceType;\n\tvSurfaceRole = surfaceRole;`,
+      `#include <begin_vertex>\n\tvSurfaceType = surfaceType;\n\tvSurfaceRole = surfaceRole;\n\tvFlowDirection = flowDirection;\n\tvFlowStrength = flowStrength;\n\tvRibbonVector = ribbonVector;\n\tvAuroraGlow = auroraGlow;`,
     );
 
     shader.fragmentShader = shader.fragmentShader.replace(
       '#include <common>',
-      `#include <common>\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nuniform float uTime;\nuniform float uEdgeGlow;\nuniform float uPulseStrength;\nuniform float uPulseSpeed;`,
+      `#include <common>\nvarying float vSurfaceType;\nvarying float vSurfaceRole;\nvarying vec2 vFlowDirection;\nvarying float vFlowStrength;\nvarying vec2 vRibbonVector;\nvarying float vAuroraGlow;\nuniform float uTime;\nuniform float uEdgeGlow;\nuniform float uPulseStrength;\nuniform float uPulseSpeed;\nuniform vec2 uRibbonOrientation;\nuniform float uAuroraHighlight;`,
     );
 
     shader.fragmentShader = shader.fragmentShader.replace(
       '#include <emissivemap_fragment>',
-      `#include <emissivemap_fragment>\n\nfloat surfaceBand = smoothstep(0.5, 1.5, vSurfaceType);\nfloat roleBand = smoothstep(${EDGE_TOP_MIN}, ${EDGE_TOP_MAX}, vSurfaceRole);\nroleBand += smoothstep(${EDGE_BOTTOM_MIN}, ${EDGE_BOTTOM_MAX}, vSurfaceRole);\nfloat edgeGlow = clamp(surfaceBand + roleBand, 0.0, 2.0);\nfloat pulse = sin(uTime * uPulseSpeed + vSurfaceType * 1.35);\nfloat luminance = max(0.0, pulse) * uPulseStrength + edgeGlow * uEdgeGlow;\ntotalEmissiveRadiance += vec3(luminance);\ndiffuseColor.a = clamp(diffuseColor.a + edgeGlow * 0.12, 0.0, 1.0);`,
+      `#include <emissivemap_fragment>\n\nvec2 ribbonDir = vRibbonVector;\nif (length(ribbonDir) < 0.001) {\n  ribbonDir = uRibbonOrientation;\n}\nif (length(ribbonDir) < 0.001) {\n  ribbonDir = vec2(0.0, 1.0);\n}\nribbonDir = normalize(ribbonDir);\nvec2 flowDir = vFlowDirection;\nif (length(flowDir) < 0.001) {\n  flowDir = ribbonDir;\n} else {\n  flowDir = normalize(flowDir);\n}\nfloat surfaceBand = smoothstep(0.5, 1.5, vSurfaceType);\nfloat roleBand = smoothstep(${EDGE_TOP_MIN}, ${EDGE_TOP_MAX}, vSurfaceRole);\nroleBand += smoothstep(${EDGE_BOTTOM_MIN}, ${EDGE_BOTTOM_MAX}, vSurfaceRole);\nfloat edgeGlow = clamp(surfaceBand + roleBand, 0.0, 2.0);\nfloat auroraEnergy = clamp(vAuroraGlow + uAuroraHighlight, 0.0, 2.0);\nauroraEnergy += clamp(vFlowStrength, 0.0, 1.0) * 0.25;\nfloat ribbonPhase = dot(flowDir, ribbonDir);\nfloat ribbonWave = sin(uTime * (uPulseSpeed + auroraEnergy * 1.2) + ribbonPhase * 6.0);\nfloat softPulse = sin(uTime * uPulseSpeed + vSurfaceType * 1.35);\nfloat auroraPulse = max(0.0, ribbonWave) * (0.5 + auroraEnergy * 0.7);\nfloat luminance = max(0.0, softPulse) * (uPulseStrength + auroraEnergy * 0.35) + edgeGlow * uEdgeGlow + auroraPulse;\nvec3 auroraTintA = vec3(0.28, 0.84, 1.05);\nvec3 auroraTintB = vec3(1.05, 0.52, 1.18);\nfloat tintBlend = clamp(0.5 + ribbonPhase * 0.45, 0.0, 1.0);\nvec3 auroraTint = mix(auroraTintA, auroraTintB, tintBlend);\ntotalEmissiveRadiance += auroraTint * luminance;\nfloat colorBlend = clamp(auroraEnergy * 0.55, 0.0, 1.0);\ndiffuseColor.rgb = mix(diffuseColor.rgb, auroraTint, colorBlend);\ndiffuseColor.a = clamp(diffuseColor.a + edgeGlow * 0.12 + colorBlend * 0.1, 0.0, 1.0);`,
     );
   };
 
@@ -69,6 +73,9 @@ export function createLumenBloomMaterial({ THREE }) {
 
   const surfacePulseOffsets = new WeakMap();
   let elapsed = 0;
+  const clamp = THREE.MathUtils?.clamp
+    ? (value, min, max) => THREE.MathUtils.clamp(value, min, max)
+    : (value, min, max) => Math.min(max, Math.max(min, value));
 
   const ensureOffset = (mesh) => {
     if (surfacePulseOffsets.has(mesh)) {
@@ -88,17 +95,62 @@ export function createLumenBloomMaterial({ THREE }) {
 
     if (!surfaces || surfaces.size === 0) {
       material.emissiveIntensity = LUMEN_SETTINGS.baseEmissiveIntensity;
+      uniforms.uAuroraHighlight.value = clamp(
+        uniforms.uAuroraHighlight.value - delta * 0.4,
+        0,
+        2,
+      );
+      uniforms.uRibbonOrientation.value.set(0, 1);
       return;
     }
 
     let biasTotal = 0;
+    let highlightTotal = 0;
+    let orientationX = 0;
+    let orientationY = 0;
+    let orientationSamples = 0;
     surfaces.forEach((mesh) => {
       const offset = ensureOffset(mesh);
-      biasTotal += 0.85 + Math.sin(elapsed * 0.3 + offset) * 0.08;
+      const auroraIntensity = Number.isFinite(mesh.userData?.auroraIntensity)
+        ? mesh.userData.auroraIntensity
+        : 0;
+      const auroraWeight = 1 + clamp(auroraIntensity / 3, 0, 1) * 0.4;
+      biasTotal +=
+        (0.85 + Math.sin(elapsed * 0.3 + offset) * 0.08) * auroraWeight;
+      highlightTotal += auroraIntensity;
+      const ribbonOrientation = mesh.userData?.ribbonOrientation;
+      if (Number.isFinite(ribbonOrientation)) {
+        orientationX += Math.cos(ribbonOrientation);
+        orientationY += Math.sin(ribbonOrientation);
+        orientationSamples += 1;
+      }
     });
     const averageBias = biasTotal / surfaces.size;
     material.emissiveIntensity =
       LUMEN_SETTINGS.baseEmissiveIntensity * averageBias;
+
+    const orientationUniform = uniforms.uRibbonOrientation.value;
+    if (orientationSamples > 0) {
+      orientationUniform.set(
+        orientationX / orientationSamples,
+        orientationY / orientationSamples,
+      );
+      if (orientationUniform.lengthSq() > 0.0001) {
+        orientationUniform.normalize();
+      } else {
+        orientationUniform.set(0, 1);
+      }
+    } else {
+      orientationUniform.set(0, 1);
+    }
+
+    const averageHighlight = highlightTotal / surfaces.size;
+    const targetHighlight = clamp(averageHighlight / 3, 0, 1.5);
+    uniforms.uAuroraHighlight.value = clamp(
+      uniforms.uAuroraHighlight.value + (targetHighlight - uniforms.uAuroraHighlight.value) * 0.2,
+      0,
+      2,
+    );
   };
 
   const onSurfaceDisposed = (mesh) => {

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -700,6 +700,12 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         auroraIntensitySamples: 0,
         orientationVector: { x: 0, z: 0 },
         orientationSamples: 0,
+        glowBiasSum: 0,
+        glowBiasSamples: 0,
+        pulseRateSum: 0,
+        pulseRateSamples: 0,
+        ridgeStrengthSum: 0,
+        ridgeStrengthSamples: 0,
       };
       columns.set(columnKey, column);
     } else {
@@ -724,6 +730,25 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     if (Number.isFinite(metadata.auroraIntensity)) {
       column.auroraIntensitySum += metadata.auroraIntensity;
       column.auroraIntensitySamples += 1;
+    }
+    if (typeof metadata.colorHex === 'string') {
+      try {
+        column.color = new THREE.Color(metadata.colorHex);
+      } catch (error) {
+        // ignore invalid color strings
+      }
+    }
+    if (Number.isFinite(metadata.glowBias)) {
+      column.glowBiasSum += metadata.glowBias;
+      column.glowBiasSamples += 1;
+    }
+    if (Number.isFinite(metadata.pulseRate)) {
+      column.pulseRateSum += metadata.pulseRate;
+      column.pulseRateSamples += 1;
+    }
+    if (Number.isFinite(metadata.ridgeStrength)) {
+      column.ridgeStrengthSum += metadata.ridgeStrength;
+      column.ridgeStrengthSamples += 1;
     }
     if (Number.isFinite(metadata.ribbonOrientation)) {
       const angle = metadata.ribbonOrientation;
@@ -1120,7 +1145,10 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       const hasAuroraRibbonCue = Boolean(
         lumenCues && lumenCues.includes('aurora_ribbon'),
       );
-      if (hasAuroraRibbonCue) {
+      const columnWasFlooded = height < waterLevel;
+      const shouldSkipLumenSurface =
+        columnWasFlooded || isUnderwater || isShore;
+      if (hasAuroraRibbonCue && !shouldSkipLumenSurface) {
         registerFluidPresence({
           type: 'lumen_bloom',
           x: worldX,
@@ -1166,13 +1194,79 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       logFluidDebug('processing water columns', columns.size);
     }
 
+    const THREE = ensureThree();
+    const auroraBaseColor =
+      type === 'lumen_bloom' ? new THREE.Color('#74f7ff') : null;
+    const auroraHighlightColor =
+      type === 'lumen_bloom' ? new THREE.Color('#ffb1ff') : null;
+    const auroraBlendColor =
+      type === 'lumen_bloom' ? new THREE.Color('#74f7ff') : null;
+
     columns.forEach((column) => {
       column.surfaceY = column.maxY;
       column.bottomY = column.minY;
       if (!column.color) {
         column.color = new THREE.Color('#3a79c5');
       }
-      column.depth = Math.max(0.05, column.surfaceY - column.bottomY);
+      const baseDepth = Math.max(0.05, column.surfaceY - column.bottomY);
+      column.depth = baseDepth;
+      if (type === 'lumen_bloom') {
+        const averageAuroraIntensity =
+          column.auroraIntensitySamples > 0
+            ? column.auroraIntensitySum / column.auroraIntensitySamples
+            : 0;
+        column.localAuroraIntensity = averageAuroraIntensity;
+        const averageGlowBias =
+          column.glowBiasSamples > 0
+            ? column.glowBiasSum / column.glowBiasSamples
+            : Math.min(1, averageAuroraIntensity / 3);
+        column.localAuroraGlow = averageGlowBias;
+        column.localPulseRate =
+          column.pulseRateSamples > 0
+            ? column.pulseRateSum / column.pulseRateSamples
+            : null;
+        column.ridgeStrength =
+          column.ridgeStrengthSamples > 0
+            ? column.ridgeStrengthSum / column.ridgeStrengthSamples
+            : column.ridgeStrength ?? 0;
+        if (column.orientationSamples > 0) {
+          const ribbonOrientation = Math.atan2(
+            column.orientationVector.z,
+            column.orientationVector.x,
+          );
+          column.ribbonOrientation = ribbonOrientation;
+          column.ribbonVector = {
+            x: Math.cos(ribbonOrientation),
+            y: Math.sin(ribbonOrientation),
+          };
+        } else {
+          column.ribbonOrientation = null;
+          column.ribbonVector = { x: 0, y: 1 };
+        }
+
+        const orientationMix = column.ribbonOrientation
+          ? (Math.sin(column.ribbonOrientation) + 1) * 0.5
+          : 0.5;
+        const auroraBlend = auroraBlendColor
+          ? auroraBlendColor.copy(auroraBaseColor).lerp(
+              auroraHighlightColor,
+              orientationMix,
+            )
+          : null;
+        const colorBlend = Math.min(
+          0.75,
+          (column.localAuroraGlow ?? 0) * 0.65 + (column.ridgeStrength ?? 0) * 0.5,
+        );
+        if (auroraBlend) {
+          column.color.lerp(auroraBlend, colorBlend);
+        }
+        column.color.offsetHSL(0, Math.min(0.2, colorBlend * 0.35), colorBlend * 0.25);
+
+        const depthBoost =
+          Math.max(0, column.ridgeStrength ?? 0) * 0.35 +
+          (column.localAuroraGlow ?? 0) * 0.25;
+        column.depth = Math.max(baseDepth, baseDepth + depthBoost);
+      }
     });
 
     if (type === 'water') {
@@ -1246,7 +1340,19 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       const dropNz = Math.max(0, centerSurface - (neighbors.nz?.surfaceY ?? centerSurface));
 
       const flowVector = new THREE.Vector2(dropPx - dropNx, dropPz - dropNz);
-      const flowStrength = Math.min(1, flowVector.length() * 0.6);
+      let flowStrength = Math.min(1, flowVector.length() * 0.6);
+      if (type === 'lumen_bloom' && column.ribbonVector) {
+        const targetX = column.ribbonVector.x ?? 0;
+        const targetZ = column.ribbonVector.y ?? 1;
+        flowVector.set(targetX, targetZ);
+        flowStrength = Math.max(
+          flowStrength,
+          Math.min(
+            1,
+            (column.localAuroraGlow ?? 0) * 0.8 + (column.ridgeStrength ?? 0) * 0.6,
+          ),
+        );
+      }
       if (flowStrength > 0.001) {
         flowVector.normalize();
       } else {
@@ -1256,7 +1362,12 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       column.neighbors = neighbors;
       column.flowDirection = flowVector;
       column.flowStrength = flowStrength;
-      column.foamAmount = Math.min(1, foamExposure * 0.18 + flowStrength * 0.4);
+      column.foamAmount = Math.min(
+        1,
+        type === 'lumen_bloom'
+          ? foamExposure * 0.1 + flowStrength * 0.25
+          : foamExposure * 0.18 + flowStrength * 0.4,
+      );
       const dropMax = Math.max(dropPx, dropNx, dropPz, dropNz);
       const neighborFluidCount = neighborOffsets.reduce((acc, offset) => {
         return acc + (neighbors[offset.key]?.hasFluid ? 1 : 0);


### PR DESCRIPTION
## Summary
- prevent lumen bloom surfaces from registering on submerged or shoreline columns in `world/generation.js`
- enrich aurora ribbon sampling metadata and geometry attributes to carry glow and orientation details
- retune the lumen bloom material shader for aurora-driven colour, intensity, and orientation cues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d86690d4832ab9bc6fef44697e96