### PR TITLE
Add weather diagnostics HUD and suppression tracking

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -1,0 +1,16 @@
+# Weather Remediation Investigation
+
+## Current Findings
+- Weather presets only advance when developers call `/weather`, so the runtime remains on `clear_skies` even though the weather manager is stepped every frame. The biome-driven rotation helpers exist but are never invoked from the main loop.
+- Precipitation emitters still fail silently when particle handles are missing; the previous logging is easy to miss and no HUD reflects the failure counts.
+- Unlike the underwater HUD (which uses a dedicated DOM overlay), weather diagnostics previously wrote only to `scene.userData`, leaving QA without real-time confirmation of active emitters or suppression state.
+
+## Instrumentation Added
+- Weather state now persists counters, anchor timestamps, and suppression metadata directly on `scene.userData.weather` so runtime tools can see failure spikes without clobbering earlier diagnostics.
+- A dedicated weather diagnostic HUD is wired through `registerDiagnosticOverlay`, mirroring the always-on underwater overlay pattern so QA immediately sees active presets, suppression status, emitter/particle counts, anchor recency, and failure history.
+- The `/weather` developer command updates the shared weather state when suppression toggles occur, keeping console overrides and on-screen diagnostics aligned.
+
+## Outstanding Work Orders
+1. **Automate biome-driven weather rotation** — sample the player’s biome during the animation loop and advance rotations with `resolveBiomeWeatherRotation` plus `scheduleWeatherChange`, pausing when overrides are suppressed.
+2. **Backfill precipitation emitter coverage** — add unit tests for `createWeatherManager` that assert precipitation emitters spawn handles and that failure counters increment when handles are missing.
+3. **Audit particle label consistency** — ensure rain, snow, and aurora emitters expose a uniform `debugLabel` prefix so the new HUD and `/weather debug` can always identify weather emitters across future presets.

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -79,6 +79,15 @@ export function registerDeveloperCommands({
     lastSuppressedWeatherId: null,
   };
 
+  const setWeatherSuppressionState = (isSuppressed) => {
+    if (!scene) {
+      return;
+    }
+    scene.userData = scene.userData || {};
+    scene.userData.weather = scene.userData.weather || {};
+    scene.userData.weather.overridesSuppressed = Boolean(isSuppressed);
+  };
+
   const biomeTeleportOffsets = [
     { dx: 0, dz: 0 },
     { dx: 1, dz: 0 },
@@ -1427,7 +1436,7 @@ export function registerDeveloperCommands({
     },
   });
 
-  const weatherCommandUsage = '/weather [on|off|status|help|weatherId]';
+  const weatherCommandUsage = '/weather [on|off|status|help|debug|weatherId]';
 
   registerCommand({
     name: 'weather',
@@ -1511,6 +1520,73 @@ export function registerDeveloperCommands({
         return;
       }
 
+      if (subcommand === 'debug') {
+        if (!particleSystem) {
+          warn('[weather debug] Particle system is not available.');
+          return;
+        }
+        if (typeof particleSystem.getDebugInfo !== 'function') {
+          warn('[weather debug] Particle system debug info is unavailable.');
+          return;
+        }
+        const debugInfo = particleSystem.getDebugInfo();
+        if (!debugInfo) {
+          warn('[weather debug] Particle system did not return debug info.');
+          return;
+        }
+        const emitters = Array.isArray(debugInfo.emitters) ? debugInfo.emitters : [];
+        const weatherEmitters = emitters.filter((emitter) => {
+          if (!emitter || typeof emitter.label !== 'string') {
+            return false;
+          }
+          return emitter.label.toLowerCase().includes('weather');
+        });
+        if (weatherEmitters.length === 0) {
+          info('[weather debug] No weather emitters are active.');
+          const weatherState = scene?.userData?.weather;
+          if (weatherState?.failedPrecipitationSpawns > 0) {
+            info(
+              `[weather debug] Detected ${weatherState.failedPrecipitationSpawns} precipitation spawn failure(s).`,
+            );
+            const failure = weatherState.lastPrecipitationFailure ?? null;
+            if (failure?.type) {
+              const elapsed = Number.isFinite(failure.elapsedTime)
+                ? `${failure.elapsedTime.toFixed(2)}s`
+                : 'unknown';
+              info(
+                `[weather debug] Most recent failure — type=${failure.type}, elapsedTime=${elapsed}.`,
+              );
+            }
+          } else {
+            info('[weather debug] Clear skies or suppressed weather may be active.');
+          }
+          return;
+        }
+        const totalActiveParticles = weatherEmitters.reduce(
+          (sum, emitter) => sum + (Number.isFinite(emitter.activeParticles) ? emitter.activeParticles : 0),
+          0,
+        );
+        info(
+          `[weather debug] Active weather emitters: ${weatherEmitters.length} (particles=${totalActiveParticles}).`,
+        );
+        weatherEmitters.forEach((emitter, index) => {
+          const status = emitter.pendingRemoval ? ' (pending removal)' : '';
+          info(
+            `[weather debug]   #${index + 1} ${emitter.label} — particles=${emitter.activeParticles}${status}.`,
+          );
+        });
+        const nonWeatherEmitters = emitters.length - weatherEmitters.length;
+        const emitterCount = Number.isFinite(debugInfo.emitterCount)
+          ? debugInfo.emitterCount
+          : emitters.length;
+        if (nonWeatherEmitters > 0) {
+          info(
+            `[weather debug] ${nonWeatherEmitters} additional non-weather emitters are active (total emitters=${emitterCount}).`,
+          );
+        }
+        return;
+      }
+
       if (subcommand === 'status') {
         const active = weatherManager.getCurrentWeather?.();
         if (!active) {
@@ -1588,6 +1664,7 @@ export function registerDeveloperCommands({
           throw new Error('Failed to disable weather overrides.');
         }
         weatherControlState.suppressed = true;
+        setWeatherSuppressionState(true);
         success('[weather] Weather overrides disabled — clear skies enforced.');
         logWeatherPresetSummary();
         return;
@@ -1612,6 +1689,7 @@ export function registerDeveloperCommands({
           }
         }
         weatherControlState.suppressed = false;
+        setWeatherSuppressionState(false);
         if (!restored) {
           warn('No valid weather preset could be restored.');
           throw new Error('Failed to enable weather overrides.');
@@ -1632,6 +1710,7 @@ export function registerDeveloperCommands({
       }
       weatherControlState.lastManualWeatherId = applied.id;
       weatherControlState.suppressed = false;
+      setWeatherSuppressionState(false);
       success(`[weather] Weather set to ${describeWeather(applied)}.`);
       logWeatherPresetSummary();
     },

--- a/three-demo/src/style.css
+++ b/three-demo/src/style.css
@@ -195,6 +195,39 @@ button:focus-visible {
   max-width: 260px;
 }
 
+.weather-debug-overlay {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(11, 16, 24, 0.86);
+  color: #eaf4ff;
+  border: 1px solid rgba(120, 168, 255, 0.32);
+  border-radius: 10px;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.42);
+  font-family: 'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  pointer-events: none;
+  z-index: 83;
+  min-width: 240px;
+  max-width: 320px;
+  white-space: pre-line;
+}
+
+.weather-debug-overlay__header {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.4rem;
+  color: #b9d8ff;
+}
+
+.weather-debug-overlay__line {
+  margin: 0.15rem 0;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/three-demo/src/ui/weather-debug-overlay.js
+++ b/three-demo/src/ui/weather-debug-overlay.js
@@ -1,0 +1,175 @@
+const OVERLAY_ID = 'weather-debug-overlay';
+
+function ensureOverlayElement() {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const existing = document.getElementById(OVERLAY_ID);
+  if (existing) {
+    existing.classList.add('visible');
+    existing.removeAttribute('aria-hidden');
+    return existing;
+  }
+
+  const element = document.createElement('div');
+  element.id = OVERLAY_ID;
+  element.className = 'weather-debug-overlay';
+  element.setAttribute('role', 'status');
+  element.setAttribute('aria-live', 'polite');
+  element.innerHTML = `
+    <header class="weather-debug-overlay__header">Weather Diagnostics</header>
+    <div class="weather-debug-overlay__body">
+      <div class="weather-debug-overlay__line" data-field="preset">Preset: —</div>
+      <div class="weather-debug-overlay__line" data-field="suppression">Suppression: —</div>
+      <div class="weather-debug-overlay__line" data-field="emitters">Emitters: —</div>
+      <div class="weather-debug-overlay__line" data-field="anchor">Last anchor update: —</div>
+      <div class="weather-debug-overlay__line" data-field="failures">Failures: —</div>
+      <div class="weather-debug-overlay__line" data-field="debug">Debug sample: —</div>
+    </div>
+  `;
+  document.body.appendChild(element);
+  return element;
+}
+
+function formatTime(value) {
+  if (!Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return `${value.toFixed(2)}s`;
+}
+
+function describePreset(weatherState) {
+  if (!weatherState) {
+    return 'Preset: unavailable';
+  }
+  const label = weatherState.label ?? weatherState.id ?? 'Unknown';
+  const idSuffix = weatherState.id ? ` [${weatherState.id}]` : '';
+  const intensity = Number.isFinite(weatherState.intensity)
+    ? ` — intensity ${weatherState.intensity.toFixed(2)}`
+    : '';
+  return `Preset: ${label}${idSuffix}${intensity}`;
+}
+
+function describeSuppression(weatherState) {
+  const suppressed = Boolean(weatherState?.overridesSuppressed);
+  const suppressionState = suppressed ? 'ACTIVE (overrides paused)' : 'INACTIVE';
+  return `Suppression: ${suppressionState}`;
+}
+
+function describeEmitters(weatherState, stats) {
+  if (!stats) {
+    const fallbackCount = weatherState?.activeEmitterCount ?? 0;
+    return `Emitters: ${fallbackCount} weather (no particle stats available)`;
+  }
+  const weatherCount = stats.weatherCount ?? weatherState?.activeEmitterCount ?? 0;
+  const totalEmittersText = Number.isFinite(stats.totalEmitters)
+    ? `${weatherCount}/${stats.totalEmitters} weather/total`
+    : `${weatherCount} weather`;
+  const particles = Number.isFinite(stats.weatherParticles)
+    ? `, particles=${stats.weatherParticles}`
+    : stats.weatherParticles === 0
+    ? ', particles=0'
+    : ', particles=n/a';
+  const summaryLines = [`Emitters: ${totalEmittersText}${particles}`];
+  if (Array.isArray(stats.emitters) && stats.emitters.length > 0) {
+    stats.emitters.forEach((emitter, index) => {
+      summaryLines.push(
+        `  #${index + 1} ${emitter.label} — particles=${emitter.particles}${emitter.status}`,
+      );
+    });
+    if (stats.extraCount > 0) {
+      summaryLines.push(`  (+${stats.extraCount} more weather emitters hidden)`);
+    }
+  }
+  return summaryLines.join('\n');
+}
+
+function describeAnchor(weatherState) {
+  if (!weatherState) {
+    return 'Last anchor update: n/a';
+  }
+  const timestamp = formatTime(weatherState.lastAnchorUpdate);
+  const lastSpawn = weatherState.lastPrecipitationSpawn
+    ? `${weatherState.lastPrecipitationSpawn.type} @ ${formatTime(
+        weatherState.lastPrecipitationSpawn.elapsedTime,
+      )}`
+    : null;
+  return lastSpawn
+    ? `Last anchor update: ${timestamp} (spawned ${lastSpawn})`
+    : `Last anchor update: ${timestamp}`;
+}
+
+function describeFailures(weatherState) {
+  if (!weatherState) {
+    return 'Failures: n/a';
+  }
+  const failures = Number.isFinite(weatherState.failedPrecipitationSpawns)
+    ? weatherState.failedPrecipitationSpawns
+    : 0;
+  if (failures <= 0) {
+    return 'Failures: none';
+  }
+  const recent = weatherState.lastPrecipitationFailure ?? null;
+  if (!recent) {
+    return `Failures: ${failures}`;
+  }
+  const type = recent.type ?? 'unknown';
+  return `Failures: ${failures} (last ${type} @ ${formatTime(recent.elapsedTime)})`;
+}
+
+function describeDebugSample(weatherState, stats) {
+  const sampledAt = Number.isFinite(weatherState?.lastDebugSample)
+    ? formatTime(weatherState.lastDebugSample)
+    : 'n/a';
+  const overlayAt = Number.isFinite(weatherState?.lastOverlayUpdate)
+    ? formatTime(weatherState.lastOverlayUpdate)
+    : 'n/a';
+  const particles = Number.isFinite(stats?.weatherParticles)
+    ? stats.weatherParticles
+    : weatherState?.totalActiveParticles;
+  const particleLine = Number.isFinite(particles) ? `particles=${particles}` : 'particles=n/a';
+  return `Debug sample: overlay=${overlayAt}, stats=${sampledAt}, ${particleLine}`;
+}
+
+export function createWeatherDebugOverlay() {
+  const element = ensureOverlayElement();
+  if (!element) {
+    return {
+      update() {},
+      dispose() {},
+    };
+  }
+
+  const fields = element.querySelectorAll('[data-field]');
+  const fieldMap = new Map();
+  fields.forEach((field) => {
+    const key = field.getAttribute('data-field');
+    if (key) {
+      fieldMap.set(key, field);
+    }
+  });
+
+  const updateField = (key, value) => {
+    const target = fieldMap.get(key);
+    if (target) {
+      target.textContent = value;
+    }
+  };
+
+  return {
+    update({ weatherState = null, stats = null } = {}) {
+      updateField('preset', describePreset(weatherState));
+      updateField('suppression', describeSuppression(weatherState));
+      updateField('emitters', describeEmitters(weatherState, stats));
+      updateField('anchor', describeAnchor(weatherState));
+      updateField('failures', describeFailures(weatherState));
+      updateField('debug', describeDebugSample(weatherState, stats));
+    },
+    dispose() {
+      fieldMap.clear();
+      if (element.parentElement) {
+        element.parentElement.removeChild(element);
+      }
+    },
+  };
+}

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -2,6 +2,7 @@ import { createAuroraRibbonEmitter } from '../../rendering/particles/aurora-effe
 import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain.js';
 import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
 import { createWeatherAudioController } from '../../audio/weather-audio.js';
+import { createWeatherDebugOverlay } from '../../ui/weather-debug-overlay.js';
 
 const DEFAULT_WEATHER_PRESETS = {
   clear_skies: {
@@ -233,20 +234,93 @@ export function createWeatherManager({
   const activeParticleEffects = [];
   let needsEffectRefresh = true;
 
+  let overlayUi = null;
+
+  const ensureWeatherState = () => {
+    if (!scene) {
+      return null;
+    }
+    scene.userData = scene.userData || {};
+    if (!scene.userData.weather) {
+      scene.userData.weather = {};
+    }
+    const state = scene.userData.weather;
+    if (!Number.isFinite(state.failedPrecipitationSpawns)) {
+      state.failedPrecipitationSpawns = 0;
+    }
+    if (state.lastPrecipitationFailure === undefined) {
+      state.lastPrecipitationFailure = null;
+    }
+    if (state.lastOverlayUpdate === undefined) {
+      state.lastOverlayUpdate = null;
+    }
+    if (state.lastDebugSample === undefined) {
+      state.lastDebugSample = null;
+    }
+    if (state.overridesSuppressed === undefined) {
+      state.overridesSuppressed = false;
+    }
+    if (state.activeEmitterCount === undefined) {
+      state.activeEmitterCount = 0;
+    }
+    if (state.totalActiveParticles === undefined) {
+      state.totalActiveParticles = null;
+    }
+    if (state.lastAnchorUpdate === undefined) {
+      state.lastAnchorUpdate = null;
+    }
+    if (state.lastPrecipitationSpawn === undefined) {
+      state.lastPrecipitationSpawn = null;
+    }
+    return state;
+  };
+
+  const syncEmitterState = () => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    state.activeEmitterCount = activeParticleEffects.length;
+    if (state.activeEmitterCount === 0) {
+      state.totalActiveParticles = 0;
+    }
+  };
+
+  const recordAnchorUpdate = (elapsedTime) => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    if (Number.isFinite(elapsedTime)) {
+      state.lastAnchorUpdate = elapsedTime;
+    }
+  };
+
+  const recordPrecipitationSpawn = ({ type, elapsedTime }) => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    state.lastPrecipitationSpawn = {
+      type,
+      elapsedTime: Number.isFinite(elapsedTime) ? elapsedTime : null,
+    };
+  };
+
   const applyWeatherEffects = (weather) => {
     if (!weather || !scene) {
       return;
     }
-    scene.userData = scene.userData || {};
+    const weatherState = ensureWeatherState();
     const resolvedEffects = resolveWeatherEffects(weather);
-    scene.userData.weather = {
-      id: weather.id,
-      label: weather.label,
-      intensity: weather.intensity,
-      category: weather.category,
-      precipitation: resolvedEffects.precipitation?.type ?? null,
-      aurora: Boolean(resolvedEffects.aurora && Object.keys(resolvedEffects.aurora).length > 0),
-    };
+    weatherState.id = weather.id;
+    weatherState.label = weather.label;
+    weatherState.intensity = weather.intensity;
+    weatherState.category = weather.category;
+    weatherState.precipitation = resolvedEffects.precipitation?.type ?? null;
+    weatherState.aurora = Boolean(
+      resolvedEffects.aurora && Object.keys(resolvedEffects.aurora).length > 0,
+    );
   };
 
   const disposeWeatherEffects = () => {
@@ -258,6 +332,7 @@ export function createWeatherManager({
       }
     }
     activeParticleEffects.length = 0;
+    syncEmitterState();
   };
 
   const spawnPrecipitationEffect = (config, context) => {
@@ -278,6 +353,20 @@ export function createWeatherManager({
           });
     const handle = particleSystem.emit(emitter);
     if (!handle) {
+      const weatherState = ensureWeatherState();
+      if (weatherState) {
+        const previousFailures = Number.isFinite(weatherState.failedPrecipitationSpawns)
+          ? weatherState.failedPrecipitationSpawns
+          : 0;
+        weatherState.failedPrecipitationSpawns = previousFailures + 1;
+        weatherState.lastPrecipitationFailure = {
+          elapsedTime: context?.elapsedTime ?? null,
+          type: config.type,
+        };
+      }
+      console.warn('Weather precipitation emitter failed to spawn; no handle was returned.', {
+        type: config.type,
+      });
       return;
     }
     let updateInterval = config.updateInterval;
@@ -323,8 +412,11 @@ export function createWeatherManager({
         z: playerPosition.z,
       };
       attachment.lastUpdateTime = elapsedTime;
+      recordAnchorUpdate(elapsedTime);
     }
     activeParticleEffects.push(attachment);
+    recordPrecipitationSpawn({ type: config.type, elapsedTime });
+    syncEmitterState();
   };
 
   const spawnAuroraEffects = (config, context) => {
@@ -370,6 +462,9 @@ export function createWeatherManager({
         lastUpdateTime: -Infinity,
       };
       activeParticleEffects.push(attachment);
+    }
+    if (count > 0) {
+      syncEmitterState();
     }
   };
 
@@ -429,6 +524,7 @@ export function createWeatherManager({
           z: playerPosition.z,
         };
         attachment.lastUpdateTime = elapsedTime;
+        recordAnchorUpdate(elapsedTime);
       } else if (attachment.type === 'aurora') {
         let heading = attachment.staticOrientation ?? 0;
         if (attachment.alignWithHeading) {
@@ -451,6 +547,7 @@ export function createWeatherManager({
           z: anchorZ,
         });
         attachment.lastUpdateTime = elapsedTime;
+        recordAnchorUpdate(elapsedTime);
       }
     }
   };
@@ -495,11 +592,63 @@ export function createWeatherManager({
     if (typeof registerDiagnosticOverlay !== 'function' || diagnosticOverlayDisposer) {
       return;
     }
+    if (!overlayUi) {
+      overlayUi = createWeatherDebugOverlay();
+    }
     diagnosticOverlayDisposer = registerDiagnosticOverlay(({ elapsedTime }) => {
-      if (!scene?.userData?.weather) {
+      const weatherState = ensureWeatherState();
+      if (!weatherState) {
         return;
       }
-      scene.userData.weather.lastOverlayUpdate = elapsedTime;
+      weatherState.lastOverlayUpdate = Number.isFinite(elapsedTime)
+        ? elapsedTime
+        : weatherState.lastOverlayUpdate;
+      weatherState.activeEmitterCount = activeParticleEffects.length;
+
+      let stats = null;
+      if (particleSystem && typeof particleSystem.getDebugInfo === 'function') {
+        const debugInfo = particleSystem.getDebugInfo();
+        if (debugInfo) {
+          const emitters = Array.isArray(debugInfo.emitters) ? debugInfo.emitters : [];
+          const weatherEmitters = emitters.filter((emitter) => {
+            if (!emitter || typeof emitter.label !== 'string') {
+              return false;
+            }
+            return emitter.label.toLowerCase().includes('weather');
+          });
+          const summaries = weatherEmitters.slice(0, 4).map((emitter) => ({
+            label: emitter.label ?? 'WeatherEmitter',
+            particles: Number.isFinite(emitter.activeParticles)
+              ? emitter.activeParticles
+              : 0,
+            status: emitter.pendingRemoval ? ' (pending removal)' : '',
+          }));
+          const weatherParticles = weatherEmitters.reduce((sum, emitter) => {
+            const value = Number.isFinite(emitter?.activeParticles)
+              ? emitter.activeParticles
+              : 0;
+            return sum + value;
+          }, 0);
+          const totalEmitters = Number.isFinite(debugInfo.emitterCount)
+            ? debugInfo.emitterCount
+            : emitters.length;
+          stats = {
+            totalEmitters,
+            weatherCount: weatherEmitters.length,
+            weatherParticles,
+            emitters: summaries,
+            extraCount: Math.max(0, weatherEmitters.length - summaries.length),
+          };
+          weatherState.lastDebugSample = Number.isFinite(elapsedTime)
+            ? elapsedTime
+            : weatherState.lastDebugSample;
+          weatherState.totalActiveParticles = Number.isFinite(weatherParticles)
+            ? weatherParticles
+            : weatherState.totalActiveParticles;
+        }
+      }
+
+      overlayUi?.update({ weatherState, stats });
     });
   };
 
@@ -597,6 +746,14 @@ export function createWeatherManager({
         console.error('Failed to dispose weather diagnostic overlay:', error);
       }
       diagnosticOverlayDisposer = null;
+    }
+    if (overlayUi) {
+      try {
+        overlayUi.dispose();
+      } catch (error) {
+        console.error('Failed to dispose weather overlay UI:', error);
+      }
+      overlayUi = null;
     }
   };
 


### PR DESCRIPTION
## Summary
- persist weather diagnostics (failures, anchor updates, suppression state, particle totals) directly on the scene weather metadata
- add an always-on weather debug HUD via `registerDiagnosticOverlay`, mirroring the underwater overlay to surface preset, emitter, and failure status
- document the outstanding weather remediation work orders for automating rotations and adding regression coverage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab4c823b0832a96f21a0b551eb01a