### PR TITLE
Handle particle emitter initialization failures

### DIFF
--- a/three-demo/src/rendering/__tests__/particle-system.test.js
+++ b/three-demo/src/rendering/__tests__/particle-system.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+const { createParticleSystem } = await import('../particle-system.js');
+
+test('emit returns null when emitter initialization throws', () => {
+  const scene = new THREE.Scene();
+  const particleSystem = createParticleSystem({ THREE, scene });
+
+  const failingEmitter = {
+    initialize() {
+      throw new Error('boom');
+    },
+  };
+
+  const originalError = console.error;
+  console.error = () => {};
+  let handle;
+
+  try {
+    handle = particleSystem.emit(failingEmitter);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(handle, null, 'expected emit to return null for a failed emitter');
+
+  particleSystem.dispose();
+});

--- a/three-demo/src/rendering/particle-system.js
+++ b/three-demo/src/rendering/particle-system.js
@@ -361,6 +361,17 @@ export function createParticleSystem({ THREE, scene }) {
     }
   }
 
+  /**
+   * Registers a particle emitter with the system.
+   *
+   * Callers receive a handle object for successful registrations. When the
+   * emitter fails to initialize or does not allocate any instanced pools, the
+   * method disposes the emitter immediately and returns `null` so callers can
+   * react to the hard failure.
+   *
+   * @param {object} emitter
+   * @returns {{ stop: () => void; getActiveParticleCount: () => number } | null}
+   */
   function emit(emitter) {
     if (isDisposed) {
       throw new Error('Cannot emit from a disposed particle system');
@@ -391,6 +402,8 @@ export function createParticleSystem({ THREE, scene }) {
 
     activeEmitters.add(state);
 
+    let initializationFailed = false;
+
     try {
       emitter.initialize?.({
         THREE,
@@ -407,11 +420,26 @@ export function createParticleSystem({ THREE, scene }) {
       state.debugLabel = label;
     } catch (error) {
       console.error('Particle emitter initialize failed:', error);
-      state.shouldRemove = true;
+      initializationFailed = true;
     }
 
-    if (!emitter.update && state.instancedPools.size === 0) {
+    const hasInstancedPools = state.instancedPools.size > 0;
+
+    if (initializationFailed || !hasInstancedPools) {
+      if (!initializationFailed && !hasInstancedPools) {
+        if (state.debugLabel) {
+          console.warn(
+            'Particle emitter initialize completed without allocating any instanced pools; disposing emitter.',
+            { label: state.debugLabel },
+          );
+        } else {
+          console.warn(
+            'Particle emitter initialize completed without allocating any instanced pools; disposing emitter.',
+          );
+        }
+      }
       disposeEmitterState(state);
+      return null;
     }
 
     return {

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -46,7 +46,7 @@ test('setWeather emits precipitation for rainy presets', () => {
 });
 
 test('failed precipitation spawns are recorded for diagnostics', () => {
-  const { manager, scene } = createManager({
+  const { manager, scene, particleSystem } = createManager({
     emitImplementation: () => null,
   });
 
@@ -56,6 +56,11 @@ test('failed precipitation spawns are recorded for diagnostics', () => {
   const weatherState = scene.userData.weather;
 
   assert.ok(weatherState, 'expected weather diagnostics state to exist');
+  assert.equal(
+    particleSystem.emitted.length,
+    0,
+    'expected no handles when particle system emit returned null',
+  );
   assert.equal(weatherState.failedPrecipitationSpawns, 1);
   assert.deepEqual(weatherState.lastPrecipitationFailure, {
     elapsedTime: 2,


### PR DESCRIPTION
## Summary
- ensure particle system emitters that fail to initialize or allocate instanced pools are disposed and return null handles, with documentation for consumers
- add regression tests covering particle system initialization failures and weather manager diagnostics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dadc8cfde0832aae90d67e2a6450e0