### PR TITLE
Add dynamic weather particle emitters

### DIFF
--- a/three-demo/src/rendering/particles/gpu-billboard-emitter.js
+++ b/three-demo/src/rendering/particles/gpu-billboard-emitter.js
@@ -269,6 +269,7 @@ export function createGpuBillboardEmitter(options = {}) {
 
   let pool = null
   let material = null
+  let threeModule = null
   let basePosition
   let positionNoise
   let baseVelocity
@@ -283,6 +284,7 @@ export function createGpuBillboardEmitter(options = {}) {
   const liveParticles = []
   let tempPosition = null
   let tempVelocity = null
+  let pendingBasePosition = null
 
   function ensureTempVectors(THREE) {
     if (!tempPosition) {
@@ -336,6 +338,7 @@ export function createGpuBillboardEmitter(options = {}) {
   return {
     initialize({ THREE, createInstancedPool, getElapsedTime }) {
       ensureTempVectors(THREE)
+      threeModule = THREE
       basePosition = resolveVector3(THREE, position, new THREE.Vector3())
       positionNoise = positionJitter
         ? resolveVector3(THREE, positionJitter, new THREE.Vector3())
@@ -397,6 +400,12 @@ export function createGpuBillboardEmitter(options = {}) {
 
       const now = getElapsedTime?.() ?? 0
       material.uniforms.uTime.value = now
+
+      if (pendingBasePosition) {
+        const resolved = resolveVector3(THREE, pendingBasePosition, basePosition)
+        basePosition.copy(resolved)
+        pendingBasePosition = null
+      }
     },
 
     update({ delta, getElapsedTime }) {
@@ -428,10 +437,26 @@ export function createGpuBillboardEmitter(options = {}) {
       return pool ? pool.getActiveCount() : 0
     },
 
+    setBasePosition(value) {
+      if (value === undefined || value === null) {
+        return
+      }
+      if (!basePosition || !threeModule) {
+        pendingBasePosition = value
+        return
+      }
+      const resolved = resolveVector3(threeModule, value, basePosition)
+      basePosition.copy(resolved)
+      pendingBasePosition = null
+    },
+
     dispose() {
       liveParticles.length = 0
       pool = null
       material = null
+      basePosition = undefined
+      threeModule = null
+      pendingBasePosition = null
     },
   }
 }

--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -1,0 +1,47 @@
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js';
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function createWeatherRainEmitter({
+  intensity = 0.6,
+  radius = 12,
+  heightOffset = 14,
+} = {}) {
+  const density = clamp(intensity, 0.2, 2.4);
+  const spawnRadius = Math.max(6, radius);
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 200 * density,
+    maxParticles: Math.ceil(240 * density),
+    lifetime: { min: 0.85, max: 1.25 },
+    baseColor: '#a9cfff',
+    colorRamp: [
+      { time: 0, color: '#9bc0ff' },
+      { time: 0.45, color: '#6e9bff' },
+      { time: 1, color: '#c9e6ff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.18 },
+      { time: 0.45, size: 0.12 },
+      { time: 1, size: 0.02 },
+    ],
+    position: { x: 0, y: heightOffset, z: 0 },
+    positionJitter: { x: spawnRadius, y: 0.6, z: spawnRadius },
+    velocity: { x: 0, y: -11 - density * 3.5, z: 0 },
+    velocityJitter: { x: 0.75, y: 2.4, z: 0.75 },
+    size: { min: 0.04, max: 0.08 },
+    gravity: { x: 0, y: -19.6, z: 0 },
+    drag: 0.22,
+    fadeIn: 0.05,
+    fadeOut: 0.15,
+    opacity: 0.52,
+    depthWrite: false,
+    renderOrder: 5,
+  });
+  emitter.debugLabel = 'WeatherRainEmitter';
+  emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 };
+  emitter.weatherUpdateInterval = 0.2;
+  emitter.weatherMinAnchorDistance = spawnRadius * 0.28;
+  return emitter;
+}

--- a/three-demo/src/rendering/particles/weather-snow.js
+++ b/three-demo/src/rendering/particles/weather-snow.js
@@ -1,0 +1,47 @@
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js';
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function createWeatherSnowEmitter({
+  intensity = 0.5,
+  radius = 11,
+  heightOffset = 12,
+} = {}) {
+  const density = clamp(intensity, 0.2, 1.8);
+  const spawnRadius = Math.max(6, radius);
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 120 * density,
+    maxParticles: Math.ceil(200 * density),
+    lifetime: { min: 2.4, max: 3.6 },
+    baseColor: '#f5fbff',
+    colorRamp: [
+      { time: 0, color: '#e3f3ff' },
+      { time: 0.5, color: '#ffffff' },
+      { time: 1, color: '#d6edff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: 0.35 },
+      { time: 0.45, size: 0.48 },
+      { time: 1, size: 0.3 },
+    ],
+    position: { x: 0, y: heightOffset, z: 0 },
+    positionJitter: { x: spawnRadius * 1.1, y: 0.8, z: spawnRadius * 1.1 },
+    velocity: { x: 0, y: -2.6 - density * 0.6, z: 0 },
+    velocityJitter: { x: 0.65, y: 0.95, z: 0.65 },
+    size: { min: 0.22, max: 0.56 },
+    gravity: { x: 0, y: -3.8, z: 0 },
+    drag: 1.25,
+    fadeIn: 0.15,
+    fadeOut: 0.35,
+    opacity: 0.78,
+    depthWrite: false,
+    renderOrder: 5,
+  });
+  emitter.debugLabel = 'WeatherSnowEmitter';
+  emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 };
+  emitter.weatherUpdateInterval = 0.3;
+  emitter.weatherMinAnchorDistance = spawnRadius * 0.2;
+  return emitter;
+}

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -1,3 +1,7 @@
+import { createAuroraRibbonEmitter } from '../../rendering/particles/aurora-effects.js';
+import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain.js';
+import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
+
 const DEFAULT_WEATHER_PRESETS = {
   clear_skies: {
     id: 'clear_skies',
@@ -7,6 +11,7 @@ const DEFAULT_WEATHER_PRESETS = {
     category: 'clear',
     moisture: 0,
     temperature: 0.65,
+    effects: {},
   },
   misty_rain: {
     id: 'misty_rain',
@@ -16,6 +21,14 @@ const DEFAULT_WEATHER_PRESETS = {
     category: 'rain',
     moisture: 0.45,
     temperature: 0.5,
+    effects: {
+      precipitation: {
+        type: 'rain',
+        intensity: 0.45,
+        radius: 10,
+        anchorHeight: 12,
+      },
+    },
   },
   charged_storm: {
     id: 'charged_storm',
@@ -25,10 +38,125 @@ const DEFAULT_WEATHER_PRESETS = {
     category: 'storm',
     moisture: 0.9,
     temperature: 0.4,
+    effects: {
+      precipitation: {
+        type: 'rain',
+        intensity: 1.2,
+        radius: 14,
+        anchorHeight: 15,
+        updateInterval: 0.18,
+      },
+    },
   },
+};
+
+const CATEGORY_DEFAULT_EFFECTS = {
+  rain: {
+    precipitation: { type: 'rain' },
+  },
+  storm: {
+    precipitation: { type: 'rain', intensity: 1 },
+  },
+  snow: {
+    precipitation: { type: 'snow' },
+  },
+  aurora: {
+    aurora: { intensity: 1.1, span: 8 },
+  },
+};
+
+const DEFAULT_TICK_INTERVAL = 1.5;
+const DEFAULT_PRECIPITATION_UPDATE_INTERVAL = 0.22;
+const DEFAULT_AURORA_UPDATE_INTERVAL = 0.55;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }
 
-const DEFAULT_TICK_INTERVAL = 1.5
+function resolveWeatherEffects(weather) {
+  if (!weather) {
+    return { precipitation: null, aurora: null };
+  }
+  const categoryDefaults = CATEGORY_DEFAULT_EFFECTS[weather.category] ?? {};
+  const effects = weather.effects ?? {};
+  return {
+    precipitation: {
+      ...(categoryDefaults.precipitation ?? {}),
+      ...(effects.precipitation ?? {}),
+    },
+    aurora: {
+      ...(categoryDefaults.aurora ?? {}),
+      ...(effects.aurora ?? {}),
+    },
+  };
+}
+
+function normalisePrecipitationEffect(weather, effect) {
+  if (!effect || !effect.type) {
+    return null;
+  }
+  const type = String(effect.type);
+  const baseIntensity = Number.isFinite(effect.intensity)
+    ? effect.intensity
+    : Number.isFinite(weather?.intensity)
+    ? weather.intensity
+    : 0.5;
+  const radius = Number.isFinite(effect.radius) ? effect.radius : 12;
+  const anchorHeight = Number.isFinite(effect.anchorHeight)
+    ? effect.anchorHeight
+    : Number.isFinite(effect.heightOffset)
+    ? effect.heightOffset
+    : 14;
+  const updateInterval = Number.isFinite(effect.updateInterval)
+    ? effect.updateInterval
+    : null;
+  const minAnchorDistance = Number.isFinite(effect.minAnchorDistance)
+    ? effect.minAnchorDistance
+    : null;
+  return {
+    type,
+    intensity: clamp(baseIntensity, 0.15, 2.6),
+    radius: Math.max(4, radius),
+    anchorHeight,
+    updateInterval: updateInterval ?? null,
+    minAnchorDistance: minAnchorDistance ?? null,
+  };
+}
+
+function normaliseAuroraEffect(weather, effect) {
+  if (!effect || (effect.intensity === undefined && effect.span === undefined && !effect.type)) {
+    return null;
+  }
+  const baseIntensity = Number.isFinite(effect.intensity)
+    ? effect.intensity
+    : Number.isFinite(weather?.intensity)
+    ? weather.intensity
+    : 0.6;
+  const span = Number.isFinite(effect.span) ? effect.span : 8;
+  const count = Number.isFinite(effect.count) ? Math.max(1, Math.round(effect.count)) : 1;
+  const anchorHeight = Number.isFinite(effect.anchorHeight) ? effect.anchorHeight : 20;
+  const forwardOffset = Number.isFinite(effect.forwardOffset) ? effect.forwardOffset : 14;
+  const lateralOffset = Number.isFinite(effect.lateralOffset) ? effect.lateralOffset : 5;
+  const orientation = Number.isFinite(effect.orientation) ? effect.orientation : null;
+  const orientationJitter = Number.isFinite(effect.orientationJitter)
+    ? effect.orientationJitter
+    : Math.PI / 10;
+  const updateInterval = Number.isFinite(effect.updateInterval)
+    ? effect.updateInterval
+    : DEFAULT_AURORA_UPDATE_INTERVAL;
+  return {
+    intensity: clamp(baseIntensity, 0.2, 3.4),
+    span: Math.max(4, span),
+    count,
+    anchorHeight,
+    forwardOffset,
+    lateralOffset,
+    orientation,
+    orientationJitter,
+    updateInterval,
+    alignWithHeading: effect.alignWithHeading !== false,
+  };
+}
 
 export function createWeatherManager({
   scene,
@@ -37,63 +165,261 @@ export function createWeatherManager({
 } = {}) {
   const weatherPresets = new Map(
     Object.entries(DEFAULT_WEATHER_PRESETS).map(([key, value]) => [key, { ...value }]),
-  )
+  );
 
-  let activeWeather = weatherPresets.get('clear_skies') ?? null
-  let tickAccumulator = 0
-  let lastElapsedTime = 0
-  const tickListeners = new Set()
-  const scheduledTransitions = []
-  let diagnosticOverlayDisposer = null
-
-  const particleEffectHandles = new Set()
+  let activeWeather = weatherPresets.get('clear_skies') ?? null;
+  let tickAccumulator = 0;
+  let lastElapsedTime = 0;
+  const tickListeners = new Set();
+  const scheduledTransitions = [];
+  let diagnosticOverlayDisposer = null;
+  const activeParticleEffects = [];
+  let needsEffectRefresh = true;
 
   const applyWeatherEffects = (weather) => {
     if (!weather || !scene) {
-      return
+      return;
     }
-    scene.userData = scene.userData || {}
+    scene.userData = scene.userData || {};
+    const resolvedEffects = resolveWeatherEffects(weather);
     scene.userData.weather = {
       id: weather.id,
       label: weather.label,
       intensity: weather.intensity,
       category: weather.category,
-    }
-  }
+      precipitation: resolvedEffects.precipitation?.type ?? null,
+      aurora: Boolean(resolvedEffects.aurora && Object.keys(resolvedEffects.aurora).length > 0),
+    };
+  };
 
   const disposeWeatherEffects = () => {
-    for (const handle of particleEffectHandles) {
+    for (const attachment of activeParticleEffects) {
       try {
-        handle?.stop?.()
+        attachment.handle?.stop?.();
       } catch (error) {
-        console.warn('Failed to dispose weather particle handle:', error)
+        console.warn('Failed to dispose weather particle handle:', error);
       }
     }
-    particleEffectHandles.clear()
-  }
+    activeParticleEffects.length = 0;
+  };
+
+  const spawnPrecipitationEffect = (config, context) => {
+    if (!particleSystem || typeof particleSystem.emit !== 'function') {
+      return;
+    }
+    const emitter =
+      config.type === 'snow'
+        ? createWeatherSnowEmitter({
+            intensity: config.intensity,
+            radius: config.radius,
+            heightOffset: config.anchorHeight,
+          })
+        : createWeatherRainEmitter({
+            intensity: config.intensity,
+            radius: config.radius,
+            heightOffset: config.anchorHeight,
+          });
+    const handle = particleSystem.emit(emitter);
+    if (!handle) {
+      return;
+    }
+    let updateInterval = config.updateInterval;
+    if (!Number.isFinite(updateInterval) && Number.isFinite(emitter.weatherUpdateInterval)) {
+      updateInterval = emitter.weatherUpdateInterval;
+    }
+    let minAnchorDistance = config.minAnchorDistance;
+    if (
+      !Number.isFinite(minAnchorDistance) &&
+      Number.isFinite(emitter.weatherMinAnchorDistance)
+    ) {
+      minAnchorDistance = emitter.weatherMinAnchorDistance;
+    }
+    const attachment = {
+      type: 'precipitation',
+      handle,
+      emitter,
+      anchorOffsetY: config.anchorHeight,
+      updateInterval: Number.isFinite(updateInterval)
+        ? Math.max(0.05, updateInterval)
+        : DEFAULT_PRECIPITATION_UPDATE_INTERVAL,
+      minDistanceSq: Number.isFinite(minAnchorDistance)
+        ? Math.max(0, minAnchorDistance) ** 2
+        : (emitter.weatherMinAnchorDistance ?? 0) ** 2,
+      lastUpdateTime: -Infinity,
+      lastAnchor: {
+        x: Number.POSITIVE_INFINITY,
+        y: Number.POSITIVE_INFINITY,
+        z: Number.POSITIVE_INFINITY,
+      },
+    };
+    const playerPosition = context.playerControls?.getPosition?.();
+    const elapsedTime = context.elapsedTime ?? 0;
+    if (playerPosition) {
+      emitter.setBasePosition?.({
+        x: playerPosition.x,
+        y: playerPosition.y + config.anchorHeight,
+        z: playerPosition.z,
+      });
+      attachment.lastAnchor = {
+        x: playerPosition.x,
+        y: playerPosition.y,
+        z: playerPosition.z,
+      };
+      attachment.lastUpdateTime = elapsedTime;
+    }
+    activeParticleEffects.push(attachment);
+  };
+
+  const spawnAuroraEffects = (config, context) => {
+    if (!particleSystem || typeof particleSystem.emit !== 'function') {
+      return;
+    }
+    const playerControls = context.playerControls;
+    const yawPitch = playerControls?.getYawPitch?.();
+    const headingYaw = yawPitch?.yaw ?? 0;
+    const count = config.count;
+    const centerIndex = (count - 1) / 2;
+    for (let i = 0; i < count; i += 1) {
+      const offsetIndex = i - centerIndex;
+      const orientationOffset = offsetIndex * 0.35;
+      const jitter = (Math.random() - 0.5) * config.orientationJitter;
+      const baseOrientation = config.alignWithHeading
+        ? headingYaw
+        : config.orientation ?? headingYaw;
+      const ribbonOrientation = baseOrientation + orientationOffset + jitter;
+      const emitter = createAuroraRibbonEmitter({
+        position: { x: 0, y: config.anchorHeight, z: 0 },
+        span: config.span,
+        intensity: config.intensity,
+        orientation: ribbonOrientation,
+      });
+      emitter.debugLabel = emitter.debugLabel ?? 'WeatherAuroraRibbon';
+      const handle = particleSystem.emit(emitter);
+      if (!handle) {
+        continue;
+      }
+      const attachment = {
+        type: 'aurora',
+        handle,
+        emitter,
+        anchorOffsetY: config.anchorHeight,
+        updateInterval: Math.max(0.25, config.updateInterval),
+        forwardOffset: config.forwardOffset,
+        lateralOffset: offsetIndex * config.lateralOffset,
+        alignWithHeading: config.alignWithHeading,
+        orientationOffset: orientationOffset + jitter,
+        baseHeadingAtSpawn: headingYaw,
+        staticOrientation: ribbonOrientation,
+        lastUpdateTime: -Infinity,
+      };
+      activeParticleEffects.push(attachment);
+    }
+  };
+
+  const refreshWeatherEffects = (context) => {
+    needsEffectRefresh = false;
+    disposeWeatherEffects();
+    if (!activeWeather) {
+      return;
+    }
+    const resolved = resolveWeatherEffects(activeWeather);
+    const precipitation = normalisePrecipitationEffect(activeWeather, resolved.precipitation);
+    if (precipitation) {
+      spawnPrecipitationEffect(precipitation, context);
+    }
+    const aurora = normaliseAuroraEffect(activeWeather, resolved.aurora);
+    if (aurora) {
+      spawnAuroraEffects(aurora, context);
+    }
+  };
+
+  const updateAnchoredEffects = (context) => {
+    if (activeParticleEffects.length === 0) {
+      return;
+    }
+    const { playerControls, elapsedTime = lastElapsedTime } = context;
+    const playerPosition = playerControls?.getPosition?.();
+    if (!playerPosition) {
+      return;
+    }
+    const yawPitch = playerControls.getYawPitch?.();
+    for (const attachment of activeParticleEffects) {
+      if (typeof attachment.emitter?.setBasePosition !== 'function') {
+        continue;
+      }
+      const interval = Number.isFinite(attachment.updateInterval)
+        ? attachment.updateInterval
+        : 0;
+      if (interval > 0 && elapsedTime - (attachment.lastUpdateTime ?? -Infinity) < interval) {
+        continue;
+      }
+      if (attachment.type === 'precipitation') {
+        const dx = playerPosition.x - attachment.lastAnchor.x;
+        const dy = playerPosition.y - attachment.lastAnchor.y;
+        const dz = playerPosition.z - attachment.lastAnchor.z;
+        const distanceSq = dx * dx + dy * dy + dz * dz;
+        if (distanceSq < (attachment.minDistanceSq ?? 0)) {
+          continue;
+        }
+        attachment.emitter.setBasePosition({
+          x: playerPosition.x,
+          y: playerPosition.y + attachment.anchorOffsetY,
+          z: playerPosition.z,
+        });
+        attachment.lastAnchor = {
+          x: playerPosition.x,
+          y: playerPosition.y,
+          z: playerPosition.z,
+        };
+        attachment.lastUpdateTime = elapsedTime;
+      } else if (attachment.type === 'aurora') {
+        let heading = attachment.staticOrientation ?? 0;
+        if (attachment.alignWithHeading) {
+          const baseYaw = yawPitch?.yaw ?? attachment.baseHeadingAtSpawn ?? 0;
+          heading = baseYaw + (attachment.orientationOffset ?? 0);
+        }
+        const forwardOffset = Number.isFinite(attachment.forwardOffset)
+          ? attachment.forwardOffset
+          : 12;
+        let anchorX = playerPosition.x + Math.cos(heading) * forwardOffset;
+        let anchorZ = playerPosition.z + Math.sin(heading) * forwardOffset;
+        if (Number.isFinite(attachment.lateralOffset) && attachment.lateralOffset !== 0) {
+          const lateralYaw = heading + Math.PI / 2;
+          anchorX += Math.cos(lateralYaw) * attachment.lateralOffset;
+          anchorZ += Math.sin(lateralYaw) * attachment.lateralOffset;
+        }
+        attachment.emitter.setBasePosition({
+          x: anchorX,
+          y: playerPosition.y + attachment.anchorOffsetY,
+          z: anchorZ,
+        });
+        attachment.lastUpdateTime = elapsedTime;
+      }
+    }
+  };
 
   const evaluateScheduledTransitions = ({ elapsedTime }) => {
     if (!Number.isFinite(elapsedTime)) {
-      return
+      return;
     }
-    const due = []
+    const due = [];
     for (let i = scheduledTransitions.length - 1; i >= 0; i -= 1) {
-      const entry = scheduledTransitions[i]
+      const entry = scheduledTransitions[i];
       if (elapsedTime >= entry.triggerTime) {
-        due.push(entry)
-        scheduledTransitions.splice(i, 1)
+        due.push(entry);
+        scheduledTransitions.splice(i, 1);
       }
     }
     for (const entry of due.sort((a, b) => a.triggerTime - b.triggerTime)) {
-      setWeather(entry.weatherId, entry.options)
+      setWeather(entry.weatherId, entry.options);
     }
-  }
+  };
 
   const runTick = (context) => {
     if (tickListeners.size === 0) {
-      return
+      return;
     }
-    const listeners = Array.from(tickListeners)
+    const listeners = Array.from(tickListeners);
     listeners.forEach((listener) => {
       try {
         listener({
@@ -101,115 +427,115 @@ export function createWeatherManager({
           scene,
           particleSystem,
           ...context,
-        })
+        });
       } catch (error) {
-        console.error('Weather tick listener failed:', error)
+        console.error('Weather tick listener failed:', error);
       }
-    })
-  }
+    });
+  };
 
   const registerOverlay = () => {
     if (typeof registerDiagnosticOverlay !== 'function' || diagnosticOverlayDisposer) {
-      return
+      return;
     }
     diagnosticOverlayDisposer = registerDiagnosticOverlay(({ elapsedTime }) => {
       if (!scene?.userData?.weather) {
-        return
+        return;
       }
-      scene.userData.weather.lastOverlayUpdate = elapsedTime
-    })
-  }
+      scene.userData.weather.lastOverlayUpdate = elapsedTime;
+    });
+  };
 
   const setWeather = (weatherId, options = {}) => {
-    const preset = weatherPresets.get(weatherId)
+    const preset = weatherPresets.get(weatherId);
     if (!preset) {
-      console.warn(`Weather preset "${weatherId}" is not registered.`)
-      return activeWeather
+      console.warn(`Weather preset "${weatherId}" is not registered.`);
+      return activeWeather;
     }
     const nextWeather = {
       ...preset,
       ...options.metadata,
       id: weatherId,
-    }
+    };
     if (activeWeather && activeWeather.id === nextWeather.id) {
-      return activeWeather
+      return activeWeather;
     }
-    disposeWeatherEffects()
-    activeWeather = nextWeather
-    applyWeatherEffects(activeWeather)
-    if (particleSystem && typeof particleSystem.emitWeatherEffect === 'function') {
-      const handle = particleSystem.emitWeatherEffect(activeWeather)
-      if (handle) {
-        particleEffectHandles.add(handle)
-      }
-    }
-    return activeWeather
-  }
+    disposeWeatherEffects();
+    activeWeather = nextWeather;
+    needsEffectRefresh = true;
+    applyWeatherEffects(activeWeather);
+    return activeWeather;
+  };
 
   const scheduleWeatherChange = ({ weatherId, delay = 0, triggerTime, options = {} }) => {
     if (!weatherId) {
-      throw new Error('scheduleWeatherChange requires a weatherId')
+      throw new Error('scheduleWeatherChange requires a weatherId');
     }
     const baseTime = Number.isFinite(triggerTime)
       ? triggerTime
-      : (Number.isFinite(lastElapsedTime) ? lastElapsedTime : 0) + Math.max(0, delay)
+      : (Number.isFinite(lastElapsedTime) ? lastElapsedTime : 0) + Math.max(0, delay);
     scheduledTransitions.push({
       weatherId,
       triggerTime: baseTime,
       options,
-    })
-  }
+    });
+  };
 
   const registerTickListener = (listener) => {
     if (typeof listener !== 'function') {
-      throw new Error('registerTickListener expects a function')
+      throw new Error('registerTickListener expects a function');
     }
-    tickListeners.add(listener)
+    tickListeners.add(listener);
     return () => {
-      tickListeners.delete(listener)
-    }
-  }
+      tickListeners.delete(listener);
+    };
+  };
 
   const registerWeatherPreset = (weather) => {
     if (!weather?.id) {
-      throw new Error('registerWeatherPreset expects an object with an id')
+      throw new Error('registerWeatherPreset expects an object with an id');
     }
-    weatherPresets.set(weather.id, { ...weather })
-  }
+    weatherPresets.set(weather.id, { ...weather });
+  };
 
-  const getCurrentWeather = () => (activeWeather ? { ...activeWeather } : null)
+  const getCurrentWeather = () => (activeWeather ? { ...activeWeather } : null);
 
   const update = (context = {}) => {
-    const { delta = 0, elapsedTime = lastElapsedTime } = context
-    lastElapsedTime = Number.isFinite(elapsedTime) ? elapsedTime : lastElapsedTime
-    evaluateScheduledTransitions({ elapsedTime: lastElapsedTime })
-    tickAccumulator += Number.isFinite(delta) ? delta : 0
+    const { delta = 0, elapsedTime = lastElapsedTime } = context;
+    lastElapsedTime = Number.isFinite(elapsedTime) ? elapsedTime : lastElapsedTime;
+    evaluateScheduledTransitions({ elapsedTime: lastElapsedTime });
+    if (needsEffectRefresh) {
+      refreshWeatherEffects({ ...context, elapsedTime: lastElapsedTime });
+    }
+    updateAnchoredEffects({ ...context, elapsedTime: lastElapsedTime });
+    tickAccumulator += Number.isFinite(delta) ? delta : 0;
     while (tickAccumulator >= DEFAULT_TICK_INTERVAL) {
-      tickAccumulator -= DEFAULT_TICK_INTERVAL
+      tickAccumulator -= DEFAULT_TICK_INTERVAL;
       runTick({
         delta: DEFAULT_TICK_INTERVAL,
         elapsedTime: lastElapsedTime,
         playerControls: context.playerControls,
-      })
+      });
     }
-  }
+  };
 
   const dispose = () => {
-    disposeWeatherEffects()
-    tickListeners.clear()
-    scheduledTransitions.length = 0
+    disposeWeatherEffects();
+    tickListeners.clear();
+    scheduledTransitions.length = 0;
+    needsEffectRefresh = false;
     if (diagnosticOverlayDisposer) {
       try {
-        diagnosticOverlayDisposer()
+        diagnosticOverlayDisposer();
       } catch (error) {
-        console.error('Failed to dispose weather diagnostic overlay:', error)
+        console.error('Failed to dispose weather diagnostic overlay:', error);
       }
-      diagnosticOverlayDisposer = null
+      diagnosticOverlayDisposer = null;
     }
-  }
+  };
 
-  applyWeatherEffects(activeWeather)
-  registerOverlay()
+  applyWeatherEffects(activeWeather);
+  registerOverlay();
 
   return {
     update,
@@ -219,5 +545,5 @@ export function createWeatherManager({
     registerWeatherPreset,
     getCurrentWeather,
     dispose,
-  }
+  };
 }


### PR DESCRIPTION
## Summary
- add support for repositioning GPU billboard emitters so weather effects can follow the player
- implement dedicated rain and snow emitters backed by GPU billboards
- extend the weather manager to spawn precipitation and aurora ribbons via the particle system and keep them anchored to the camera

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da95c4ead8832a803fe50ec4a700a0