### PR TITLE
Adjust rain particle blending for better visibility

### DIFF
--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js';
 
 function clamp(value, min, max) {
@@ -38,7 +39,8 @@ export function createWeatherRainEmitter({
     drag: 0.12,
     fadeIn: 0.06,
     fadeOut: 0.22,
-    opacity: 0.68,
+    opacity: 0.82,
+    blending: THREE.NormalBlending,
     depthWrite: false,
     renderOrder: 5,
   });


### PR DESCRIPTION
## Summary
- import Three.js in the rain emitter module to expose blending constants
- switch the rain billboard emitter to use normal blending with a higher opacity so streaks stay bright under alpha compositing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab32144c0832aa8e8e0be49a1b701