### PR TITLE
Add static texture loader for nonprocedural block textures

### DIFF
--- a/three-demo/src/rendering/static-texture-loader.js
+++ b/three-demo/src/rendering/static-texture-loader.js
@@ -1,0 +1,65 @@
+const STATIC_TEXTURE_URLS = import.meta.glob(
+  '../textures/nonprocedural/**/*.{png,PNG,jpg,JPG,jpeg,JPEG,webp,WEBP,avif,AVIF,gif,GIF}',
+  { eager: true, import: 'default', query: '?url' }
+);
+
+const textureCache = new WeakMap();
+
+function parseTextureKey(filePath) {
+  const filename = filePath.split('/').pop();
+  const nameWithoutExt = filename.replace(/\.[^.]+$/, '');
+  const match = nameWithoutExt.match(/^(.*?)(?:@(\d+))?$/);
+  const baseName = match ? match[1] : nameWithoutExt;
+  const variantSize = match && match[2] ? Number.parseInt(match[2], 10) : Number.MAX_SAFE_INTEGER;
+  return { baseName, variantSize };
+}
+
+function normalizeTexture(texture, { THREE, key }) {
+  texture.name = key;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.minFilter = THREE.NearestFilter;
+  texture.magFilter = THREE.NearestFilter;
+  texture.flipY = false;
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else if ('encoding' in texture) {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+  texture.needsUpdate = true;
+  return texture;
+}
+
+export function loadStaticTextureMap({ THREE } = {}) {
+  if (!THREE) {
+    throw new Error('loadStaticTextureMap requires a THREE instance');
+  }
+
+  if (textureCache.has(THREE)) {
+    return textureCache.get(THREE);
+  }
+
+  const loader = new THREE.TextureLoader();
+  const entries = Object.entries(STATIC_TEXTURE_URLS);
+  const staged = new Map();
+
+  for (const [path, url] of entries) {
+    if (!url) continue;
+    const { baseName, variantSize } = parseTextureKey(path);
+    const existing = staged.get(baseName);
+    if (existing && existing.variantSize >= variantSize) {
+      continue;
+    }
+
+    const texture = normalizeTexture(loader.load(url), { THREE, key: baseName });
+    staged.set(baseName, { texture, variantSize });
+  }
+
+  const result = {};
+  for (const [key, { texture }] of staged.entries()) {
+    result[key] = texture;
+  }
+
+  textureCache.set(THREE, result);
+  return result;
+}

--- a/three-demo/src/rendering/textures.js
+++ b/three-demo/src/rendering/textures.js
@@ -1,5 +1,6 @@
 import { TextureEngine } from './texture-engine.js';
 import { createBiomeTintMaterial } from './biome-tint-material.js';
+import { loadStaticTextureMap } from './static-texture-loader.js';
 
 export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
   if (!THREE) {
@@ -800,6 +801,11 @@ export function createBlockMaterials({ THREE, seed = 1337 } = {}) {
       },
     }),
   };
+
+  const staticTextures = loadStaticTextureMap({ THREE });
+  for (const [key, texture] of Object.entries(staticTextures)) {
+    textures[key] = texture;
+  }
 
   const damageStageCount = 6;
   const damageTextures = Array.from({ length: damageStageCount }, (_, stage) => {

--- a/three-demo/src/textures/README.md
+++ b/three-demo/src/textures/README.md
@@ -1,16 +1,25 @@
 # Texture Assets
 
-This directory stores texture images that are authored outside of the procedural material pipeline. Use it for hand-painted or photo-sourced art that should override the generated blocks.
+This directory stores texture images that are authored outside of the procedural material pipeline. Use it for hand-painted or photo-sourced art that should override the generated blocks via `src/rendering/static-texture-loader.js`.
 
-## Naming
-- Name files after the block ID they are meant to replace (for example, `grass.png`, `sand.png`, or `oak_log.png`).
-- When providing multiple resolutions, append the pixel height (e.g., `grass@128.png`). Keep the base name consistent so the asset map can pair variants automatically.
+## Supported Formats
+- The loader watches `nonprocedural/` for images with the extensions `png`, `jpg`, `jpeg`, `webp`, `avif`, and `gif` (any capitalization).
+- Keep the exported files optimized for web delivery—lossless PNG or WebP for pixel art, AVIF/JPEG for photographic sources, etc.
+
+## Naming and Resolution Variants
+- Name files after the block/material ID they are meant to replace (for example, `grass.png`, `sand.png`, or `oak_log.png`).
+- You may append a resolution suffix using the `@<height>` convention (e.g., `grass@128.png`). The loader picks the highest available suffix for a given base name, falling back to the unsuffixed file when present.
+- Subdirectories are allowed; only the filename (minus extension and optional resolution suffix) is used to match the block ID.
+
+## Loader Defaults and Overrides
+- Imported textures are normalized to repeat on both axes, sample with nearest-neighbor filtering, and use the sRGB color space so they match the procedural materials.
+- If a specific asset needs different wrapping, filtering, or color settings, update the `normalizeTexture` helper in `static-texture-loader.js` to handle that case before committing the file.
+
+## Folder Structure
+- Place curated textures inside `nonprocedural/`. Keep generated source imagery in sibling folders so the loader can focus on hand-authored art.
+- Organize large sets with optional subdirectories (for example, `blocks/`, `items/`, or `ui/`). Only the filename is used for ID matching, so nesting will not affect overrides.
 
 ## Format and Orientation
-- Save textures as PNG files with power-of-two dimensions (32×32, 64×64, 128×128, etc.) to avoid mipmap artifacts.
+- Save textures with power-of-two dimensions (32×32, 64×64, 128×128, etc.) to avoid mipmap artifacts.
 - Author images so the top edge corresponds to the block's north-facing side and the pattern tiles seamlessly on all edges.
 - If a texture is not tileable, note the intended usage (single-face decals, UI elements, etc.) in a README alongside the asset.
-
-## Subdirectories
-- Place source files that are generated procedurally or via scripts in other folders. This `nonprocedural/` subdirectory is reserved for textures that require manual curation.
-- Use additional subfolders inside `nonprocedural/` (for example, `blocks/`, `items/`, or `ui/`) when you need to group related art while keeping the naming rules above.


### PR DESCRIPTION
## Summary
- add a static texture loader that glob-imports curated assets and normalizes repeat/filters in `src/rendering/static-texture-loader.js`
- integrate the loader into `createBlockMaterials` so static files override procedural textures when present
- document supported formats, naming conventions, and customization guidance in `src/textures/README.md`

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d9ff3726a0832abc30033421aef580