### PR TITLE
Add biome weather pools and defaults

### DIFF
--- a/three-demo/src/world/biome-engine.js
+++ b/three-demo/src/world/biome-engine.js
@@ -100,6 +100,59 @@ function cloneShaderMetadata(value) {
   }
 }
 
+const DEFAULT_WEATHER_DURATION = { min: 180, max: 420 };
+const MIN_WEATHER_DURATION = 30;
+
+function normaliseWeatherDuration(duration, fallback = DEFAULT_WEATHER_DURATION) {
+  const fallbackMin = Number.isFinite(fallback?.min)
+    ? fallback.min
+    : DEFAULT_WEATHER_DURATION.min;
+  const fallbackMax = Number.isFinite(fallback?.max)
+    ? fallback.max
+    : DEFAULT_WEATHER_DURATION.max;
+  const rawMin = Number.isFinite(duration?.min) ? duration.min : fallbackMin;
+  const rawMax = Number.isFinite(duration?.max) ? duration.max : fallbackMax;
+  const min = Math.max(MIN_WEATHER_DURATION, rawMin);
+  const max = Math.max(min, rawMax);
+  return { min, max };
+}
+
+function normaliseBiomeWeather(definition) {
+  if (!definition || typeof definition !== 'object') {
+    return null;
+  }
+
+  const candidatesSource = Array.isArray(definition.candidates)
+    ? definition.candidates
+    : Array.isArray(definition)
+    ? definition
+    : [];
+  const defaultDuration = normaliseWeatherDuration(definition.defaultDuration);
+
+  const candidates = candidatesSource
+    .filter((candidate) => candidate && typeof candidate.id === 'string')
+    .map((candidate) => {
+      const weightValue = Number(candidate.weight);
+      const weight = Number.isFinite(weightValue) ? Math.max(0, weightValue) : 1;
+      const duration = normaliseWeatherDuration(candidate.duration, defaultDuration);
+      return {
+        id: String(candidate.id),
+        weight,
+        duration,
+      };
+    })
+    .filter((candidate) => candidate.weight > 0);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return {
+    candidates,
+    defaultDuration,
+  };
+}
+
 export function createBiomeEngine({
   THREE,
   seed = defaultWorldOptions.seedHash,
@@ -227,6 +280,7 @@ export function createBiomeEngine({
         hazards: cloneShaderMetadata(shaderDefinition.hazards),
         references: cloneShaderMetadata(shaderDefinition.references),
       },
+      weather: normaliseBiomeWeather(definition.weather),
     };
   });
 

--- a/three-demo/src/world/biomes/aurora_shard_expanse.json
+++ b/three-demo/src/world/biomes/aurora_shard_expanse.json
@@ -78,5 +78,24 @@
       "auroraGradient": "aurora_shard_expanse:ribbons",
       "gustField": "aurora_shard_expanse:electromagnetic"
     }
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 3,
+        "duration": { "min": 260, "max": 520 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 1,
+        "duration": { "min": 140, "max": 260 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 2,
+        "duration": { "min": 110, "max": 220 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/auroral_glass_reef.json
+++ b/three-demo/src/world/biomes/auroral_glass_reef.json
@@ -39,5 +39,19 @@
     "fogColor": "#7ed6ff",
     "tintColor": "#8bdcf8",
     "tintStrength": 0.5
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 5,
+        "duration": { "min": 260, "max": 520 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 2,
+        "duration": { "min": 150, "max": 280 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/desert.json
+++ b/three-demo/src/world/biomes/desert.json
@@ -38,5 +38,19 @@
     "fogColor": "#f3d8a6",
     "tintColor": "#ffe3b0",
     "tintStrength": 0.45
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 6,
+        "duration": { "min": 300, "max": 600 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 1,
+        "duration": { "min": 90, "max": 180 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/fading_vaporwave_dimension.json
+++ b/three-demo/src/world/biomes/fading_vaporwave_dimension.json
@@ -40,5 +40,24 @@
     "fogColor": "#fbd9ff",
     "tintColor": "#ffdff5",
     "tintStrength": 0.55
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 4,
+        "duration": { "min": 240, "max": 480 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 1,
+        "duration": { "min": 120, "max": 210 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 1,
+        "duration": { "min": 100, "max": 180 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/ice_spire_tundra.json
+++ b/three-demo/src/world/biomes/ice_spire_tundra.json
@@ -62,5 +62,24 @@
         "description": "Supercooled squalls sap body heat within moments of exposure."
       }
     }
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 2,
+        "duration": { "min": 200, "max": 420 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 1,
+        "duration": { "min": 130, "max": 240 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 3,
+        "duration": { "min": 90, "max": 180 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/noctilucent_fungus_glade.json
+++ b/three-demo/src/world/biomes/noctilucent_fungus_glade.json
@@ -44,5 +44,19 @@
     "fogColor": "#2a3945",
     "tintColor": "#3de0f0",
     "tintStrength": 0.55
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 3,
+        "duration": { "min": 220, "max": 460 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 3,
+        "duration": { "min": 150, "max": 280 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
+++ b/three-demo/src/world/biomes/pseudo_borgesian_librarium.json
@@ -40,5 +40,19 @@
     "fogColor": "#5b4a6f",
     "tintColor": "#d7c9ff",
     "tintStrength": 0.5
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 5,
+        "duration": { "min": 260, "max": 520 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 1,
+        "duration": { "min": 140, "max": 240 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/temperate.json
+++ b/three-demo/src/world/biomes/temperate.json
@@ -39,5 +39,24 @@
     "fogColor": "#a9d6ff",
     "tintColor": "#ffffff",
     "tintStrength": 0.0
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 4,
+        "duration": { "min": 240, "max": 480 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 2,
+        "duration": { "min": 120, "max": 240 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 1,
+        "duration": { "min": 90, "max": 160 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/biomes/tundra.json
+++ b/three-demo/src/world/biomes/tundra.json
@@ -38,5 +38,24 @@
     "fogColor": "#dce8f1",
     "tintColor": "#e9f1f6",
     "tintStrength": 0.4
+  },
+  "weather": {
+    "candidates": [
+      {
+        "id": "clear_skies",
+        "weight": 3,
+        "duration": { "min": 240, "max": 500 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 2,
+        "duration": { "min": 150, "max": 260 }
+      },
+      {
+        "id": "charged_storm",
+        "weight": 1,
+        "duration": { "min": 100, "max": 180 }
+      }
+    ]
   }
 }

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -68,6 +68,61 @@ const CATEGORY_DEFAULT_EFFECTS = {
 const DEFAULT_TICK_INTERVAL = 1.5;
 const DEFAULT_PRECIPITATION_UPDATE_INTERVAL = 0.22;
 const DEFAULT_AURORA_UPDATE_INTERVAL = 0.55;
+const MIN_WEATHER_DURATION_SECONDS = 30;
+const DEFAULT_BIOME_WEATHER_DURATION = { min: 180, max: 420 };
+
+export const DEFAULT_BIOME_WEATHER_ROTATION = Object.freeze([
+  {
+    id: 'clear_skies',
+    weight: 1,
+    duration: { ...DEFAULT_BIOME_WEATHER_DURATION },
+  },
+]);
+
+function cloneWeatherDuration(duration, fallback = DEFAULT_BIOME_WEATHER_DURATION) {
+  const fallbackMin = Number.isFinite(fallback?.min)
+    ? fallback.min
+    : DEFAULT_BIOME_WEATHER_DURATION.min;
+  const fallbackMax = Number.isFinite(fallback?.max)
+    ? fallback.max
+    : DEFAULT_BIOME_WEATHER_DURATION.max;
+  const rawMin = Number.isFinite(duration?.min) ? duration.min : fallbackMin;
+  const rawMax = Number.isFinite(duration?.max) ? duration.max : fallbackMax;
+  const min = Math.max(MIN_WEATHER_DURATION_SECONDS, rawMin);
+  const max = Math.max(min, rawMax);
+  return { min, max };
+}
+
+function cloneWeatherCandidate(candidate, fallbackDuration = DEFAULT_BIOME_WEATHER_DURATION) {
+  if (!candidate?.id) {
+    return null;
+  }
+  const weightValue = Number(candidate.weight);
+  const weight = Number.isFinite(weightValue) ? Math.max(0, weightValue) : 1;
+  if (weight <= 0) {
+    return null;
+  }
+  return {
+    id: String(candidate.id),
+    weight,
+    duration: cloneWeatherDuration(candidate.duration, fallbackDuration),
+  };
+}
+
+export function resolveBiomeWeatherRotation(biome) {
+  const weather = biome?.weather ?? null;
+  const source = Array.isArray(weather?.candidates) ? weather.candidates : [];
+  const fallbackDuration = weather?.defaultDuration ?? DEFAULT_BIOME_WEATHER_DURATION;
+  const resolved = source
+    .map((candidate) => cloneWeatherCandidate(candidate, fallbackDuration))
+    .filter(Boolean);
+  if (resolved.length > 0) {
+    return resolved;
+  }
+  return DEFAULT_BIOME_WEATHER_ROTATION.map((candidate) =>
+    cloneWeatherCandidate(candidate, DEFAULT_BIOME_WEATHER_DURATION),
+  ).filter(Boolean);
+}
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);


### PR DESCRIPTION
## Summary
- add weighted weather candidate lists to every biome configuration
- carry normalised weather metadata through biome-engine runtime objects
- expose a weather-manager helper with clear-skies defaults when a biome omits weather

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da99ace090832aa2827398a9ddc680