### PR TITLE
Retune rain emitter for daylight visibility

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -53,6 +53,16 @@ Please continue appending follow-up findings or configuration changes here whene
 - Switched the raindrop shader to additive blending with a `0.55` opacity multiplier to increase contrast when precipitation particles are occluded, providing a clearer fallback cue for QA when rain volumes underperform.【F:src/rendering/effects/raindrop-overlay.js†L1-L86】
 - Added a unit test that locks the overlay intensity maths to the new tuning so future adjustments must update this plan and QA expectations in tandem—treat the stronger overlay as the fallback visibility requirement during manual checks.【F:src/world/__tests__/weather-manager.test.js†L1-L138】
 
+## 2025-09 High-Contrast Rain Refresh
+- Reworked `createWeatherRainEmitter` with thicker billboards, a dark-to-ice-blue color ramp, and normal blending so rain streaks retain contrast during daylight scenes.【F:src/rendering/particles/weather-rain.js†L9-L55】
+- Increased spawn and lifetime budgets to keep at least 30 active particles during the regression harness and renamed the debug label to `WeatherRainEmitter/HighContrast` so tooling can confirm the look is active.【F:src/rendering/particles/weather-rain.js†L15-L55】【F:src/world/__tests__/weather-manager.test.js†L170-L203】
+- Updated the regression test to assert both the higher particle floor and the high-contrast label—future changes must update this plan *and* the test expectations together to avoid silent drift.【F:src/world/__tests__/weather-manager.test.js†L170-L203】
+- **QA checklist:**
+  - Trigger `/weather misty_rain` (or cycle via the harness) at midday lighting and verify streaks remain visible against bright terrain.
+  - Confirm the weather debug overlay reports the `WeatherRainEmitter/HighContrast` label and at least 30 active particles once the emitter stabilises.
+  - Re-run `/weather debug` to ensure the darker-core ramp remains readable when the overlay is disabled, noting any deviations here.
+- **Reminder:** When retuning rain visuals or thresholds, update this section, the automated test expectations, and any overlay heuristics so QA retains a single source of truth.
+
 ## Work Orders
 1. **Gameplay-driven rotation**
    - Sample the player’s biome each frame (reusing the `sampleBiomeAt` helper from `/weather status`) and resolve the preset rotation with `resolveBiomeWeatherRotation`, storing timing metadata per biome.【F:src/player/dev-commands.js†L1532-L1562】【F:src/world/weather/weather-manager.js†L76-L127】

--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -13,41 +13,42 @@ export function createWeatherRainEmitter({
   const density = clamp(intensity, 0.2, 2.4);
   const spawnRadius = Math.max(6, radius);
   const emitter = createGpuBillboardEmitter({
-    spawnRate: Math.min(420 * density, 720),
-    maxParticles: Math.ceil(Math.min(660 * density, 880)),
-    lifetime: { min: 1.2, max: 1.8 },
-    baseColor: '#d0f3ff',
+    spawnRate: Math.min(560 * density, 960),
+    maxParticles: Math.ceil(Math.min(900 * density, 1180)),
+    lifetime: { min: 1.35, max: 2.25 },
+    baseColor: '#204c7a',
     colorRamp: [
-      { time: 0, color: '#66c4ff' },
-      { time: 0.35, color: '#aee6ff' },
-      { time: 0.75, color: '#e6f9ff' },
-      { time: 1, color: '#ffffff' },
+      { time: 0, color: '#081629' },
+      { time: 0.18, color: '#0f2f57' },
+      { time: 0.45, color: '#1e6bc0' },
+      { time: 0.78, color: '#6faef5' },
+      { time: 1, color: '#d6ecff' },
     ],
     sizeOverLifetime: [
-      { time: 0, size: 1.2 },
-      { time: 0.2, size: 1.05 },
-      { time: 0.75, size: 0.95 },
-      { time: 1, size: 0.82 },
+      { time: 0, size: 1.5 },
+      { time: 0.22, size: 1.32 },
+      { time: 0.68, size: 1.08 },
+      { time: 1, size: 0.92 },
     ],
     position: { x: 0, y: heightOffset, z: 0 },
-    positionJitter: { x: spawnRadius, y: 1.1, z: spawnRadius },
-    velocity: { x: 0, y: -11 - density * 3.6, z: 0 },
-    velocityJitter: { x: 0.8, y: 2.4, z: 0.8 },
-    size: { min: 0.16, max: 0.26 },
-    sizeJitter: 0.04,
-    lengthMultiplier: { min: 6, max: 9 },
-    gravity: { x: 0, y: -19.6, z: 0 },
-    drag: 0.16,
-    fadeIn: 0.05,
-    fadeOut: 0.26,
-    opacity: 0.92,
-    blending: THREE.AdditiveBlending,
+    positionJitter: { x: spawnRadius, y: 1.4, z: spawnRadius },
+    velocity: { x: 0, y: -12.4 - density * 4.6, z: 0 },
+    velocityJitter: { x: 0.9, y: 2.9, z: 0.9 },
+    size: { min: 0.22, max: 0.36 },
+    sizeJitter: 0.06,
+    lengthMultiplier: { min: 9, max: 14 },
+    gravity: { x: 0, y: -21.6, z: 0 },
+    drag: 0.12,
+    fadeIn: 0.06,
+    fadeOut: 0.34,
+    opacity: 0.94,
+    blending: THREE.NormalBlending,
     depthWrite: false,
-    renderOrder: 5,
+    renderOrder: 4,
   });
-  emitter.debugLabel = 'WeatherRainEmitter';
+  emitter.debugLabel = 'WeatherRainEmitter/HighContrast';
   emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 };
-  emitter.weatherUpdateInterval = 0.16;
+  emitter.weatherUpdateInterval = 0.12;
   emitter.weatherMinAnchorDistance = Math.max(spawnRadius * 0.2, 1.6);
   return emitter;
 }

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -290,9 +290,10 @@ test('rain preset spawns active particles with the real particle system', () => 
 
     let elapsedTime = 0;
     let peakWeatherParticles = 0;
+    let observedHighContrastLabel = false;
 
     const frameDelta = 1 / 60;
-    const minimumParticles = 18;
+    const minimumParticles = 30;
     for (let frame = 0; frame < 300; frame += 1) {
       elapsedTime += frameDelta;
       manager.update({ delta: frameDelta, elapsedTime });
@@ -303,6 +304,9 @@ test('rain preset spawns active particles with the real particle system', () => 
         typeof emitter.label === 'string' && emitter.label.toLowerCase().includes('weather'),
       );
       if (weatherEmitter) {
+        if (weatherEmitter.label.includes('HighContrast')) {
+          observedHighContrastLabel = true;
+        }
         const activeParticles = Number(weatherEmitter.activeParticles) || 0;
         if (activeParticles > peakWeatherParticles) {
           peakWeatherParticles = activeParticles;
@@ -316,6 +320,10 @@ test('rain preset spawns active particles with the real particle system', () => 
     assert.ok(
       peakWeatherParticles >= minimumParticles,
       `expected real weather emitter to accumulate at least ${minimumParticles} active particles after ticking the system (received ${peakWeatherParticles})`,
+    );
+    assert.ok(
+      observedHighContrastLabel,
+      'expected live weather emitter debug label to advertise the high-contrast tuning',
     );
   } finally {
     particleSystem.dispose();


### PR DESCRIPTION
## Summary
- retune the rain GPU billboard emitter with a darker ramp, thicker streaks, and higher budgets so daylight rain stands out
- raise the end-to-end weather regression expectations to the new particle floor and label the high-contrast emitter in debug output
- document the updated look and QA checklist in the weather remediation plan with reminders to keep tests and docs in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db0311d458832a8cc172de72336725