### PR TITLE
Document nonprocedural texture directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This project hosts a browser-based sandbox inspired by classic block-building ga
 - Enhanced lighting pass with ACES filmic tone mapping, soft shadows, and a fill light for richer visuals.
 - Responsive HUD overlay that surfaces health, oxygen, and contextual status messaging.
 
+## Art Assets
+
+Artists can drop hand-authored overrides into `three-demo/src/textures/nonprocedural/`. See the README in that folder for naming and tiling conventions so the runtime picks up your textures automatically.
+
 ## Audio
 The sandbox ships with a lightweight background music pipeline so developers can quickly audition new tracks:
 

--- a/three-demo/src/textures/README.md
+++ b/three-demo/src/textures/README.md
@@ -1,0 +1,16 @@
+# Texture Assets
+
+This directory stores texture images that are authored outside of the procedural material pipeline. Use it for hand-painted or photo-sourced art that should override the generated blocks.
+
+## Naming
+- Name files after the block ID they are meant to replace (for example, `grass.png`, `sand.png`, or `oak_log.png`).
+- When providing multiple resolutions, append the pixel height (e.g., `grass@128.png`). Keep the base name consistent so the asset map can pair variants automatically.
+
+## Format and Orientation
+- Save textures as PNG files with power-of-two dimensions (32×32, 64×64, 128×128, etc.) to avoid mipmap artifacts.
+- Author images so the top edge corresponds to the block's north-facing side and the pattern tiles seamlessly on all edges.
+- If a texture is not tileable, note the intended usage (single-face decals, UI elements, etc.) in a README alongside the asset.
+
+## Subdirectories
+- Place source files that are generated procedurally or via scripts in other folders. This `nonprocedural/` subdirectory is reserved for textures that require manual curation.
+- Use additional subfolders inside `nonprocedural/` (for example, `blocks/`, `items/`, or `ui/`) when you need to group related art while keeping the naming rules above.


### PR DESCRIPTION
## Summary
- add a placeholder in three-demo/src/textures/nonprocedural so manual assets can be tracked in git
- document naming, tiling, and folder conventions for hand-authored textures
- point artists to the new directory from the root contributor README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9fec00540832abeed0098d6aaf11b