### PR TITLE
Instrument weather precipitation spawn failures

### DIFF
--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -238,6 +238,7 @@ export function createWeatherManager({
       return;
     }
     scene.userData = scene.userData || {};
+    const previousOverlayUpdate = scene.userData.weather?.lastOverlayUpdate ?? null;
     const resolvedEffects = resolveWeatherEffects(weather);
     scene.userData.weather = {
       id: weather.id,
@@ -246,6 +247,9 @@ export function createWeatherManager({
       category: weather.category,
       precipitation: resolvedEffects.precipitation?.type ?? null,
       aurora: Boolean(resolvedEffects.aurora && Object.keys(resolvedEffects.aurora).length > 0),
+      failedPrecipitationSpawns: 0,
+      lastPrecipitationFailure: null,
+      lastOverlayUpdate: previousOverlayUpdate,
     };
   };
 
@@ -278,6 +282,20 @@ export function createWeatherManager({
           });
     const handle = particleSystem.emit(emitter);
     if (!handle) {
+      const weatherState = scene?.userData?.weather;
+      if (weatherState) {
+        const previousFailures = Number.isFinite(weatherState.failedPrecipitationSpawns)
+          ? weatherState.failedPrecipitationSpawns
+          : 0;
+        weatherState.failedPrecipitationSpawns = previousFailures + 1;
+        weatherState.lastPrecipitationFailure = {
+          elapsedTime: context?.elapsedTime ?? null,
+          type: config.type,
+        };
+      }
+      console.warn('Weather precipitation emitter failed to spawn; no handle was returned.', {
+        type: config.type,
+      });
       return;
     }
     let updateInterval = config.updateInterval;


### PR DESCRIPTION
## Summary
- preserve existing weather overlay metadata when refreshing user data so diagnostics can be extended
- log precipitation emitter spawn failures and track counters/timestamps on the scene weather state for debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab4c823b0832a96f21a0b551eb01a