### PR TITLE
Stop GPU billboard emission after handle stop

### DIFF
--- a/three-demo/src/rendering/__tests__/particle-system.test.js
+++ b/three-demo/src/rendering/__tests__/particle-system.test.js
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 import * as THREE from 'three';
 
 const { createParticleSystem } = await import('../particle-system.js');
+const { createGpuBillboardEmitter } = await import(
+  '../particles/gpu-billboard-emitter.js'
+);
 
 test('emit returns null when emitter initialization throws', () => {
   const scene = new THREE.Scene();
@@ -25,6 +28,51 @@ test('emit returns null when emitter initialization throws', () => {
   }
 
   assert.equal(handle, null, 'expected emit to return null for a failed emitter');
+
+  particleSystem.dispose();
+});
+
+test('GPU billboard emitter stops spawning after handle.stop()', () => {
+  const scene = new THREE.Scene();
+  const particleSystem = createParticleSystem({ THREE, scene });
+
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: 30,
+    maxParticles: 128,
+    lifetime: { min: 0.1, max: 0.1 },
+  });
+
+  const handle = particleSystem.emit(emitter);
+  assert.ok(handle, 'expected emitter handle to be returned');
+
+  for (let i = 0; i < 10; i += 1) {
+    particleSystem.update(0.1);
+  }
+
+  let debugInfo = particleSystem.getDebugInfo();
+  assert.ok(
+    debugInfo.totalActiveParticles > 0,
+    'expected particles to spawn before stopping the emitter',
+  );
+
+  handle.stop();
+
+  let finalInfo = null;
+  for (let i = 0; i < 120; i += 1) {
+    particleSystem.update(1 / 30);
+    debugInfo = particleSystem.getDebugInfo();
+    if (debugInfo.emitterCount === 0) {
+      finalInfo = debugInfo;
+      break;
+    }
+  }
+
+  assert.ok(finalInfo, 'expected the emitter to dispose after being stopped');
+  assert.equal(
+    finalInfo.totalActiveParticles,
+    0,
+    'expected all particles to expire after stopping the emitter',
+  );
 
   particleSystem.dispose();
 });

--- a/three-demo/src/rendering/particle-system.js
+++ b/three-demo/src/rendering/particle-system.js
@@ -13,6 +13,10 @@
  * - `update(context)` — invoked once per frame while the emitter is alive.
  *   Return `false` to signal that the emitter should be removed once all of its
  *   particles have expired.
+ * - `stop(context)` — invoked exactly once when the emitter is requested to
+ *   stop spawning new particles (for example when the handle's `stop()` method
+ *   is called or the emitter's `update()` hook returns `false`). Emitters can
+ *   use this hook to flush any internal spawn state.
  * - `dispose()` — called once when the emitter is removed from the system.
  */
 
@@ -361,6 +365,24 @@ export function createParticleSystem({ THREE, scene }) {
     }
   }
 
+  function requestEmitterStop(state) {
+    state.shouldRemove = true;
+    if (state.stopNotified) {
+      return;
+    }
+    state.stopNotified = true;
+    try {
+      state.emitter.stop?.({
+        THREE,
+        getElapsedTime: () => elapsedTime,
+        createInstancedPool: state.createInstancedPool,
+        root,
+      });
+    } catch (error) {
+      console.error('Particle emitter stop failed:', error);
+    }
+  }
+
   /**
    * Registers a particle emitter with the system.
    *
@@ -387,6 +409,7 @@ export function createParticleSystem({ THREE, scene }) {
       instancedPools: new Set(),
       debugLabel: null,
       debugId: (emitterIdCounter += 1),
+      stopNotified: false,
     };
 
     function createPool(options) {
@@ -444,7 +467,7 @@ export function createParticleSystem({ THREE, scene }) {
 
     return {
       stop: () => {
-        state.shouldRemove = true;
+        requestEmitterStop(state);
       },
       getActiveParticleCount: () => {
         let count = 0;
@@ -626,8 +649,9 @@ export function createParticleSystem({ THREE, scene }) {
       if (typeof state.emitter.update === 'function') {
         let keepAlive = true;
         try {
+          const deltaForEmitter = state.shouldRemove ? 0 : deltaSeconds;
           const result = state.emitter.update({
-            delta: deltaSeconds,
+            delta: deltaForEmitter,
             THREE,
             getElapsedTime: () => elapsedTime,
             createInstancedPool: state.createInstancedPool,
@@ -641,7 +665,7 @@ export function createParticleSystem({ THREE, scene }) {
           keepAlive = false;
         }
         if (!keepAlive) {
-          state.shouldRemove = true;
+          requestEmitterStop(state);
         }
       }
     }
@@ -708,3 +732,4 @@ export function createParticleSystem({ THREE, scene }) {
  * {@link createGpuBillboardEmitter} from `./particles/gpu-billboard-emitter.js`.
  */
 export { createGpuBillboardEmitter as createBillboardEmitter } from './particles/gpu-billboard-emitter.js';
+

--- a/three-demo/src/rendering/particles/gpu-billboard-emitter.js
+++ b/three-demo/src/rendering/particles/gpu-billboard-emitter.js
@@ -290,6 +290,7 @@ export function createGpuBillboardEmitter(options = {}) {
   let tempPosition = null
   let tempVelocity = null
   let pendingBasePosition = null
+  let isStopped = false
 
   function ensureTempVectors(THREE) {
     if (!tempPosition) {
@@ -410,6 +411,7 @@ export function createGpuBillboardEmitter(options = {}) {
 
       spawnAccumulator = 0
       liveParticles.length = 0
+      isStopped = false
 
       const now = getElapsedTime?.() ?? 0
       material.uniforms.uTime.value = now
@@ -430,7 +432,8 @@ export function createGpuBillboardEmitter(options = {}) {
 
       recycleExpired(now)
 
-      if (maxParticles <= 0) {
+      const spawningDisabled = isStopped || maxParticles <= 0 || spawnRate <= 0
+      if (spawningDisabled) {
         spawnAccumulator = 0
         return liveParticles.length > 0
       }
@@ -443,7 +446,7 @@ export function createGpuBillboardEmitter(options = {}) {
         toSpawn -= 1
       }
 
-      return liveParticles.length > 0 || spawnRate > 0
+      return liveParticles.length > 0 || (!isStopped && spawnRate > 0)
     },
 
     getActiveParticleCount() {
@@ -463,6 +466,11 @@ export function createGpuBillboardEmitter(options = {}) {
       pendingBasePosition = null
     },
 
+    stop() {
+      isStopped = true
+      spawnAccumulator = 0
+    },
+
     dispose() {
       liveParticles.length = 0
       pool = null
@@ -470,6 +478,7 @@ export function createGpuBillboardEmitter(options = {}) {
       basePosition = undefined
       threeModule = null
       pendingBasePosition = null
+      isStopped = false
     },
   }
 }


### PR DESCRIPTION
## Summary
- add a stop hook contract to the particle system and stop passing non-zero deltas once an emitter is shutting down
- teach the GPU billboard emitter to honour the stop hook so precipitation emitters wind down cleanly
- add a regression test ensuring stopped GPU billboard emitters dispose once their particles expire

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae0f32c50832a905b5dab078610b6