### PR TITLE
Add lumen bloom motes particle effect

### DIFF
--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -23,6 +23,7 @@ import {
 } from './rendering/particle-system.js'
 import { createWaterSurfaceMistEmitter } from './rendering/particles/water-effects.js'
 import { createAuroraRibbonEmitter } from './rendering/particles/aurora-effects.js'
+import { createLumenBloomMotesEmitter } from './rendering/particles/lumen-bloom-effects.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -268,16 +269,33 @@ try {
       const orientationValue = metadata?.ribbonOrientation ?? mesh.userData?.ribbonOrientation
       const intensity = Number.isFinite(intensityValue) ? intensityValue : 1
       const orientation = Number.isFinite(orientationValue) ? orientationValue : 0
-      const handle = emit(
-        createAuroraRibbonEmitter({
-          position: anchor,
-          span,
-          intensity,
-          orientation,
-        }),
+      const handles = []
+      handles.push(
+        emit(
+          createAuroraRibbonEmitter({
+            position: anchor,
+            span,
+            intensity,
+            orientation,
+          }),
+        ),
+      )
+      handles.push(
+        emit(
+          createLumenBloomMotesEmitter({
+            position: anchor,
+            radius: span * 0.55,
+            intensity: intensity * 0.9,
+            riseHeight: Math.max(2.4, span * 0.35),
+          }),
+        ),
       )
       return {
-        dispose: () => handle?.stop?.(),
+        dispose: () => {
+          for (const handle of handles) {
+            handle?.stop?.()
+          }
+        },
       }
     },
   )

--- a/three-demo/src/rendering/particles/lumen-bloom-effects.js
+++ b/three-demo/src/rendering/particles/lumen-bloom-effects.js
@@ -1,0 +1,52 @@
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js'
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function createLumenBloomMotesEmitter({
+  position,
+  radius = 4.5,
+  intensity = 1,
+  riseHeight = 2.8,
+} = {}) {
+  const glow = clamp(intensity, 0.35, 3.4)
+  const spawnRadius = Math.max(1.2, radius)
+  const driftHeight = Math.max(1.4, riseHeight)
+
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 22 * glow,
+    maxParticles: Math.ceil(110 * glow),
+    lifetime: { min: 3.2, max: 5.4 },
+    baseColor: '#f0f8ff',
+    colorRamp: [
+      { time: 0, color: '#1bffff' },
+      { time: 0.32, color: '#5dffe7' },
+      { time: 0.68, color: '#fefbff' },
+      { time: 1, color: '#ffd6ff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.32 * glow },
+      { time: 0.55, size: 0.62 * glow },
+      { time: 1, size: 0.12 * glow },
+    ],
+    position,
+    positionJitter: {
+      x: spawnRadius * 0.6,
+      y: driftHeight * 0.45,
+      z: spawnRadius * 0.6,
+    },
+    velocity: { x: 0, y: 0.46 + glow * 0.18, z: 0 },
+    velocityJitter: { x: 0.18, y: 0.2, z: 0.18 },
+    size: { min: 0.28 * glow, max: 0.74 * glow },
+    gravity: { x: 0, y: 0.38, z: 0 },
+    drag: 0.72,
+    fadeIn: 0.18,
+    fadeOut: 0.36,
+    opacity: 0.82,
+    renderOrder: 7,
+  })
+
+  emitter.debugLabel = 'LumenBloomMotesEmitter'
+  return emitter
+}


### PR DESCRIPTION
## Summary
- add a lumen bloom motes GPU billboard emitter for slow-rising emissive particles
- extend the lumen_bloom fluid surface effect to emit motes alongside aurora ribbons when aurora cues are present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0b0926a0832abaca148c3666b0f4