### PR TITLE
Add weather audio hooks to weather manager

### DIFF
--- a/three-demo/src/audio/weather-audio.js
+++ b/three-demo/src/audio/weather-audio.js
@@ -1,0 +1,181 @@
+const cueImports = import.meta.glob(
+  '../sounds/sound_effects/weather/**/{start,stop}.{mp3,MP3,wav,WAV,ogg,OGG}',
+  {
+    eager: true,
+    import: 'default',
+    query: '?url',
+  },
+)
+
+const SUPPORTED_CUE_TYPES = new Set(['start', 'stop'])
+
+function normalizeCueType(fileName) {
+  const withoutExtension = fileName.replace(/\.[^.]+$/, '')
+  const [maybeCue] = withoutExtension.split(/[-_.\s]/)
+  const cue = maybeCue?.toLowerCase?.()
+  return SUPPORTED_CUE_TYPES.has(cue) ? cue : null
+}
+
+function extractWeatherId(pathSegments) {
+  const weatherIndex = pathSegments.lastIndexOf('weather')
+  if (weatherIndex === -1 || weatherIndex + 1 >= pathSegments.length) {
+    return null
+  }
+  return pathSegments[weatherIndex + 1]
+}
+
+const weatherCueMap = new Map()
+
+Object.entries(cueImports)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .forEach(([path, url]) => {
+    const segments = path.split('/').filter(Boolean)
+    const weatherId = extractWeatherId(segments)
+    if (!weatherId) {
+      return
+    }
+    const fileName = segments[segments.length - 1]
+    const cueType = normalizeCueType(fileName)
+    if (!cueType) {
+      return
+    }
+    const cues = weatherCueMap.get(weatherId) ?? {}
+    cues[cueType] = url
+    weatherCueMap.set(weatherId, cues)
+  })
+
+export function getWeatherCueUrl(weatherId, cueType) {
+  if (!weatherId || !cueType) {
+    return null
+  }
+  const cues = weatherCueMap.get(weatherId)
+  if (!cues) {
+    return null
+  }
+  const normalizedCue = cueType.toLowerCase()
+  return cues[normalizedCue] ?? null
+}
+
+export function getWeatherAudioCues(weatherId) {
+  const cues = weatherCueMap.get(weatherId)
+  if (!cues) {
+    return null
+  }
+  return { ...cues }
+}
+
+export function listWeatherAudioCues() {
+  return Array.from(weatherCueMap.entries()).map(([weatherId, cues]) => ({
+    weatherId,
+    cues: { ...cues },
+  }))
+}
+
+export function hasWeatherAudio() {
+  return weatherCueMap.size > 0
+}
+
+export function createWeatherAudioController({ defaultVolume = 0.7 } = {}) {
+  if (typeof Audio !== 'function') {
+    return {
+      playCue: () => null,
+      handleTransition: () => {},
+      dispose: () => {},
+      getCueUrl: getWeatherCueUrl,
+    }
+  }
+
+  const activeElements = new Set()
+
+  const clampVolume = (value) => {
+    if (!Number.isFinite(value)) {
+      return defaultVolume
+    }
+    return Math.min(1, Math.max(0, value))
+  }
+
+  const cleanup = (entry) => {
+    if (!entry) {
+      return
+    }
+    const { audio, listeners } = entry
+    if (!audio) {
+      return
+    }
+    if (listeners) {
+      audio.removeEventListener('ended', listeners.ended)
+      audio.removeEventListener('error', listeners.error)
+    }
+    try {
+      audio.pause()
+    } catch (error) {
+      // Ignore pause errors (can happen if the audio element is already stopped).
+    }
+    audio.src = ''
+    activeElements.delete(entry)
+  }
+
+  const playCue = ({ weatherId, cueType, volume } = {}) => {
+    const url = getWeatherCueUrl(weatherId, cueType)
+    if (!url) {
+      return null
+    }
+    const audio = new Audio()
+    audio.preload = 'auto'
+    audio.crossOrigin = 'anonymous'
+    audio.volume = clampVolume(volume)
+
+    const entry = { audio, listeners: null }
+    const listeners = {
+      ended: () => cleanup(entry),
+      error: (event) => {
+        console.warn('Failed to play weather audio cue:', event?.error ?? event)
+        cleanup(entry)
+      },
+    }
+    entry.listeners = listeners
+
+    audio.addEventListener('ended', listeners.ended)
+    audio.addEventListener('error', listeners.error)
+
+    audio.src = url
+
+    const playPromise = audio.play()
+    if (playPromise?.catch) {
+      playPromise.catch((error) => {
+        console.warn('Failed to play weather audio cue:', error)
+        cleanup(entry)
+      })
+    }
+
+    activeElements.add(entry)
+
+    return {
+      stop: () => cleanup(entry),
+      audio,
+    }
+  }
+
+  const handleTransition = ({ previousWeatherId, nextWeatherId } = {}) => {
+    if (previousWeatherId && previousWeatherId !== nextWeatherId) {
+      playCue({ weatherId: previousWeatherId, cueType: 'stop' })
+    }
+    if (nextWeatherId) {
+      playCue({ weatherId: nextWeatherId, cueType: 'start' })
+    }
+  }
+
+  const dispose = () => {
+    for (const entry of Array.from(activeElements)) {
+      cleanup(entry)
+    }
+    activeElements.clear()
+  }
+
+  return {
+    playCue,
+    handleTransition,
+    dispose,
+    getCueUrl: getWeatherCueUrl,
+  }
+}

--- a/three-demo/src/sounds/sound_effects/weather/.gitignore
+++ b/three-demo/src/sounds/sound_effects/weather/.gitignore
@@ -1,0 +1,10 @@
+# Ignore local audio work files and logs
+*.log
+*.tmp
+*.bak
+*.mp3
+*.MP3
+*.wav
+*.WAV
+*.ogg
+*.OGG

--- a/three-demo/src/sounds/sound_effects/weather/README.md
+++ b/three-demo/src/sounds/sound_effects/weather/README.md
@@ -1,0 +1,3 @@
+# Weather Sound Effects Placeholder
+
+Drop weather-specific audio cues in this folder. Subdirectories named after the weather preset (for example, `rainstorm/`) can include files such as `start.mp3` or `stop.wav` to automatically hook into the weather audio system.

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -1,6 +1,7 @@
 import { createAuroraRibbonEmitter } from '../../rendering/particles/aurora-effects.js';
 import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain.js';
 import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
+import { createWeatherAudioController } from '../../audio/weather-audio.js';
 
 const DEFAULT_WEATHER_PRESETS = {
   clear_skies: {
@@ -218,6 +219,7 @@ export function createWeatherManager({
   particleSystem,
   registerDiagnosticOverlay,
 } = {}) {
+  const audioController = createWeatherAudioController();
   const weatherPresets = new Map(
     Object.entries(DEFAULT_WEATHER_PRESETS).map(([key, value]) => [key, { ...value }]),
   );
@@ -515,10 +517,15 @@ export function createWeatherManager({
     if (activeWeather && activeWeather.id === nextWeather.id) {
       return activeWeather;
     }
+    const previousWeatherId = activeWeather?.id ?? null;
     disposeWeatherEffects();
     activeWeather = nextWeather;
     needsEffectRefresh = true;
     applyWeatherEffects(activeWeather);
+    audioController.handleTransition({
+      previousWeatherId,
+      nextWeatherId: activeWeather?.id ?? null,
+    });
     return activeWeather;
   };
 
@@ -582,6 +589,7 @@ export function createWeatherManager({
     tickListeners.clear();
     scheduledTransitions.length = 0;
     needsEffectRefresh = false;
+    audioController.dispose();
     if (diagnosticOverlayDisposer) {
       try {
         diagnosticOverlayDisposer();


### PR DESCRIPTION
## Summary
- add a weather sound effects folder with placeholder documentation and ignore rules for local assets
- introduce a weather audio library/controller that maps start/stop cues from dropped files
- trigger weather start/stop audio cues from the weather manager so new tracks play automatically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa1468228832a989509c037cba3b9