### PR TITLE
Add particle-system integration test for misty rain

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -29,6 +29,12 @@
 - The weather debug overlay now streams particle-system diagnostics every frame, reporting precipitation emitter particle counts, retry windows, last failure reasons, and harness timing so testers can watch the system recover without rerunning console commands.【F:src/ui/weather-debug-overlay.js†L1-L156】【F:src/world/weather/weather-manager.js†L872-L940】
 - Rain emitters were retuned (higher particle budget, longer lifetimes, faster anchor updates) to match the reliability of the underwater bubble effects and guarantee visible spawn when the harness cycles into rain-heavy presets.【F:src/rendering/particles/weather-rain.js†L9-L53】【F:src/rendering/particles/water-effects.js†L46-L80】
 
+## 2025-05 Regression Coverage Updates
+- Added a node:test case that boots the real GPU billboard particle system, applies the `misty_rain` preset, and advances both managers until `particleSystem.getDebugInfo()` reports active “weather” emitters—proving end-to-end precipitation spawning works without mocks.【F:src/world/__tests__/weather-manager.test.js†L1-L127】
+- Remaining gaps: the suite still lacks automated checks for aurora ribbons, anchor repositioning against live player controls, and rotation-harness scheduling edge cases—these should follow once we expose lightweight test doubles for those systems.
+
+> **Reminder for reviewers:** please continue keeping this remediation plan up to date whenever you touch weather logic or diagnostics so future investigators inherit an accurate coverage map.
+
 Please continue appending follow-up findings or configuration changes here whenever the harness or emitter settings evolve.
 
 ## Work Orders

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -1,7 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import * as THREE from 'three';
 
 const { createWeatherManager } = await import('../weather/weather-manager.js');
+const { createParticleSystem } = await import('../../rendering/particle-system.js');
 
 function createManager({ emitImplementation }) {
   const emit = emitImplementation ?? (() => ({ stop() {} }));
@@ -115,4 +117,40 @@ test('zero-particle precipitation handles trigger retries and diagnostics', () =
     type: 'rain',
     reason: 'zero_particles',
   });
+});
+
+test('rain preset spawns active particles with the real particle system', () => {
+  const scene = new THREE.Scene();
+  const particleSystem = createParticleSystem({ THREE, scene });
+  const manager = createWeatherManager({ scene, particleSystem });
+
+  try {
+    manager.setWeather('misty_rain');
+
+    let elapsedTime = 0;
+    let weatherParticles = 0;
+
+    const frameDelta = 1 / 60;
+    for (let frame = 0; frame < 300; frame += 1) {
+      elapsedTime += frameDelta;
+      manager.update({ delta: frameDelta, elapsedTime });
+      particleSystem.update(frameDelta);
+      const debugInfo = particleSystem.getDebugInfo();
+      const emitters = Array.isArray(debugInfo?.emitters) ? debugInfo.emitters : [];
+      const weatherEmitter = emitters.find((emitter) =>
+        typeof emitter.label === 'string' && emitter.label.toLowerCase().includes('weather'),
+      );
+      if (weatherEmitter?.activeParticles > 0) {
+        weatherParticles = weatherEmitter.activeParticles;
+        break;
+      }
+    }
+
+    assert.ok(
+      weatherParticles > 0,
+      'expected real weather emitter to accumulate active particles after ticking the system',
+    );
+  } finally {
+    particleSystem.dispose();
+  }
 });


### PR DESCRIPTION
## Summary
- add a node:test case that drives the real particle system until misty rain emits active weather particles
- document the new automated coverage and remaining weather testing gaps in the remediation plan

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daeef48ecc832a9952862eb5bae672