### PR TITLE
Add raindrop overlay effect and console controls

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -43,6 +43,11 @@ Please continue appending follow-up findings or configuration changes here whene
 - The end-to-end precipitation regression test now requires the live rain emitter to reach at least 18 active particles, matching the new readability targets.【F:src/world/__tests__/weather-manager.test.js†L170-L198】
 - **Reminder:** keep this section updated whenever precipitation visuals or thresholds change so QA can track expectation shifts alongside the documented plan.
 
+## 2025-07 Raindrop Overlay Diagnostics
+- Added a lightweight screen-space raindrop overlay that tracks the camera, scales with precipitation intensity, and is created or disposed alongside rain emitters so `/weather misty_rain` always renders a visible drizzle cue for testers.【F:src/rendering/effects/raindrop-overlay.js†L1-L147】【F:src/world/weather/weather-manager.js†L262-L407】
+- Exposed `/weather overlay` developer-console controls to toggle the overlay, adjust manual intensity, or reset to automatic behaviour for quick regression probes without touching presets.【F:src/player/dev-commands.js†L1443-L1542】
+- **Reminder:** keep this remediation plan current whenever the overlay visuals or tooling change so future weather investigators inherit accurate guidance.
+
 ## Work Orders
 1. **Gameplay-driven rotation**
    - Sample the player’s biome each frame (reusing the `sampleBiomeAt` helper from `/weather status`) and resolve the preset rotation with `resolveBiomeWeatherRotation`, storing timing metadata per biome.【F:src/player/dev-commands.js†L1532-L1562】【F:src/world/weather/weather-manager.js†L76-L127】

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1437,7 +1437,7 @@ export function registerDeveloperCommands({
     },
   });
 
-  const weatherCommandUsage = '/weather [on|off|status|help|debug|harness|weatherId]';
+  const weatherCommandUsage = '/weather [on|off|status|help|debug|harness|overlay|weatherId]';
 
   registerCommand({
     name: 'weather',
@@ -1523,6 +1523,9 @@ export function registerDeveloperCommands({
         info('[weather help]   once — run through the current biome rotation a single time.');
         info('[weather help]   stop — halt the developer harness.');
         info('[weather help]   status — report the harness state.');
+        info(
+          '[weather help] Overlay controls: /weather overlay [status|on|off|toggle|auto|intensity <value|auto>|clear].',
+        );
         return;
       }
 
@@ -1762,6 +1765,102 @@ export function registerDeveloperCommands({
         }
         logWeatherPresetSummary({ prefix: '[weather status]' });
         return;
+      }
+
+      if (subcommand === 'overlay') {
+        if (
+          typeof weatherManager.getRaindropOverlayState !== 'function' ||
+          typeof weatherManager.setRaindropOverlayManualEnabled !== 'function' ||
+          typeof weatherManager.setRaindropOverlayManualIntensity !== 'function'
+        ) {
+          warn('[weather overlay] Overlay controls are unavailable in this build.');
+          return;
+        }
+
+        const overlayArgs = args.slice(1);
+
+        const reportOverlayStatus = (prefix = '[weather overlay]') => {
+          const current = weatherManager.getRaindropOverlayState() ?? {};
+          const mode =
+            current.manualEnabled === null || current.manualEnabled === undefined
+              ? 'auto'
+              : current.manualEnabled
+              ? 'manual:on'
+              : 'manual:off';
+          const source = current.manualIntensity !== null && current.manualIntensity !== undefined ? 'manual' : 'auto';
+          const appliedIntensity = Number.isFinite(current.intensity)
+            ? current.intensity.toFixed(2)
+            : 'n/a';
+          const baseIntensity = Number.isFinite(current.baseIntensity)
+            ? current.baseIntensity.toFixed(2)
+            : 'n/a';
+          info(
+            `${prefix} visible=${current.visible ? 'yes' : 'no'}, enabled=${current.enabled ? 'yes' : 'no'}, mode=${mode}, intensity=${appliedIntensity} (${source}), base=${baseIntensity}.`,
+          );
+        };
+
+        if (overlayArgs.length === 0 || overlayArgs[0].toLowerCase() === 'status') {
+          reportOverlayStatus();
+          return;
+        }
+
+        const action = overlayArgs[0].toLowerCase();
+
+        if (action === 'clear') {
+          weatherManager.setRaindropOverlayManualEnabled(null);
+          weatherManager.setRaindropOverlayManualIntensity(null);
+          success('[weather overlay] Cleared manual overrides; overlay returned to auto mode.');
+          reportOverlayStatus();
+          return;
+        }
+
+        if (action === 'auto') {
+          weatherManager.setRaindropOverlayManualEnabled(null);
+          success('[weather overlay] Overlay visibility returned to auto mode.');
+          reportOverlayStatus();
+          return;
+        }
+
+        if (action === 'on' || action === 'off' || action === 'toggle') {
+          const state = weatherManager.getRaindropOverlayState();
+          const current =
+            state?.manualEnabled !== null && state?.manualEnabled !== undefined
+              ? state.manualEnabled
+              : state?.enabled;
+          const next = action === 'toggle' ? !current : action === 'on';
+          weatherManager.setRaindropOverlayManualEnabled(next);
+          success(
+            `[weather overlay] Manual overlay ${next ? 'enabled' : 'disabled'}. Use /weather overlay auto to resume automatic control.`,
+          );
+          reportOverlayStatus();
+          return;
+        }
+
+        if (action === 'intensity') {
+          const valueToken = overlayArgs[1];
+          if (valueToken === undefined) {
+            throw new Error('Usage: /weather overlay intensity <value|auto>.');
+          }
+          const normalized = valueToken.toLowerCase();
+          if (normalized === 'auto' || normalized === 'default') {
+            weatherManager.setRaindropOverlayManualIntensity(null);
+            success('[weather overlay] Cleared manual intensity override.');
+            reportOverlayStatus();
+            return;
+          }
+          const numeric = Number(valueToken);
+          if (!Number.isFinite(numeric)) {
+            throw new Error('Specify a numeric overlay intensity (e.g. 0.5) or "auto".');
+          }
+          weatherManager.setRaindropOverlayManualIntensity(numeric);
+          success(`[weather overlay] Manual intensity set to ${numeric.toFixed(2)}.`);
+          reportOverlayStatus();
+          return;
+        }
+
+        throw new Error(
+          'Usage: /weather overlay [status|on|off|toggle|auto|intensity <value|auto>|clear].',
+        );
       }
 
       if (subcommand === 'off') {

--- a/three-demo/src/rendering/effects/raindrop-overlay.js
+++ b/three-demo/src/rendering/effects/raindrop-overlay.js
@@ -1,0 +1,139 @@
+import * as THREE from 'three';
+
+const OVERLAY_DISTANCE = 0.65;
+const MIN_INTENSITY = 0;
+const MAX_INTENSITY = 2.4;
+const DEFAULT_INTENSITY = 0.45;
+
+const tempDirection = new THREE.Vector3();
+const tempQuaternion = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function createOverlayMaterial(intensity = DEFAULT_INTENSITY) {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      uTime: { value: 0 },
+      uIntensity: { value: clamp(intensity, MIN_INTENSITY, MAX_INTENSITY) },
+    },
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+    blending: THREE.NormalBlending,
+    vertexShader: /* glsl */ `
+      varying vec2 vUv;
+
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      varying vec2 vUv;
+      uniform float uTime;
+      uniform float uIntensity;
+
+      float hash(vec2 p) {
+        return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+      }
+
+      float raindropMask(vec2 uv, float speed, float tilt) {
+        vec2 flowUv = vec2(uv.x + tilt * uv.y, uv.y);
+        flowUv.y = fract(flowUv.y + uTime * speed);
+        vec2 grid = floor(flowUv * vec2(8.0, 5.0));
+        vec2 local = fract(flowUv * vec2(8.0, 5.0));
+        float seed = hash(grid);
+        float trail = smoothstep(0.95, 0.1, local.y + seed * 0.4);
+        float column = smoothstep(0.42, 0.0, abs(local.x - 0.5));
+        float head = smoothstep(0.18, 0.0, length(local - vec2(0.5, 0.12 + seed * 0.12)));
+        float sparkle = smoothstep(0.75, 0.95, sin((local.y + seed) * 6.28318));
+        return (trail * column * 0.65 + head * 0.45) * sparkle;
+      }
+
+      void main() {
+        float base = raindropMask(vUv * vec2(1.0, 1.3), 0.08, -0.08);
+        float offset = raindropMask(vUv * vec2(1.0, 1.6) + vec2(0.35, 0.0), 0.12, -0.05);
+        float fine = raindropMask(vUv * vec2(1.0, 1.1) + vec2(-0.2, 0.1), 0.06, -0.1);
+        float mask = clamp(base + offset * 0.8 + fine * 0.6, 0.0, 1.0);
+        float opacity = mask * clamp(uIntensity, 0.0, ${MAX_INTENSITY.toFixed(1)}) * 0.35;
+        if (opacity <= 0.001) {
+          discard;
+        }
+        vec3 tint = mix(vec3(0.55, 0.66, 0.78), vec3(0.78, 0.86, 0.93), mask);
+        gl_FragColor = vec4(tint, opacity);
+      }
+    `,
+  });
+}
+
+export function createRaindropOverlay({ intensity = DEFAULT_INTENSITY } = {}) {
+  const geometry = new THREE.PlaneGeometry(2, 2);
+  const material = createOverlayMaterial(intensity);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = 'WeatherRaindropOverlay';
+  mesh.renderOrder = 995;
+  mesh.frustumCulled = false;
+
+  let elapsed = 0;
+
+  mesh.onBeforeRender = function onBeforeRender(renderer, scene, camera) {
+    if (!camera) {
+      return;
+    }
+    const targetDistance = OVERLAY_DISTANCE;
+    const direction = camera.getWorldDirection(tempDirection.set(0, 0, -1));
+    mesh.position.copy(camera.position).addScaledVector(direction, targetDistance);
+    mesh.quaternion.copy(camera.quaternion).multiply(tempQuaternion);
+
+    if (camera.isPerspectiveCamera) {
+      const vertical = Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * targetDistance * 2;
+      mesh.scale.set(vertical * camera.aspect, vertical, 1);
+    } else if (camera.isOrthographicCamera) {
+      const width = Math.abs(camera.right - camera.left);
+      const height = Math.abs(camera.top - camera.bottom);
+      mesh.scale.set(width, height, 1);
+    }
+    mesh.updateMatrix();
+    mesh.updateMatrixWorld(true);
+  };
+
+  function setIntensity(value) {
+    const next = clamp(value, MIN_INTENSITY, MAX_INTENSITY);
+    material.uniforms.uIntensity.value = next;
+  }
+
+  function getIntensity() {
+    return material.uniforms.uIntensity.value;
+  }
+
+  function update({ delta = 0, elapsedTime } = {}) {
+    if (Number.isFinite(elapsedTime)) {
+      elapsed = elapsedTime;
+    } else if (Number.isFinite(delta)) {
+      elapsed += delta;
+    }
+    material.uniforms.uTime.value = elapsed;
+  }
+
+  function dispose() {
+    if (mesh.parent) {
+      mesh.parent.remove(mesh);
+    }
+    geometry.dispose();
+    material.dispose();
+  }
+
+  return {
+    mesh,
+    setIntensity,
+    getIntensity,
+    update,
+    dispose,
+  };
+}
+
+export function clampRaindropOverlayIntensity(value) {
+  return clamp(value, MIN_INTENSITY, MAX_INTENSITY);
+}

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -1,6 +1,10 @@
 import { createAuroraRibbonEmitter } from '../../rendering/particles/aurora-effects.js';
 import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain.js';
 import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
+import {
+  clampRaindropOverlayIntensity,
+  createRaindropOverlay,
+} from '../../rendering/effects/raindrop-overlay.js';
 import { createWeatherAudioController } from '../../audio/weather-audio.js';
 import { createWeatherDebugOverlay } from '../../ui/weather-debug-overlay.js';
 
@@ -76,6 +80,9 @@ const PRECIPITATION_SPAWN_MAX_RETRIES = 2;
 const MIN_WEATHER_DURATION_SECONDS = 30;
 const DEFAULT_BIOME_WEATHER_DURATION = { min: 180, max: 420 };
 const ROTATION_HARNESS_TAG = 'weather-rotation-harness';
+const RAIN_OVERLAY_INTENSITY_MIN = 0.18;
+const RAIN_OVERLAY_INTENSITY_MAX = 1.1;
+const RAIN_OVERLAY_INTENSITY_SCALE = 0.55;
 
 export const DEFAULT_BIOME_WEATHER_ROTATION = Object.freeze([
   {
@@ -219,6 +226,15 @@ function normaliseAuroraEffect(weather, effect) {
   };
 }
 
+function resolveRainOverlayIntensity(precipitation) {
+  if (!precipitation) {
+    return 0;
+  }
+  const base = Number.isFinite(precipitation.intensity) ? precipitation.intensity : 0;
+  const scaled = clamp(base * RAIN_OVERLAY_INTENSITY_SCALE, RAIN_OVERLAY_INTENSITY_MIN, RAIN_OVERLAY_INTENSITY_MAX);
+  return clampRaindropOverlayIntensity(scaled);
+}
+
 export function createWeatherManager({
   scene,
   particleSystem,
@@ -255,6 +271,13 @@ export function createWeatherManager({
   let needsEffectRefresh = true;
 
   let overlayUi = null;
+  let raindropOverlay = null;
+  const raindropOverlayState = {
+    baseActive: false,
+    baseIntensity: 0,
+    manualEnabled: null,
+    manualIntensity: null,
+  };
 
   const ensureWeatherState = () => {
     if (!scene) {
@@ -304,6 +327,17 @@ export function createWeatherManager({
     if (!Number.isFinite(state.precipitationActiveParticles)) {
       state.precipitationActiveParticles = 0;
     }
+    if (!state.raindropOverlay) {
+      state.raindropOverlay = {
+        baseActive: false,
+        baseIntensity: 0,
+        manualEnabled: null,
+        manualIntensity: null,
+        enabled: false,
+        intensity: 0,
+        visible: false,
+      };
+    }
     if (!Array.isArray(state.pendingPrecipitationRetries)) {
       state.pendingPrecipitationRetries = [];
     }
@@ -321,6 +355,140 @@ export function createWeatherManager({
       };
     }
     return state;
+  };
+
+  const updateRaindropOverlayMetadata = () => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    const overlay = state.raindropOverlay || (state.raindropOverlay = {});
+    const targetIntensity = clampRaindropOverlayIntensity(
+      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity,
+    );
+    const manualEnabled = raindropOverlayState.manualEnabled;
+    const baseActive = raindropOverlayState.baseActive;
+    overlay.baseActive = baseActive;
+    overlay.baseIntensity = raindropOverlayState.baseIntensity;
+    overlay.manualEnabled = manualEnabled;
+    overlay.manualIntensity = raindropOverlayState.manualIntensity;
+    overlay.enabled = Boolean((manualEnabled ?? baseActive) && targetIntensity > 0);
+    overlay.intensity = raindropOverlay?.getIntensity?.() ?? targetIntensity;
+    overlay.visible = Boolean(raindropOverlay);
+  };
+
+  const ensureRaindropOverlayEffect = (intensity) => {
+    if (raindropOverlay || !scene) {
+      if (raindropOverlay && Number.isFinite(intensity)) {
+        raindropOverlay.setIntensity(intensity);
+      }
+      return raindropOverlay;
+    }
+    const overlay = createRaindropOverlay({ intensity });
+    if (!overlay?.mesh) {
+      return null;
+    }
+    overlay.mesh.visible = true;
+    scene.add(overlay.mesh);
+    raindropOverlay = overlay;
+    updateRaindropOverlayMetadata();
+    return raindropOverlay;
+  };
+
+  const disposeRaindropOverlayEffect = () => {
+    if (!raindropOverlay) {
+      return;
+    }
+    try {
+      raindropOverlay.dispose();
+    } catch (error) {
+      console.warn('Failed to dispose raindrop overlay effect:', error);
+    }
+    raindropOverlay = null;
+    updateRaindropOverlayMetadata();
+  };
+
+  const syncRaindropOverlay = () => {
+    const manualEnabled = raindropOverlayState.manualEnabled;
+    const baseActive = raindropOverlayState.baseActive;
+    const shouldShow = manualEnabled !== null ? manualEnabled : baseActive;
+    const intensityTarget = clampRaindropOverlayIntensity(
+      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity,
+    );
+    if (!shouldShow || intensityTarget <= 0) {
+      if (raindropOverlay) {
+        disposeRaindropOverlayEffect();
+      } else {
+        updateRaindropOverlayMetadata();
+      }
+      return;
+    }
+    const overlay = ensureRaindropOverlayEffect(intensityTarget);
+    if (overlay) {
+      overlay.setIntensity(intensityTarget);
+      if (overlay.mesh) {
+        overlay.mesh.visible = true;
+      }
+    }
+    updateRaindropOverlayMetadata();
+  };
+
+  const setRaindropOverlayBaseState = ({ active, intensity }) => {
+    const nextActive = Boolean(active);
+    const nextIntensity = Number.isFinite(intensity)
+      ? clampRaindropOverlayIntensity(intensity)
+      : 0;
+    if (
+      raindropOverlayState.baseActive === nextActive &&
+      raindropOverlayState.baseIntensity === nextIntensity
+    ) {
+      return;
+    }
+    raindropOverlayState.baseActive = nextActive;
+    raindropOverlayState.baseIntensity = nextIntensity;
+    syncRaindropOverlay();
+  };
+
+  const setRaindropOverlayManualEnabled = (value) => {
+    const next = value === null || value === undefined ? null : Boolean(value);
+    if (raindropOverlayState.manualEnabled === next) {
+      return;
+    }
+    raindropOverlayState.manualEnabled = next;
+    syncRaindropOverlay();
+  };
+
+  const setRaindropOverlayManualIntensity = (value) => {
+    let next = null;
+    if (value !== null && value !== undefined) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return;
+      }
+      next = clampRaindropOverlayIntensity(numeric);
+    }
+    if (raindropOverlayState.manualIntensity === next) {
+      return;
+    }
+    raindropOverlayState.manualIntensity = next;
+    syncRaindropOverlay();
+  };
+
+  const getRaindropOverlayState = () => {
+    const manualEnabled = raindropOverlayState.manualEnabled;
+    const baseActive = raindropOverlayState.baseActive;
+    const intensity = raindropOverlay?.getIntensity?.() ?? clampRaindropOverlayIntensity(
+      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity,
+    );
+    return {
+      enabled: Boolean((manualEnabled ?? baseActive) && intensity > 0),
+      visible: Boolean(raindropOverlay),
+      intensity,
+      baseActive,
+      baseIntensity: raindropOverlayState.baseIntensity,
+      manualEnabled,
+      manualIntensity: raindropOverlayState.manualIntensity,
+    };
   };
 
   const syncEmitterState = () => {
@@ -773,6 +941,7 @@ export function createWeatherManager({
       stopAttachmentHandle(attachment);
     }
     activeParticleEffects.length = 0;
+    disposeRaindropOverlayEffect();
     syncEmitterState();
     clearPendingPrecipitationRetries();
   };
@@ -951,9 +1120,17 @@ export function createWeatherManager({
     }
     const resolved = resolveWeatherEffects(activeWeather);
     const precipitation = normalisePrecipitationEffect(activeWeather, resolved.precipitation);
+    let overlayBaseState = { active: false, intensity: 0 };
     if (precipitation) {
       spawnPrecipitationEffect(precipitation, context);
+      if (precipitation.type === 'rain') {
+        overlayBaseState = {
+          active: true,
+          intensity: resolveRainOverlayIntensity(precipitation),
+        };
+      }
     }
+    setRaindropOverlayBaseState(overlayBaseState);
     const aurora = normaliseAuroraEffect(activeWeather, resolved.aurora);
     if (aurora) {
       spawnAuroraEffects(aurora, context);
@@ -1349,6 +1526,9 @@ export function createWeatherManager({
     processPendingPrecipitationRetries({ ...context, elapsedTime: lastElapsedTime });
     updateAnchoredEffects({ ...context, elapsedTime: lastElapsedTime });
     validatePrecipitationHandles({ ...context, elapsedTime: lastElapsedTime });
+    if (raindropOverlay) {
+      raindropOverlay.update({ delta, elapsedTime: lastElapsedTime });
+    }
     updateRotationHarnessTick({ elapsedTime: lastElapsedTime });
     tickAccumulator += Number.isFinite(delta) ? delta : 0;
     while (tickAccumulator >= DEFAULT_TICK_INTERVAL) {
@@ -1387,6 +1567,7 @@ export function createWeatherManager({
   };
 
   applyWeatherEffects(activeWeather);
+  updateRaindropOverlayMetadata();
   registerOverlay();
 
   return {
@@ -1400,6 +1581,9 @@ export function createWeatherManager({
     startRotationHarness,
     stopRotationHarness,
     getRotationHarnessStatus,
+    getRaindropOverlayState,
+    setRaindropOverlayManualEnabled,
+    setRaindropOverlayManualIntensity,
     dispose,
   };
 }


### PR DESCRIPTION
## Summary
- add a camera-locked raindrop overlay effect and expose intensity helpers
- hook the weather manager to create/dispose the overlay with rain presets and publish manual controls
- extend the developer console overlay subcommand and document the new tooling in the remediation plan

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf979f2f4832a8c3271d91bf27b5a