### PR TITLE
Queue precipitation retries when particle emit fails

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -10,7 +10,7 @@
 
 ## Manual Testing Symptoms
 - The `/weather debug` subcommand reads particle-system statistics and prints whether any emitters labeled “weather” are alive, but the command must be rerun manually and provides no guidance on why emitters failed to appear.【F:src/player/dev-commands.js†L1532-L1587】
-- When `particleSystem.emit` returns a falsy handle, `spawnPrecipitationEffect` records a failure count and logs a warning, yet there is no proactive signal to surface the failure to players beyond consulting diagnostics after the fact.【F:src/world/weather/weather-manager.js†L338-L370】
+- When `particleSystem.emit` returns a falsy handle, `spawnPrecipitationEffect` records a failure count and (as of May 2025) queues a follow-up attempt that the overlay reports as a pending retry, keeping testers aware of self-healing behaviour without rerunning console probes.【F:src/world/weather/weather-manager.js†L258-L363】【F:src/ui/weather-debug-overlay.js†L86-L143】
 - Active precipitation emitters anchor themselves to the player each frame, so if spawning succeeds we expect to see rain or snow volumes following the camera; the absence of any visuals implies either emitters are not spawned, are culled immediately, or are suppressed before they can update.【F:src/world/weather/weather-manager.js†L338-L420】【F:src/world/weather/weather-manager.js†L500-L551】
 
 ## Candidate Root Causes
@@ -32,8 +32,9 @@
 ## 2025-05 Regression Coverage Updates
 - Added a node:test case that boots the real GPU billboard particle system, applies the `misty_rain` preset, and advances both managers until `particleSystem.getDebugInfo()` reports active “weather” emitters—proving end-to-end precipitation spawning works without mocks.【F:src/world/__tests__/weather-manager.test.js†L1-L127】
 - Remaining gaps: the suite still lacks automated checks for aurora ribbons, anchor repositioning against live player controls, and rotation-harness scheduling edge cases—these should follow once we expose lightweight test doubles for those systems.
+- Missing precipitation handles now trigger scheduled retries that are stored on `scene.userData.weather.pendingPrecipitationRetries`, increment `precipitationRecoveryAttempts`, and surface upcoming retry windows plus reasons in the overlay so live sessions show when the system will self-heal.【F:src/world/weather/weather-manager.js†L258-L381】【F:src/ui/weather-debug-overlay.js†L86-L143】
 
-> **Reminder for reviewers:** please continue keeping this remediation plan up to date whenever you touch weather logic or diagnostics so future investigators inherit an accurate coverage map.
+> **Reminder for reviewers:** please continue keeping this remediation plan up to date whenever you touch weather logic or diagnostics so future investigators inherit an accurate coverage map. Be especially diligent about updating the new retry/overlay notes whenever precipitation recovery logic or diagnostics evolve.
 
 Please continue appending follow-up findings or configuration changes here whenever the harness or emitter settings evolve.
 

--- a/three-demo/src/ui/weather-debug-overlay.js
+++ b/three-demo/src/ui/weather-debug-overlay.js
@@ -132,6 +132,9 @@ function describePrecipitation(weatherState) {
   const emitters = Array.isArray(weatherState?.precipitationEmitters)
     ? weatherState.precipitationEmitters
     : [];
+  const pending = Array.isArray(weatherState?.pendingPrecipitationRetries)
+    ? weatherState.pendingPrecipitationRetries
+    : [];
   const totalParticles = Number.isFinite(weatherState?.precipitationActiveParticles)
     ? weatherState.precipitationActiveParticles
     : null;
@@ -143,15 +146,31 @@ function describePrecipitation(weatherState) {
       ? 'Precipitation: none active'
       : `Precipitation: none active (particles=${totalParticles})`;
     const failure = weatherState?.lastPrecipitationFailure ?? null;
+    const lines = [`${baseSummary}${recoveries > 0 ? ` (recoveries=${recoveries})` : ''}.`];
+    if (pending.length > 0) {
+      lines.push(`  Pending retries (${pending.length}):`);
+      pending.forEach((retry, index) => {
+        const attempt = Number.isFinite(retry.attempt) ? retry.attempt : '?';
+        const maxAttempts = Number.isFinite(retry.maxAttempts) ? retry.maxAttempts : '?';
+        const nextRetry = Number.isFinite(retry.nextRetryIn)
+          ? `, retry in ${formatTime(retry.nextRetryIn)}`
+          : '';
+        const retryAt = Number.isFinite(retry.retryAt)
+          ? ` (target ${formatTime(retry.retryAt)})`
+          : '';
+        const reason = retry.reason ? `, reason=${retry.reason}` : '';
+        lines.push(
+          `    #${index + 1} ${retry.type ?? 'precipitation'} — attempt ${attempt}/${maxAttempts}${nextRetry}${retryAt}${reason}.`,
+        );
+      });
+    }
     if (failure) {
       const reason = failure.reason ? `, reason=${failure.reason}` : '';
-      return `${baseSummary}. Last failure ${failure.type ?? 'unknown'} @ ${formatTime(
-        failure.elapsedTime,
-      )}${reason}.`;
+      lines.push(
+        `  Last failure ${failure.type ?? 'unknown'} @ ${formatTime(failure.elapsedTime)}${reason}.`,
+      );
     }
-    return recoveries > 0
-      ? `${baseSummary} (recoveries=${recoveries}).`
-      : `${baseSummary}.`;
+    return lines.join('\n');
   }
   const summaryParts = [`Precipitation: ${emitters.length} active`];
   if (Number.isFinite(totalParticles)) {
@@ -182,6 +201,23 @@ function describePrecipitation(weatherState) {
       `  #${index + 1} ${label} (${type}) — particles=${particles}, attempt ${attempts}/${maxAttempts}, status=${status}${retryText}${spawnedText}.`,
     );
   });
+  if (pending.length > 0) {
+    lines.push(`  Pending retries (${pending.length}):`);
+    pending.forEach((retry, index) => {
+      const attempt = Number.isFinite(retry.attempt) ? retry.attempt : '?';
+      const maxAttempts = Number.isFinite(retry.maxAttempts) ? retry.maxAttempts : '?';
+      const nextRetry = Number.isFinite(retry.nextRetryIn)
+        ? `, retry in ${formatTime(retry.nextRetryIn)}`
+        : '';
+      const reason = retry.reason ? `, reason=${retry.reason}` : '';
+      const retryAt = Number.isFinite(retry.retryAt)
+        ? ` (target ${formatTime(retry.retryAt)})`
+        : '';
+      lines.push(
+        `    #${index + 1} ${retry.type ?? 'precipitation'} — attempt ${attempt}/${maxAttempts}${nextRetry}${retryAt}${reason}.`,
+      );
+    });
+  }
   const failure = weatherState?.lastPrecipitationFailure ?? null;
   if (failure) {
     const reason = failure.reason ? `, reason=${failure.reason}` : '';

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -64,11 +64,63 @@ test('failed precipitation spawns are recorded for diagnostics', () => {
     'expected no handles when particle system emit returned null',
   );
   assert.equal(weatherState.failedPrecipitationSpawns, 1);
+  assert.equal(weatherState.precipitationRecoveryAttempts, 1);
   assert.deepEqual(weatherState.lastPrecipitationFailure, {
     elapsedTime: 2,
     type: 'rain',
     reason: 'no_handle',
   });
+  assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
+  const pendingRetry = weatherState.pendingPrecipitationRetries[0];
+  assert.equal(pendingRetry.type, 'rain');
+  assert.equal(pendingRetry.attempt, 2);
+  assert.equal(pendingRetry.maxAttempts, 3);
+  assert.equal(pendingRetry.reason, 'no_handle');
+});
+
+test('precipitation spawn retries recover after missing handles', () => {
+  let emitCount = 0;
+  const handles = [null, null, { stop() {}, getActiveParticleCount() { return 12; } }];
+
+  const { manager, scene, particleSystem } = createManager({
+    emitImplementation: () => {
+      const handle = emitCount < handles.length ? handles[emitCount] : handles.at(-1);
+      emitCount += 1;
+      return handle;
+    },
+  });
+
+  manager.setWeather('misty_rain');
+
+  manager.update({ delta: 0.1, elapsedTime: 0.1 });
+
+  let weatherState = scene.userData.weather;
+  assert.equal(emitCount, 1, 'expected initial precipitation emit call');
+  assert.equal(weatherState.failedPrecipitationSpawns, 1);
+  assert.equal(weatherState.precipitationRecoveryAttempts, 1);
+  assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
+  assert.equal(weatherState.pendingPrecipitationRetries[0].attempt, 2);
+
+  manager.update({ delta: 0.4, elapsedTime: 0.5 });
+  weatherState = scene.userData.weather;
+  assert.equal(emitCount, 1, 'expected retry to wait until the interval has elapsed');
+  assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
+
+  manager.update({ delta: 0.3, elapsedTime: 0.8 });
+  weatherState = scene.userData.weather;
+  assert.equal(emitCount, 2, 'expected queued retry to fire after the interval');
+  assert.equal(weatherState.failedPrecipitationSpawns, 2);
+  assert.equal(weatherState.precipitationRecoveryAttempts, 2);
+  assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
+  assert.equal(weatherState.pendingPrecipitationRetries[0].attempt, 3);
+
+  manager.update({ delta: 0.7, elapsedTime: 1.5 });
+  weatherState = scene.userData.weather;
+  assert.equal(emitCount, 3, 'expected final retry to execute');
+  assert.equal(particleSystem.emitted.length, 1, 'expected successful handle to be recorded');
+  assert.equal(weatherState.pendingPrecipitationRetries.length, 0);
+  assert.equal(weatherState.failedPrecipitationSpawns, 2);
+  assert.equal(weatherState.precipitationRecoveryAttempts, 2);
 });
 
 test('zero-particle precipitation handles trigger retries and diagnostics', () => {

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -251,6 +251,7 @@ export function createWeatherManager({
   };
   let diagnosticOverlayDisposer = null;
   const activeParticleEffects = [];
+  const pendingPrecipitationRetries = [];
   let needsEffectRefresh = true;
 
   let overlayUi = null;
@@ -302,6 +303,9 @@ export function createWeatherManager({
     }
     if (!Number.isFinite(state.precipitationActiveParticles)) {
       state.precipitationActiveParticles = 0;
+    }
+    if (!Array.isArray(state.pendingPrecipitationRetries)) {
+      state.pendingPrecipitationRetries = [];
     }
     if (!state.rotationHarness) {
       state.rotationHarness = {
@@ -365,6 +369,98 @@ export function createWeatherManager({
       elapsedTime: Number.isFinite(elapsedTime) ? elapsedTime : null,
       reason: reason ?? null,
     };
+  };
+
+  const syncPendingPrecipitationRetries = (now = lastElapsedTime) => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    const resolvedNow = Number.isFinite(now)
+      ? now
+      : Number.isFinite(lastElapsedTime)
+      ? lastElapsedTime
+      : null;
+    const maxAttempts = PRECIPITATION_SPAWN_MAX_RETRIES + 1;
+    state.pendingPrecipitationRetries = pendingPrecipitationRetries.map((entry) => {
+      const attemptIndex = Number.isFinite(entry.attempt) ? entry.attempt : 0;
+      const retryAt = Number.isFinite(entry.readyTime) ? entry.readyTime : null;
+      const nextRetryIn =
+        Number.isFinite(retryAt) && Number.isFinite(resolvedNow)
+          ? Math.max(0, retryAt - resolvedNow)
+          : null;
+      return {
+        type: entry.config?.type ?? 'precipitation',
+        attempt: attemptIndex + 1,
+        attemptIndex,
+        maxAttempts,
+        reason: entry.reason ?? null,
+        scheduledAt: Number.isFinite(entry.scheduledAt) ? entry.scheduledAt : null,
+        retryAt,
+        nextRetryIn,
+      };
+    });
+  };
+
+  const clearPendingPrecipitationRetries = (now = lastElapsedTime) => {
+    pendingPrecipitationRetries.length = 0;
+    syncPendingPrecipitationRetries(now);
+  };
+
+  const queuePrecipitationRetry = ({
+    config,
+    attempt,
+    readyTime,
+    reason,
+    elapsedTime,
+  }) => {
+    const entry = {
+      config: { ...(config ?? {}) },
+      attempt: Number.isFinite(attempt) ? attempt : 0,
+      readyTime: Number.isFinite(readyTime)
+        ? readyTime
+        : (Number.isFinite(elapsedTime) ? elapsedTime : 0) + PRECIPITATION_HANDLE_RECHECK_INTERVAL,
+      reason: reason ?? null,
+      scheduledAt: Number.isFinite(elapsedTime) ? elapsedTime : null,
+    };
+    pendingPrecipitationRetries.push(entry);
+    const state = ensureWeatherState();
+    if (state) {
+      const previousRecoveries = Number.isFinite(state.precipitationRecoveryAttempts)
+        ? state.precipitationRecoveryAttempts
+        : 0;
+      state.precipitationRecoveryAttempts = previousRecoveries + 1;
+    }
+    syncPendingPrecipitationRetries(elapsedTime);
+  };
+
+  const processPendingPrecipitationRetries = (context) => {
+    if (pendingPrecipitationRetries.length === 0) {
+      syncPendingPrecipitationRetries(context?.elapsedTime);
+      return;
+    }
+    const { elapsedTime = lastElapsedTime } = context ?? {};
+    const now = Number.isFinite(elapsedTime) ? elapsedTime : lastElapsedTime;
+    if (!Number.isFinite(now)) {
+      syncPendingPrecipitationRetries(now);
+      return;
+    }
+    const readyEntries = [];
+    for (let i = pendingPrecipitationRetries.length - 1; i >= 0; i -= 1) {
+      const entry = pendingPrecipitationRetries[i];
+      const readyTime = Number.isFinite(entry.readyTime) ? entry.readyTime : Number.POSITIVE_INFINITY;
+      if (now >= readyTime) {
+        pendingPrecipitationRetries.splice(i, 1);
+        readyEntries.unshift(entry);
+      }
+    }
+    syncPendingPrecipitationRetries(now);
+    if (readyEntries.length === 0) {
+      return;
+    }
+    readyEntries.forEach((entry) => {
+      spawnPrecipitationEffect(entry.config, context, entry.attempt);
+    });
   };
 
   const clearScheduledTransitionsByTag = (tag) => {
@@ -678,6 +774,7 @@ export function createWeatherManager({
     }
     activeParticleEffects.length = 0;
     syncEmitterState();
+    clearPendingPrecipitationRetries();
   };
 
   const spawnPrecipitationEffect = (config, context, attempt = 0) => {
@@ -698,14 +795,44 @@ export function createWeatherManager({
           });
     const handle = particleSystem.emit(emitter);
     if (!handle) {
+      const now = Number.isFinite(context?.elapsedTime)
+        ? context.elapsedTime
+        : Number.isFinite(lastElapsedTime)
+        ? lastElapsedTime
+        : null;
       recordPrecipitationFailure({
         type: config.type,
-        elapsedTime: context?.elapsedTime ?? null,
+        elapsedTime: now,
         reason: 'no_handle',
       });
-      console.warn('Weather precipitation emitter failed to spawn; no handle was returned.', {
-        type: config.type,
-      });
+      const maxAttempts = PRECIPITATION_SPAWN_MAX_RETRIES + 1;
+      if (attempt < PRECIPITATION_SPAWN_MAX_RETRIES) {
+        const nextAttempt = attempt + 1;
+        const retryReadyTime = Number.isFinite(now)
+          ? now + PRECIPITATION_HANDLE_RECHECK_INTERVAL
+          : null;
+        queuePrecipitationRetry({
+          config,
+          attempt: nextAttempt,
+          readyTime: retryReadyTime,
+          reason: 'no_handle',
+          elapsedTime: now,
+        });
+        console.warn(
+          'Weather precipitation emitter failed to spawn; retry scheduled.',
+          {
+            type: config.type,
+            attempt: nextAttempt,
+            maxAttempts,
+            retryAt: retryReadyTime,
+          },
+        );
+      } else {
+        console.error('Weather precipitation emitter failed after maximum retries.', {
+          type: config.type,
+          attempts: maxAttempts,
+        });
+      }
       return;
     }
     let updateInterval = config.updateInterval;
@@ -954,6 +1081,7 @@ export function createWeatherManager({
       weatherState.activeEmitterCount = activeParticleEffects.length;
 
       const now = Number.isFinite(elapsedTime) ? elapsedTime : lastElapsedTime;
+      syncPendingPrecipitationRetries(now);
       const precipitationSummaries = activeParticleEffects
         .filter((attachment) => attachment.type === 'precipitation')
         .map((attachment, index) => {
@@ -1218,6 +1346,7 @@ export function createWeatherManager({
     if (needsEffectRefresh) {
       refreshWeatherEffects({ ...context, elapsedTime: lastElapsedTime });
     }
+    processPendingPrecipitationRetries({ ...context, elapsedTime: lastElapsedTime });
     updateAnchoredEffects({ ...context, elapsedTime: lastElapsedTime });
     validatePrecipitationHandles({ ...context, elapsedTime: lastElapsedTime });
     updateRotationHarnessTick({ elapsedTime: lastElapsedTime });


### PR DESCRIPTION
## Summary
- queue precipitation spawn retries when `particleSystem.emit` returns no handle and track retry metadata for diagnostics
- surface pending precipitation retries in the weather debug overlay and cover the multi-attempt recovery path in tests
- document the new retry behaviour in the weather remediation plan and remind reviewers to keep it current

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf21ec05c832a88e73fcdd3562613