### PR TITLE
Instrument weather precipitation spawn failures and add debug tooling

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1427,7 +1427,7 @@ export function registerDeveloperCommands({
     },
   });
 
-  const weatherCommandUsage = '/weather [on|off|status|help|weatherId]';
+  const weatherCommandUsage = '/weather [on|off|status|help|debug|weatherId]';
 
   registerCommand({
     name: 'weather',
@@ -1508,6 +1508,73 @@ export function registerDeveloperCommands({
       if (subcommand === 'help') {
         info(`[weather] Usage: ${weatherCommandUsage}.`);
         logVerboseWeatherPresetSummary();
+        return;
+      }
+
+      if (subcommand === 'debug') {
+        if (!particleSystem) {
+          warn('[weather debug] Particle system is not available.');
+          return;
+        }
+        if (typeof particleSystem.getDebugInfo !== 'function') {
+          warn('[weather debug] Particle system debug info is unavailable.');
+          return;
+        }
+        const debugInfo = particleSystem.getDebugInfo();
+        if (!debugInfo) {
+          warn('[weather debug] Particle system did not return debug info.');
+          return;
+        }
+        const emitters = Array.isArray(debugInfo.emitters) ? debugInfo.emitters : [];
+        const weatherEmitters = emitters.filter((emitter) => {
+          if (!emitter || typeof emitter.label !== 'string') {
+            return false;
+          }
+          return emitter.label.toLowerCase().includes('weather');
+        });
+        if (weatherEmitters.length === 0) {
+          info('[weather debug] No weather emitters are active.');
+          const weatherState = scene?.userData?.weather;
+          if (weatherState?.failedPrecipitationSpawns > 0) {
+            info(
+              `[weather debug] Detected ${weatherState.failedPrecipitationSpawns} precipitation spawn failure(s).`,
+            );
+            const failure = weatherState.lastPrecipitationFailure ?? null;
+            if (failure?.type) {
+              const elapsed = Number.isFinite(failure.elapsedTime)
+                ? `${failure.elapsedTime.toFixed(2)}s`
+                : 'unknown';
+              info(
+                `[weather debug] Most recent failure — type=${failure.type}, elapsedTime=${elapsed}.`,
+              );
+            }
+          } else {
+            info('[weather debug] Clear skies or suppressed weather may be active.');
+          }
+          return;
+        }
+        const totalActiveParticles = weatherEmitters.reduce(
+          (sum, emitter) => sum + (Number.isFinite(emitter.activeParticles) ? emitter.activeParticles : 0),
+          0,
+        );
+        info(
+          `[weather debug] Active weather emitters: ${weatherEmitters.length} (particles=${totalActiveParticles}).`,
+        );
+        weatherEmitters.forEach((emitter, index) => {
+          const status = emitter.pendingRemoval ? ' (pending removal)' : '';
+          info(
+            `[weather debug]   #${index + 1} ${emitter.label} — particles=${emitter.activeParticles}${status}.`,
+          );
+        });
+        const nonWeatherEmitters = emitters.length - weatherEmitters.length;
+        const emitterCount = Number.isFinite(debugInfo.emitterCount)
+          ? debugInfo.emitterCount
+          : emitters.length;
+        if (nonWeatherEmitters > 0) {
+          info(
+            `[weather debug] ${nonWeatherEmitters} additional non-weather emitters are active (total emitters=${emitterCount}).`,
+          );
+        }
         return;
       }
 

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -238,6 +238,7 @@ export function createWeatherManager({
       return;
     }
     scene.userData = scene.userData || {};
+    const previousOverlayUpdate = scene.userData.weather?.lastOverlayUpdate ?? null;
     const resolvedEffects = resolveWeatherEffects(weather);
     scene.userData.weather = {
       id: weather.id,
@@ -246,6 +247,9 @@ export function createWeatherManager({
       category: weather.category,
       precipitation: resolvedEffects.precipitation?.type ?? null,
       aurora: Boolean(resolvedEffects.aurora && Object.keys(resolvedEffects.aurora).length > 0),
+      failedPrecipitationSpawns: 0,
+      lastPrecipitationFailure: null,
+      lastOverlayUpdate: previousOverlayUpdate,
     };
   };
 
@@ -278,6 +282,20 @@ export function createWeatherManager({
           });
     const handle = particleSystem.emit(emitter);
     if (!handle) {
+      const weatherState = scene?.userData?.weather;
+      if (weatherState) {
+        const previousFailures = Number.isFinite(weatherState.failedPrecipitationSpawns)
+          ? weatherState.failedPrecipitationSpawns
+          : 0;
+        weatherState.failedPrecipitationSpawns = previousFailures + 1;
+        weatherState.lastPrecipitationFailure = {
+          elapsedTime: context?.elapsedTime ?? null,
+          type: config.type,
+        };
+      }
+      console.warn('Weather precipitation emitter failed to spawn; no handle was returned.', {
+        type: config.type,
+      });
       return;
     }
     let updateInterval = config.updateInterval;


### PR DESCRIPTION
## Summary
- preserve existing weather overlay metadata when refreshing user data so diagnostics can be extended
- log precipitation emitter spawn failures and track counters/timestamps on the scene weather state for debugging
- add a `/weather debug` console subcommand that surfaces active weather emitters, particle counts, and recent spawn failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dab4c823b0832a96f21a0b551eb01a