### PR TITLE
Add bright streak rain shader and QA overrides

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -54,14 +54,25 @@ Please continue appending follow-up findings or configuration changes here whene
 - Added a unit test that locks the overlay intensity maths to the new tuning so future adjustments must update this plan and QA expectations in tandem—treat the stronger overlay as the fallback visibility requirement during manual checks.【F:src/world/__tests__/weather-manager.test.js†L1-L138】
 
 ## 2025-09 High-Contrast Rain Refresh
-- Reworked `createWeatherRainEmitter` with thicker billboards, a dark-to-ice-blue color ramp, and normal blending so rain streaks retain contrast during daylight scenes.【F:src/rendering/particles/weather-rain.js†L9-L55】
-- Increased spawn and lifetime budgets to keep at least 30 active particles during the regression harness and renamed the debug label to `WeatherRainEmitter/HighContrast` so tooling can confirm the look is active.【F:src/rendering/particles/weather-rain.js†L15-L55】【F:src/world/__tests__/weather-manager.test.js†L170-L203】
-- Updated the regression test to assert both the higher particle floor and the high-contrast label—future changes must update this plan *and* the test expectations together to avoid silent drift.【F:src/world/__tests__/weather-manager.test.js†L170-L203】
-- **QA checklist:**
+> _Historical note:_ superseded by the 2025-10 bright-streak shader but retained here so we remember why the earlier pass existed.
+- Reworked `createWeatherRainEmitter` with thicker billboards, a dark-to-ice-blue color ramp, and normal blending so rain streaks retain contrast during daylight scenes.【F:src/rendering/particles/weather-rain.js†L1-L92】
+- Increased spawn and lifetime budgets to keep at least 30 active particles during the regression harness and renamed the debug label to `WeatherRainEmitter/HighContrast` so tooling can confirm the look is active.【F:src/rendering/particles/weather-rain.js†L1-L92】【F:src/world/__tests__/weather-manager.test.js†L160-L230】
+- Updated the regression test to assert both the higher particle floor and the high-contrast label—future changes must update this plan *and* the test expectations together to avoid silent drift.【F:src/world/__tests__/weather-manager.test.js†L160-L230】
+- **QA checklist (legacy):**
   - Trigger `/weather misty_rain` (or cycle via the harness) at midday lighting and verify streaks remain visible against bright terrain.
   - Confirm the weather debug overlay reports the `WeatherRainEmitter/HighContrast` label and at least 30 active particles once the emitter stabilises.
   - Re-run `/weather debug` to ensure the darker-core ramp remains readable when the overlay is disabled, noting any deviations here.
 - **Reminder:** When retuning rain visuals or thresholds, update this section, the automated test expectations, and any overlay heuristics so QA retains a single source of truth.
+
+## 2025-10 Bright-Streak Rain Shader
+- Swapped the rain fragment shader to `weather-rain-streak.glsl.js`, introducing wind-tilt, streak-noise, and highlight-width uniforms so we can tune sheen and gusts without rebuilding the emitter.【F:src/rendering/particles/weather-rain.js†L1-L109】【F:src/rendering/shaders/weather-rain-streak.glsl.js†L1-L54】
+- `createWeatherRainEmitter` now feeds those uniforms, thickens the base billboard width to ~0.35–0.45 m, and renames the debug label to `WeatherRainEmitter/BrightStreakPass` to match the new look.【F:src/rendering/particles/weather-rain.js†L13-L109】【F:src/world/__tests__/weather-manager.test.js†L206-L231】
+- Manual precipitation overrides (`scene.userData.weather.manualOverrides.precipitation`) can force intensity or wind parameters at runtime so `/weather` QA scripts can probe edge cases; the manager keeps snapshots in emitter diagnostics.【F:src/world/weather/weather-manager.js†L300-L430】【F:src/world/weather/weather-manager.js†L930-L1074】【F:src/world/__tests__/weather-manager.test.js†L120-L205】
+- Regression coverage now locks the bright-streak label, a 34-particle floor, and uniform override behaviour so shader tweaks stay visible in CI.【F:src/world/__tests__/weather-manager.test.js†L198-L264】
+- **QA checklist:**
+  - Trigger `/weather misty_rain` under daylight; ensure the overlay reports `WeatherRainEmitter/BrightStreakPass` with ≥34 active particles after stabilisation.【F:src/world/__tests__/weather-manager.test.js†L206-L231】
+  - Use `/weather` overrides (or edit `scene.userData.weather.manualOverrides.precipitation`) to test gust extremes—verify wind tilt, streak noise, and highlight width respond live via the overlay and rain visuals.【F:src/world/weather/weather-manager.js†L300-L430】【F:src/world/weather/weather-manager.js†L1012-L1115】
+  - Keep `/weather debug` handy to confirm manual overrides propagate into the emitter summaries (uniform readouts now surface in diagnostics).【F:src/world/weather/weather-manager.js†L1260-L1310】
 
 ## Work Orders
 1. **Gameplay-driven rotation**

--- a/three-demo/src/rendering/particles/gpu-billboard-emitter.js
+++ b/three-demo/src/rendering/particles/gpu-billboard-emitter.js
@@ -241,7 +241,23 @@ function jitterVector(base, jitter, target) {
  * @param {boolean} [options.depthWrite=false] Whether the particles should write to the depth buffer.
  * @param {boolean} [options.depthTest=true] Whether the particles participate in depth testing.
  * @param {number} [options.renderOrder] Optional render order override for the instanced mesh.
- */
+ * @param {(context: {
+ *   THREE: typeof import('three')
+ *   defaultFactory: () => import('three').ShaderMaterial
+ *   options: {
+ *     gravity: import('three').Vector3
+ *     drag: number
+ *     fadeIn: number
+ *     fadeOut: number
+ *     colorRamp: any
+ *     sizeOverLifetime: any
+ *     blending: import('three').Blending | undefined
+ *     depthWrite: boolean | undefined
+ *     depthTest: boolean | undefined
+ *   }
+ * }) => import('three').ShaderMaterial} [options.materialFactory]
+ *   Optional factory to build a custom ShaderMaterial. When omitted, a default billboard material is created.
+*/
 export function createGpuBillboardEmitter(options = {}) {
   const {
     spawnRate = 24,
@@ -266,6 +282,7 @@ export function createGpuBillboardEmitter(options = {}) {
     depthWrite = undefined,
     depthTest = undefined,
     renderOrder = undefined,
+    materialFactory = null,
   } = options
 
   const clampedOpacity = Math.max(0, Math.min(1, opacity))
@@ -373,7 +390,7 @@ export function createGpuBillboardEmitter(options = {}) {
       lifetimeRange.max = Math.max(lifetimeRange.min, lifetimeRange.max)
       gravityVector = resolveVector3(THREE, gravity ?? { x: 0, y: -9.81, z: 0 }, new THREE.Vector3(0, -9.81, 0))
 
-      material = createMaterial(THREE, {
+      const materialOptions = {
         gravity: gravityVector,
         drag,
         fadeIn,
@@ -383,7 +400,22 @@ export function createGpuBillboardEmitter(options = {}) {
         blending,
         depthWrite,
         depthTest,
-      })
+      }
+
+      if (typeof materialFactory === 'function') {
+        const defaultFactory = () => createMaterial(THREE, materialOptions)
+        material = materialFactory({ THREE, defaultFactory, options: materialOptions })
+      } else {
+        material = null
+      }
+
+      if (!material) {
+        material = createMaterial(THREE, materialOptions)
+      }
+
+      if (material && typeof material === 'object') {
+        material.uniformsNeedUpdate = true
+      }
 
       const baseGeometry = getQuadGeometry(THREE)
 

--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -1,17 +1,84 @@
-import * as THREE from 'three';
-import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js';
+import * as THREE from 'three'
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js'
+import { weatherRainStreakFragmentShader } from '../shaders/weather-rain-streak.glsl.js'
 
 function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
+  return Math.min(Math.max(value, min), max)
 }
 
 export function createWeatherRainEmitter({
   intensity = 0.6,
   radius = 12,
   heightOffset = 14,
+  windTilt = null,
+  streakNoise = null,
+  highlightWidth = null,
 } = {}) {
-  const density = clamp(intensity, 0.2, 2.4);
-  const spawnRadius = Math.max(6, radius);
+  const density = clamp(intensity, 0.2, 2.4)
+  const normalized = clamp((density - 0.2) / (2.4 - 0.2), 0, 1)
+  const spawnRadius = Math.max(6, radius)
+  const baseWindTilt = THREE.MathUtils.lerp(0.045, 0.28, normalized)
+  const baseStreakNoise = THREE.MathUtils.lerp(0.38, 0.9, normalized)
+  const baseHighlightWidth = THREE.MathUtils.lerp(0.22, 0.095, normalized)
+
+  const uniformState = {
+    windTilt: Number.isFinite(windTilt) ? windTilt : baseWindTilt,
+    streakNoise: Number.isFinite(streakNoise) ? streakNoise : baseStreakNoise,
+    highlightWidth: Number.isFinite(highlightWidth)
+      ? Math.max(0.02, highlightWidth)
+      : baseHighlightWidth,
+  }
+
+  const baseUniforms = {
+    windTilt: baseWindTilt,
+    streakNoise: baseStreakNoise,
+    highlightWidth: baseHighlightWidth,
+  }
+
+  let materialRef = null
+
+  const applyUniforms = () => {
+    if (!materialRef) {
+      return
+    }
+    if (materialRef.uniforms.uWindTilt) {
+      materialRef.uniforms.uWindTilt.value = uniformState.windTilt
+    }
+    if (materialRef.uniforms.uStreakNoise) {
+      materialRef.uniforms.uStreakNoise.value = uniformState.streakNoise
+    }
+    if (materialRef.uniforms.uHighlightWidth) {
+      materialRef.uniforms.uHighlightWidth.value = uniformState.highlightWidth
+    }
+    materialRef.uniformsNeedUpdate = true
+    materialRef.needsUpdate = true
+  }
+
+  const setUniformOverrides = (overrides = {}) => {
+    if (overrides.windTilt !== undefined) {
+      if (overrides.windTilt === null) {
+        uniformState.windTilt = baseUniforms.windTilt
+      } else if (Number.isFinite(overrides.windTilt)) {
+        uniformState.windTilt = overrides.windTilt
+      }
+    }
+    if (overrides.streakNoise !== undefined) {
+      if (overrides.streakNoise === null) {
+        uniformState.streakNoise = baseUniforms.streakNoise
+      } else if (Number.isFinite(overrides.streakNoise)) {
+        uniformState.streakNoise = overrides.streakNoise
+      }
+    }
+    if (overrides.highlightWidth !== undefined) {
+      if (overrides.highlightWidth === null) {
+        uniformState.highlightWidth = baseUniforms.highlightWidth
+      } else if (Number.isFinite(overrides.highlightWidth)) {
+        uniformState.highlightWidth = Math.max(0.02, overrides.highlightWidth)
+      }
+    }
+    applyUniforms()
+  }
+
   const emitter = createGpuBillboardEmitter({
     spawnRate: Math.min(560 * density, 960),
     maxParticles: Math.ceil(Math.min(900 * density, 1180)),
@@ -34,8 +101,8 @@ export function createWeatherRainEmitter({
     positionJitter: { x: spawnRadius, y: 1.4, z: spawnRadius },
     velocity: { x: 0, y: -12.4 - density * 4.6, z: 0 },
     velocityJitter: { x: 0.9, y: 2.9, z: 0.9 },
-    size: { min: 0.22, max: 0.36 },
-    sizeJitter: 0.06,
+    size: { min: 0.35, max: 0.45 },
+    sizeJitter: 0.08,
     lengthMultiplier: { min: 9, max: 14 },
     gravity: { x: 0, y: -21.6, z: 0 },
     drag: 0.12,
@@ -45,10 +112,30 @@ export function createWeatherRainEmitter({
     blending: THREE.NormalBlending,
     depthWrite: false,
     renderOrder: 4,
-  });
-  emitter.debugLabel = 'WeatherRainEmitter/HighContrast';
-  emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 };
-  emitter.weatherUpdateInterval = 0.12;
-  emitter.weatherMinAnchorDistance = Math.max(spawnRadius * 0.2, 1.6);
-  return emitter;
+    materialFactory: ({ defaultFactory }) => {
+      const material = defaultFactory()
+      material.fragmentShader = weatherRainStreakFragmentShader
+      material.uniforms.uWindTilt = { value: uniformState.windTilt }
+      material.uniforms.uStreakNoise = { value: uniformState.streakNoise }
+      material.uniforms.uHighlightWidth = { value: uniformState.highlightWidth }
+      materialRef = material
+      applyUniforms()
+      return material
+    },
+  })
+  emitter.debugLabel = 'WeatherRainEmitter/BrightStreakPass'
+  emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 }
+  emitter.weatherUpdateInterval = 0.12
+  emitter.weatherMinAnchorDistance = Math.max(spawnRadius * 0.2, 1.6)
+  emitter.weatherWind = {
+    base: { ...baseUniforms },
+    current: () => ({ ...uniformState }),
+  }
+  emitter.getWeatherRainShaderUniforms = () => ({ ...uniformState })
+  emitter.getWeatherRainShaderBaseUniforms = () => ({ ...baseUniforms })
+  emitter.setWeatherRainShaderUniforms = (overrides) => {
+    setUniformOverrides(overrides)
+  }
+
+  return emitter
 }

--- a/three-demo/src/rendering/shaders/gpu-particle-vertex.glsl.js
+++ b/three-demo/src/rendering/shaders/gpu-particle-vertex.glsl.js
@@ -21,6 +21,8 @@ uniform vec2 uSizeStops[8];
 uniform int uSizeStopCount;
 
 varying vec4 vColor;
+varying vec2 vLocalUv;
+varying float vNormalizedAge;
 
 vec3 integrateMotion(vec3 origin, vec3 velocity, vec3 gravity, float drag, float age) {
   vec3 displacement;
@@ -79,6 +81,7 @@ void main() {
   float lifetime = max(aLifetime.y, 0.0001);
   float age = max(uTime - spawnTime, 0.0);
   float normalizedAge = clamp(age / lifetime, 0.0, 1.0);
+  vNormalizedAge = normalizedAge;
 
   vec3 center = integrateMotion(aOrigin, aVelocity, uGravity, uDrag, age);
 
@@ -92,6 +95,7 @@ void main() {
 
   vec3 rampColor = sampleColorRamp(normalizedAge);
   vColor = vec4(rampColor * aColor.rgb, alpha);
+  vLocalUv = position.xy + 0.5;
 
   vec3 billboardRight = normalize(vec3(modelViewMatrix[0][0], modelViewMatrix[1][0], modelViewMatrix[2][0]));
   vec3 billboardUp = normalize(vec3(modelViewMatrix[0][1], modelViewMatrix[1][1], modelViewMatrix[2][1]));

--- a/three-demo/src/rendering/shaders/weather-rain-streak.glsl.js
+++ b/three-demo/src/rendering/shaders/weather-rain-streak.glsl.js
@@ -1,0 +1,53 @@
+export const weatherRainStreakFragmentShader = /* glsl */ `
+precision mediump float;
+
+uniform float uWindTilt;
+uniform float uStreakNoise;
+uniform float uHighlightWidth;
+
+varying vec4 vColor;
+varying vec2 vLocalUv;
+varying float vNormalizedAge;
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float streakNoise(vec2 uv, float travel) {
+  vec2 cell = floor(vec2(uv.x * 18.0, uv.y * 42.0 + travel));
+  float base = hash(cell + travel);
+  float head = fract(uv.y * 18.0 + base * 6.0 + travel * 0.5);
+  float sparkle = smoothstep(0.65, 0.1, head);
+  return mix(base, sparkle, 0.75);
+}
+
+float streakMask(float offset, float highlightWidth) {
+  float core = smoothstep(0.85, 0.0, abs(offset));
+  float highlight = exp(-pow(offset / max(highlightWidth, 0.02), 2.0));
+  return clamp(core + highlight * 1.4, 0.0, 1.6);
+}
+
+void main() {
+  if (vColor.a <= 0.0001) {
+    discard;
+  }
+
+  vec2 uv = vLocalUv;
+  float tilt = uWindTilt;
+  float slantedX = (uv.x - 0.5) + tilt * (1.0 - uv.y);
+  float highlightWidth = max(uHighlightWidth, 0.025);
+  float travel = vNormalizedAge * 12.0;
+  float noiseSample = streakNoise(uv, travel + uStreakNoise * 4.0);
+
+  float streak = streakMask(slantedX, highlightWidth);
+  float taper = smoothstep(1.0, 0.25, uv.y);
+  float shimmer = smoothstep(0.15, 0.95, noiseSample + streak * uStreakNoise);
+  float body = clamp(streak * (0.6 + noiseSample * 0.5), 0.0, 1.2);
+
+  float brightness = clamp(body * 0.9 + shimmer * 0.75, 0.0, 1.75);
+  vec3 color = vColor.rgb * (0.6 + brightness);
+  float alpha = vColor.a * clamp(body * 0.85 + shimmer * 0.45, 0.0, 1.0) * taper;
+
+  gl_FragColor = vec4(color, alpha);
+}
+`;

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -187,6 +187,50 @@ test('failed precipitation spawns are recorded for diagnostics', () => {
   assert.equal(pendingRetry.reason, 'no_handle');
 });
 
+test('manual precipitation overrides adjust rain uniforms', () => {
+  let capturedEmitter = null;
+  const { manager, scene } = createManager({
+    emitImplementation: (emitter) => {
+      capturedEmitter = emitter;
+      return {
+        stop() {},
+        getActiveParticleCount() {
+          return 42;
+        },
+      };
+    },
+  });
+
+  const state = scene.userData.weather;
+  assert.ok(state?.manualOverrides?.precipitation, 'expected precipitation manual overrides to exist');
+
+  state.manualOverrides.precipitation.windTilt = 0.31;
+  state.manualOverrides.precipitation.streakNoise = 0.72;
+  state.manualOverrides.precipitation.highlightWidth = 0.12;
+  state.manualOverrides.precipitation.intensity = 0.95;
+
+  manager.setWeather('misty_rain');
+  manager.update({ delta: 0.05, elapsedTime: 0.5 });
+
+  assert.ok(capturedEmitter, 'expected precipitation emitter to spawn with manual overrides');
+  let uniforms = capturedEmitter.getWeatherRainShaderUniforms?.();
+  assert.ok(uniforms, 'expected rain emitter to expose shader uniforms');
+  assert.ok(approxEqual(uniforms.windTilt, 0.31, 1e-4));
+  assert.ok(approxEqual(uniforms.streakNoise, 0.72, 1e-4));
+  assert.ok(approxEqual(uniforms.highlightWidth, 0.12, 1e-4));
+
+  state.manualOverrides.precipitation.windTilt = 0.42;
+  state.manualOverrides.precipitation.streakNoise = 0.86;
+  state.manualOverrides.precipitation.highlightWidth = 0.18;
+
+  manager.update({ delta: 0.05, elapsedTime: 0.55 });
+
+  uniforms = capturedEmitter.getWeatherRainShaderUniforms?.();
+  assert.ok(approxEqual(uniforms.windTilt, 0.42, 1e-4));
+  assert.ok(approxEqual(uniforms.streakNoise, 0.86, 1e-4));
+  assert.ok(approxEqual(uniforms.highlightWidth, 0.18, 1e-4));
+});
+
 test('precipitation spawn retries recover after missing handles', () => {
   let emitCount = 0;
   const handles = [null, null, { stop() {}, getActiveParticleCount() { return 12; } }];
@@ -290,10 +334,10 @@ test('rain preset spawns active particles with the real particle system', () => 
 
     let elapsedTime = 0;
     let peakWeatherParticles = 0;
-    let observedHighContrastLabel = false;
+    let observedBrightStreakLabel = false;
 
     const frameDelta = 1 / 60;
-    const minimumParticles = 30;
+    const minimumParticles = 34;
     for (let frame = 0; frame < 300; frame += 1) {
       elapsedTime += frameDelta;
       manager.update({ delta: frameDelta, elapsedTime });
@@ -304,8 +348,8 @@ test('rain preset spawns active particles with the real particle system', () => 
         typeof emitter.label === 'string' && emitter.label.toLowerCase().includes('weather'),
       );
       if (weatherEmitter) {
-        if (weatherEmitter.label.includes('HighContrast')) {
-          observedHighContrastLabel = true;
+        if (weatherEmitter.label.includes('BrightStreakPass')) {
+          observedBrightStreakLabel = true;
         }
         const activeParticles = Number(weatherEmitter.activeParticles) || 0;
         if (activeParticles > peakWeatherParticles) {
@@ -322,8 +366,8 @@ test('rain preset spawns active particles with the real particle system', () => 
       `expected real weather emitter to accumulate at least ${minimumParticles} active particles after ticking the system (received ${peakWeatherParticles})`,
     );
     assert.ok(
-      observedHighContrastLabel,
-      'expected live weather emitter debug label to advertise the high-contrast tuning',
+      observedBrightStreakLabel,
+      'expected live weather emitter debug label to advertise the bright streak pass',
     );
   } finally {
     particleSystem.dispose();

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -341,6 +341,25 @@ export function createWeatherManager({
     if (!Array.isArray(state.pendingPrecipitationRetries)) {
       state.pendingPrecipitationRetries = [];
     }
+    if (!state.manualOverrides) {
+      state.manualOverrides = {};
+    }
+    if (!state.manualOverrides.precipitation) {
+      state.manualOverrides.precipitation = {};
+    }
+    const precipitationOverrides = state.manualOverrides.precipitation;
+    if (!('intensity' in precipitationOverrides)) {
+      precipitationOverrides.intensity = null;
+    }
+    if (!('windTilt' in precipitationOverrides)) {
+      precipitationOverrides.windTilt = null;
+    }
+    if (!('streakNoise' in precipitationOverrides)) {
+      precipitationOverrides.streakNoise = null;
+    }
+    if (!('highlightWidth' in precipitationOverrides)) {
+      precipitationOverrides.highlightWidth = null;
+    }
     if (!state.rotationHarness) {
       state.rotationHarness = {
         active: false,
@@ -375,6 +394,32 @@ export function createWeatherManager({
     overlay.enabled = Boolean((manualEnabled ?? baseActive) && targetIntensity > 0);
     overlay.intensity = raindropOverlay?.getIntensity?.() ?? targetIntensity;
     overlay.visible = Boolean(raindropOverlay);
+  };
+
+  const getManualPrecipitationOverrides = () => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return null;
+    }
+    const overrides = state.manualOverrides?.precipitation ?? null;
+    if (!overrides) {
+      return null;
+    }
+    const normalise = (value) => {
+      if (Number.isFinite(value)) {
+        return Number(value);
+      }
+      if (value === null) {
+        return null;
+      }
+      return undefined;
+    };
+    return {
+      intensity: normalise(overrides.intensity),
+      windTilt: normalise(overrides.windTilt),
+      streakNoise: normalise(overrides.streakNoise),
+      highlightWidth: normalise(overrides.highlightWidth),
+    };
   };
 
   const ensureRaindropOverlayEffect = (intensity) => {
@@ -950,17 +995,34 @@ export function createWeatherManager({
     if (!particleSystem || typeof particleSystem.emit !== 'function') {
       return;
     }
+    const manualOverrides = getManualPrecipitationOverrides();
+    const intensityOverride = manualOverrides?.intensity;
+    const appliedIntensity = Number.isFinite(intensityOverride)
+      ? intensityOverride
+      : config.intensity;
     const emitter =
       config.type === 'snow'
         ? createWeatherSnowEmitter({
-            intensity: config.intensity,
+            intensity: appliedIntensity,
             radius: config.radius,
             heightOffset: config.anchorHeight,
           })
         : createWeatherRainEmitter({
-            intensity: config.intensity,
+            intensity: appliedIntensity,
             radius: config.radius,
             heightOffset: config.anchorHeight,
+            windTilt:
+              manualOverrides && manualOverrides.windTilt !== undefined
+                ? manualOverrides.windTilt
+                : undefined,
+            streakNoise:
+              manualOverrides && manualOverrides.streakNoise !== undefined
+                ? manualOverrides.streakNoise
+                : undefined,
+            highlightWidth:
+              manualOverrides && manualOverrides.highlightWidth !== undefined
+                ? manualOverrides.highlightWidth
+                : undefined,
           });
     const handle = particleSystem.emit(emitter);
     if (!handle) {
@@ -1050,7 +1112,7 @@ export function createWeatherManager({
       recordAnchorUpdate(elapsedTime);
     }
     activeParticleEffects.push(attachment);
-    attachment.spawnConfig = { ...config };
+    attachment.spawnConfig = { ...config, intensity: appliedIntensity };
     attachment.spawnAttempt = attempt;
     attachment.spawnElapsedTime = elapsedTime;
     attachment.validationReadyTime = Number.isFinite(elapsedTime)
@@ -1060,7 +1122,96 @@ export function createWeatherManager({
     attachment.validationRetryAfter = null;
     attachment.validationPendingSince = null;
     recordPrecipitationSpawn({ type: config.type, elapsedTime });
+    attachment.appliedIntensity = appliedIntensity;
+    attachment.manualOverrides = manualOverrides;
+    if (typeof emitter.getWeatherRainShaderBaseUniforms === 'function') {
+      attachment.baseRainUniforms = emitter.getWeatherRainShaderBaseUniforms();
+    }
+    if (typeof emitter.getWeatherRainShaderUniforms === 'function') {
+      const uniforms = emitter.getWeatherRainShaderUniforms();
+      if (!attachment.baseRainUniforms) {
+        attachment.baseRainUniforms = { ...uniforms };
+      }
+      attachment.lastAppliedRainOverrides = {
+        windTilt: uniforms?.windTilt,
+        streakNoise: uniforms?.streakNoise,
+        highlightWidth: uniforms?.highlightWidth,
+      };
+    }
     syncEmitterState();
+  };
+
+  const syncPrecipitationUniformOverrides = () => {
+    const state = ensureWeatherState();
+    if (!state) {
+      return;
+    }
+    const overrides = state.manualOverrides?.precipitation ?? null;
+    if (!overrides) {
+      return;
+    }
+    activeParticleEffects.forEach((attachment) => {
+      if (attachment.type !== 'precipitation') {
+        return;
+      }
+      const setter = attachment.emitter?.setWeatherRainShaderUniforms;
+      if (typeof setter !== 'function') {
+        return;
+      }
+      const last = attachment.lastAppliedRainOverrides || {};
+      const updates = {};
+      let changed = false;
+      if (overrides.windTilt !== undefined) {
+        const overrideValue = overrides.windTilt;
+        const target = Number.isFinite(overrideValue)
+          ? overrideValue
+          : overrideValue === null
+          ? null
+          : undefined;
+        if (target !== undefined && target !== last.windTilt) {
+          updates.windTilt = target;
+          changed = true;
+        }
+      }
+      if (overrides.streakNoise !== undefined) {
+        const overrideValue = overrides.streakNoise;
+        const target = Number.isFinite(overrideValue)
+          ? overrideValue
+          : overrideValue === null
+          ? null
+          : undefined;
+        if (target !== undefined && target !== last.streakNoise) {
+          updates.streakNoise = target;
+          changed = true;
+        }
+      }
+      if (overrides.highlightWidth !== undefined) {
+        const overrideValue = overrides.highlightWidth;
+        const target = Number.isFinite(overrideValue)
+          ? overrideValue
+          : overrideValue === null
+          ? null
+          : undefined;
+        if (target !== undefined && target !== last.highlightWidth) {
+          updates.highlightWidth = target;
+          changed = true;
+        }
+      }
+      attachment.manualOverrides = {
+        intensity: overrides.intensity,
+        windTilt: overrides.windTilt,
+        streakNoise: overrides.streakNoise,
+        highlightWidth: overrides.highlightWidth,
+      };
+      if (!changed) {
+        return;
+      }
+      setter.call(attachment.emitter, updates);
+      attachment.lastAppliedRainOverrides = {
+        ...last,
+        ...updates,
+      };
+    });
   };
 
   const spawnAuroraEffects = (config, context) => {
@@ -1287,6 +1438,19 @@ export function createWeatherManager({
             spawnedAt: Number.isFinite(attachment.spawnElapsedTime)
               ? attachment.spawnElapsedTime
               : null,
+            appliedIntensity: Number.isFinite(attachment.appliedIntensity)
+              ? attachment.appliedIntensity
+              : null,
+            manualOverrides: attachment.manualOverrides ?? null,
+            shaderUniforms:
+              typeof attachment.emitter?.getWeatherRainShaderUniforms === 'function'
+                ? attachment.emitter.getWeatherRainShaderUniforms()
+                : null,
+            shaderBase:
+              typeof attachment.emitter?.getWeatherRainShaderBaseUniforms === 'function'
+                ? attachment.emitter.getWeatherRainShaderBaseUniforms()
+                : attachment.baseRainUniforms ?? null,
+            lastAppliedRainOverrides: attachment.lastAppliedRainOverrides ?? null,
           };
         });
       weatherState.precipitationEmitters = precipitationSummaries;
@@ -1525,6 +1689,7 @@ export function createWeatherManager({
     }
     processPendingPrecipitationRetries({ ...context, elapsedTime: lastElapsedTime });
     updateAnchoredEffects({ ...context, elapsedTime: lastElapsedTime });
+    syncPrecipitationUniformOverrides();
     validatePrecipitationHandles({ ...context, elapsedTime: lastElapsedTime });
     if (raindropOverlay) {
       raindropOverlay.update({ delta, elapsedTime: lastElapsedTime });


### PR DESCRIPTION
## Summary
- implement the bright streak rain fragment shader with configurable tilt, noise, and highlight uniforms
- update the GPU billboard emitter, rain emitter, and weather manager to expose manual override hooks and rename the rain pass
- refresh regression tests and weather remediation plan for the new shader label, particle floor, and QA checklist

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db07bdfebc832a8d5603198a3221c1