### PR TITLE
Adjust dropBottom handling for dry neighbors

### DIFF
--- a/three-demo/src/world/fluids/fluid-geometry.js
+++ b/three-demo/src/world/fluids/fluid-geometry.js
@@ -182,7 +182,9 @@ export function buildFluidGeometry({ THREE, columns }) {
     const auroraGlow = column.localAuroraGlow ?? column.localAuroraIntensity ?? 0;
 
     const dropSurface = surfaceY;
-    const dropBottom = Math.min(bottomY, neighborInfo.bottomY);
+    const dropBottom = neighborInfo.hasFluid
+      ? Math.min(bottomY, neighborInfo.bottomY ?? bottomY)
+      : bottomY;
     if (!(dropSurface > dropBottom + 0.01)) {
       return;
     }


### PR DESCRIPTION
## Summary
- ensure side face dropBottom only uses neighbor depths when the neighbor column contains fluid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f354c81c832abe54b72d1b450b10