### PR TITLE
Add parallax rain overlay uniforms and tooling

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -74,6 +74,12 @@ Please continue appending follow-up findings or configuration changes here whene
   - Use `/weather` overrides (or edit `scene.userData.weather.manualOverrides.precipitation`) to test gust extremes—verify wind tilt, streak noise, and highlight width respond live via the overlay and rain visuals.【F:src/world/weather/weather-manager.js†L300-L430】【F:src/world/weather/weather-manager.js†L1012-L1115】
   - Keep `/weather debug` handy to confirm manual overrides propagate into the emitter summaries (uniform readouts now surface in diagnostics).【F:src/world/weather/weather-manager.js†L1260-L1310】
 
+## 2025-11 Parallax Rain Overlay Controls
+- Rebuilt the screen-space raindrop fragment shader with three parallaxed streak layers, wind-driven tilt, and sparkle pulses, exposing uniforms for wind speed, streak density, and sparkle gain so QA can see gust variations even when world particles underperform.【F:src/rendering/effects/raindrop-overlay.js†L1-L192】
+- Weather manager now derives overlay wind/density/sparkle from precipitation configs (with clamps), persists the applied values on `scene.userData.weather.raindropOverlay`, and exposes manual setters for `/weather overlay` to tweak wind and density live.【F:src/world/weather/weather-manager.js†L229-L540】【F:src/world/weather/weather-manager.js†L1267-L1752】
+- `/weather overlay wind|density` commands apply those manual overrides, extend the status readout, and a new regression checks the clamps, metadata persistence, and override clearing so CI guards the documented intensity scale—update this plan alongside future tuning shifts.【F:src/player/dev-commands.js†L1780-L1900】【F:src/world/__tests__/weather-manager.test.js†L132-L268】
+- **Reminder:** keep this section synchronized whenever you touch the overlay shader, uniform maths, or console tooling so QA expectations, metadata snapshots, and tests stay aligned.
+
 ## Work Orders
 1. **Gameplay-driven rotation**
    - Sample the player’s biome each frame (reusing the `sampleBiomeAt` helper from `/weather status`) and resolve the preset rotation with `resolveBiomeWeatherRotation`, storing timing metadata per biome.【F:src/player/dev-commands.js†L1532-L1562】【F:src/world/weather/weather-manager.js†L76-L127】

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1771,7 +1771,10 @@ export function registerDeveloperCommands({
         if (
           typeof weatherManager.getRaindropOverlayState !== 'function' ||
           typeof weatherManager.setRaindropOverlayManualEnabled !== 'function' ||
-          typeof weatherManager.setRaindropOverlayManualIntensity !== 'function'
+          typeof weatherManager.setRaindropOverlayManualIntensity !== 'function' ||
+          typeof weatherManager.setRaindropOverlayManualWindSpeed !== 'function' ||
+          typeof weatherManager.setRaindropOverlayManualStreakDensity !== 'function' ||
+          typeof weatherManager.setRaindropOverlayManualSparkleGain !== 'function'
         ) {
           warn('[weather overlay] Overlay controls are unavailable in this build.');
           return;
@@ -1787,15 +1790,41 @@ export function registerDeveloperCommands({
               : current.manualEnabled
               ? 'manual:on'
               : 'manual:off';
-          const source = current.manualIntensity !== null && current.manualIntensity !== undefined ? 'manual' : 'auto';
+          const source =
+            current.manualIntensity !== null && current.manualIntensity !== undefined
+              ? 'manual'
+              : 'auto';
           const appliedIntensity = Number.isFinite(current.intensity)
             ? current.intensity.toFixed(2)
             : 'n/a';
           const baseIntensity = Number.isFinite(current.baseIntensity)
             ? current.baseIntensity.toFixed(2)
             : 'n/a';
+          const windSource =
+            current.manualWindSpeed !== null && current.manualWindSpeed !== undefined
+              ? 'manual'
+              : 'auto';
+          const streakSource =
+            current.manualStreakDensity !== null && current.manualStreakDensity !== undefined
+              ? 'manual'
+              : 'auto';
+          const sparkleSource =
+            current.manualSparkleGain !== null && current.manualSparkleGain !== undefined
+              ? 'manual'
+              : 'auto';
+          const windSpeed = Number.isFinite(current.windSpeed)
+            ? current.windSpeed.toFixed(2)
+            : 'n/a';
+          const streakDensity = Number.isFinite(current.streakDensity)
+            ? current.streakDensity.toFixed(2)
+            : 'n/a';
+          const sparkleGain = Number.isFinite(current.sparkleGain)
+            ? current.sparkleGain.toFixed(2)
+            : 'n/a';
           info(
-            `${prefix} visible=${current.visible ? 'yes' : 'no'}, enabled=${current.enabled ? 'yes' : 'no'}, mode=${mode}, intensity=${appliedIntensity} (${source}), base=${baseIntensity}.`,
+            `${prefix} visible=${current.visible ? 'yes' : 'no'}, enabled=${
+              current.enabled ? 'yes' : 'no'
+            }, mode=${mode}, intensity=${appliedIntensity} (${source}), base=${baseIntensity}, wind=${windSpeed} (${windSource}), density=${streakDensity} (${streakSource}), sparkle=${sparkleGain} (${sparkleSource}).`,
           );
         };
 
@@ -1809,6 +1838,9 @@ export function registerDeveloperCommands({
         if (action === 'clear') {
           weatherManager.setRaindropOverlayManualEnabled(null);
           weatherManager.setRaindropOverlayManualIntensity(null);
+          weatherManager.setRaindropOverlayManualWindSpeed(null);
+          weatherManager.setRaindropOverlayManualStreakDensity(null);
+          weatherManager.setRaindropOverlayManualSparkleGain(null);
           success('[weather overlay] Cleared manual overrides; overlay returned to auto mode.');
           reportOverlayStatus();
           return;
@@ -1841,7 +1873,7 @@ export function registerDeveloperCommands({
           if (valueToken === undefined) {
             throw new Error('Usage: /weather overlay intensity <value|auto>.');
           }
-          const normalized = valueToken.toLowerCase();
+          const normalized = String(valueToken).toLowerCase();
           if (normalized === 'auto' || normalized === 'default') {
             weatherManager.setRaindropOverlayManualIntensity(null);
             success('[weather overlay] Cleared manual intensity override.');
@@ -1858,8 +1890,52 @@ export function registerDeveloperCommands({
           return;
         }
 
+        if (action === 'wind') {
+          const valueToken = overlayArgs[1];
+          if (valueToken === undefined) {
+            throw new Error('Usage: /weather overlay wind <value|auto>.');
+          }
+          const normalized = String(valueToken).toLowerCase();
+          if (normalized === 'auto' || normalized === 'default') {
+            weatherManager.setRaindropOverlayManualWindSpeed(null);
+            success('[weather overlay] Cleared manual wind override.');
+            reportOverlayStatus();
+            return;
+          }
+          const numeric = Number(valueToken);
+          if (!Number.isFinite(numeric)) {
+            throw new Error('Specify a numeric overlay wind speed (e.g. 1.1) or "auto".');
+          }
+          weatherManager.setRaindropOverlayManualWindSpeed(numeric);
+          success(`[weather overlay] Manual wind speed set to ${numeric.toFixed(2)}.`);
+          reportOverlayStatus();
+          return;
+        }
+
+        if (action === 'density') {
+          const valueToken = overlayArgs[1];
+          if (valueToken === undefined) {
+            throw new Error('Usage: /weather overlay density <value|auto>.');
+          }
+          const normalized = String(valueToken).toLowerCase();
+          if (normalized === 'auto' || normalized === 'default') {
+            weatherManager.setRaindropOverlayManualStreakDensity(null);
+            success('[weather overlay] Cleared manual density override.');
+            reportOverlayStatus();
+            return;
+          }
+          const numeric = Number(valueToken);
+          if (!Number.isFinite(numeric)) {
+            throw new Error('Specify a numeric overlay streak density (e.g. 1.4) or "auto".');
+          }
+          weatherManager.setRaindropOverlayManualStreakDensity(numeric);
+          success(`[weather overlay] Manual streak density set to ${numeric.toFixed(2)}.`);
+          reportOverlayStatus();
+          return;
+        }
+
         throw new Error(
-          'Usage: /weather overlay [status|on|off|toggle|auto|intensity <value|auto>|clear].',
+          'Usage: /weather overlay [status|on|off|toggle|auto|intensity <value|auto>|wind <value|auto>|density <value|auto>|clear].',
         );
       }
 

--- a/three-demo/src/rendering/effects/raindrop-overlay.js
+++ b/three-demo/src/rendering/effects/raindrop-overlay.js
@@ -5,6 +5,18 @@ const MIN_INTENSITY = 0;
 const MAX_INTENSITY = 2.4;
 const DEFAULT_INTENSITY = 0.45;
 
+const MIN_WIND_SPEED = -2.5;
+const MAX_WIND_SPEED = 2.5;
+const DEFAULT_WIND_SPEED = 0;
+
+const MIN_STREAK_DENSITY = 0.45;
+const MAX_STREAK_DENSITY = 2.8;
+const DEFAULT_STREAK_DENSITY = 1.05;
+
+const MIN_SPARKLE_GAIN = 0.25;
+const MAX_SPARKLE_GAIN = 1.9;
+const DEFAULT_SPARKLE_GAIN = 0.85;
+
 const tempDirection = new THREE.Vector3();
 const tempQuaternion = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
 
@@ -12,11 +24,31 @@ function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
-function createOverlayMaterial(intensity = DEFAULT_INTENSITY) {
+function clampWindSpeed(value) {
+  return clamp(value, MIN_WIND_SPEED, MAX_WIND_SPEED);
+}
+
+function clampStreakDensity(value) {
+  return clamp(value, MIN_STREAK_DENSITY, MAX_STREAK_DENSITY);
+}
+
+function clampSparkleGain(value) {
+  return clamp(value, MIN_SPARKLE_GAIN, MAX_SPARKLE_GAIN);
+}
+
+function createOverlayMaterial({
+  intensity = DEFAULT_INTENSITY,
+  windSpeed = DEFAULT_WIND_SPEED,
+  streakDensity = DEFAULT_STREAK_DENSITY,
+  sparkleGain = DEFAULT_SPARKLE_GAIN,
+} = {}) {
   return new THREE.ShaderMaterial({
     uniforms: {
       uTime: { value: 0 },
       uIntensity: { value: clamp(intensity, MIN_INTENSITY, MAX_INTENSITY) },
+      uWindSpeed: { value: clampWindSpeed(windSpeed) },
+      uStreakDensity: { value: clampStreakDensity(streakDensity) },
+      uSparkleGain: { value: clampSparkleGain(sparkleGain) },
     },
     transparent: true,
     depthTest: false,
@@ -34,43 +66,70 @@ function createOverlayMaterial(intensity = DEFAULT_INTENSITY) {
       varying vec2 vUv;
       uniform float uTime;
       uniform float uIntensity;
+      uniform float uWindSpeed;
+      uniform float uStreakDensity;
+      uniform float uSparkleGain;
 
       float hash(vec2 p) {
         return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
       }
 
-      float raindropMask(vec2 uv, float speed, float tilt) {
-        vec2 flowUv = vec2(uv.x + tilt * uv.y, uv.y);
-        flowUv.y = fract(flowUv.y + uTime * speed);
-        vec2 grid = floor(flowUv * vec2(8.0, 5.0));
-        vec2 local = fract(flowUv * vec2(8.0, 5.0));
-        float seed = hash(grid);
-        float trail = smoothstep(0.95, 0.1, local.y + seed * 0.4);
-        float column = smoothstep(0.42, 0.0, abs(local.x - 0.5));
-        float head = smoothstep(0.18, 0.0, length(local - vec2(0.5, 0.12 + seed * 0.12)));
-        float sparkle = smoothstep(0.75, 0.95, sin((local.y + seed) * 6.28318));
+      float saturate(float value) {
+        return clamp(value, 0.0, 1.0);
+      }
+
+      float streakLayer(vec2 uv, float scale, float speed, float seed) {
+        float density = max(0.3, uStreakDensity * scale);
+        vec2 tilting = vec2(uWindSpeed * 0.22 * scale, 0.0);
+        vec2 flow = uv * vec2(1.0, mix(1.15, 1.4, saturate(scale * 0.4)));
+        flow.xy += tilting * (flow.y + seed);
+        float phase = uTime * speed + seed * 1.7;
+        flow.y += phase;
+        vec2 grid = floor(flow * vec2(density * 0.95, density * 3.6));
+        vec2 local = fract(flow * vec2(density * 0.95, density * 3.6));
+        float jitter = hash(grid + seed);
+        float trail = smoothstep(0.98 - jitter * 0.2, 0.15 + jitter * 0.1, local.y);
+        float spread = 0.42 + jitter * 0.1;
+        float column = smoothstep(spread, 0.0, abs(local.x - 0.5));
+        vec2 headCenter = vec2(0.5 + jitter * 0.08, 0.12 + jitter * 0.16);
+        float head = smoothstep(0.24, 0.0, distance(local, headCenter));
+        float sparklePulse = 0.5 + 0.5 * sin((phase * 2.2 + (local.y + jitter) * 6.28318));
+        float sparkle = mix(1.0, sparklePulse * 1.35, saturate(uSparkleGain));
         return (trail * column * 0.65 + head * 0.45) * sparkle;
       }
 
       void main() {
-        float base = raindropMask(vUv * vec2(1.0, 1.3), 0.08, -0.08);
-        float offset = raindropMask(vUv * vec2(1.0, 1.6) + vec2(0.35, 0.0), 0.12, -0.05);
-        float fine = raindropMask(vUv * vec2(1.0, 1.1) + vec2(-0.2, 0.1), 0.06, -0.1);
-        float mask = clamp(base + offset * 0.8 + fine * 0.6, 0.0, 1.0);
-        float opacity = mask * clamp(uIntensity, 0.0, ${MAX_INTENSITY.toFixed(1)}) * 0.55;
+        vec2 baseUv = vUv * vec2(1.0, 1.32);
+        float layerA = streakLayer(baseUv + vec2(0.08, 0.02), 0.8, 0.35, 1.1);
+        float layerB = streakLayer(baseUv * vec2(1.08, 1.05) + vec2(-0.12, 0.21), 1.0, 0.62, 2.7);
+        float layerC = streakLayer(baseUv * vec2(1.22, 1.18) + vec2(0.18, -0.17), 1.35, 0.9, 4.3);
+        float mask = clamp(layerA * 0.7 + layerB * 0.9 + layerC * 0.85, 0.0, 1.0);
+        float opacity = mask * clamp(uIntensity, 0.0, ${MAX_INTENSITY.toFixed(1)}) * 0.58;
         if (opacity <= 0.001) {
           discard;
         }
-        vec3 tint = mix(vec3(0.55, 0.66, 0.78), vec3(0.78, 0.86, 0.93), mask);
+        vec3 darkTint = vec3(0.46, 0.62, 0.78);
+        vec3 lightTint = vec3(0.83, 0.9, 0.98);
+        vec3 tint = mix(darkTint, lightTint, mask);
         gl_FragColor = vec4(tint, opacity);
       }
     `,
   });
 }
 
-export function createRaindropOverlay({ intensity = DEFAULT_INTENSITY } = {}) {
+export function createRaindropOverlay({
+  intensity = DEFAULT_INTENSITY,
+  windSpeed = DEFAULT_WIND_SPEED,
+  streakDensity = DEFAULT_STREAK_DENSITY,
+  sparkleGain = DEFAULT_SPARKLE_GAIN,
+} = {}) {
   const geometry = new THREE.PlaneGeometry(2, 2);
-  const material = createOverlayMaterial(intensity);
+  const material = createOverlayMaterial({
+    intensity,
+    windSpeed,
+    streakDensity,
+    sparkleGain,
+  });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.name = 'WeatherRaindropOverlay';
   mesh.renderOrder = 995;
@@ -99,14 +158,30 @@ export function createRaindropOverlay({ intensity = DEFAULT_INTENSITY } = {}) {
     mesh.updateMatrixWorld(true);
   };
 
-  function setIntensity(value) {
+  const setIntensity = (value) => {
     const next = clamp(value, MIN_INTENSITY, MAX_INTENSITY);
     material.uniforms.uIntensity.value = next;
-  }
+  };
 
-  function getIntensity() {
-    return material.uniforms.uIntensity.value;
-  }
+  const getIntensity = () => material.uniforms.uIntensity.value;
+
+  const setWindSpeed = (value) => {
+    material.uniforms.uWindSpeed.value = clampWindSpeed(value);
+  };
+
+  const getWindSpeed = () => material.uniforms.uWindSpeed.value;
+
+  const setStreakDensity = (value) => {
+    material.uniforms.uStreakDensity.value = clampStreakDensity(value);
+  };
+
+  const getStreakDensity = () => material.uniforms.uStreakDensity.value;
+
+  const setSparkleGain = (value) => {
+    material.uniforms.uSparkleGain.value = clampSparkleGain(value);
+  };
+
+  const getSparkleGain = () => material.uniforms.uSparkleGain.value;
 
   function update({ delta = 0, elapsedTime } = {}) {
     if (Number.isFinite(elapsedTime)) {
@@ -129,6 +204,12 @@ export function createRaindropOverlay({ intensity = DEFAULT_INTENSITY } = {}) {
     mesh,
     setIntensity,
     getIntensity,
+    setWindSpeed,
+    getWindSpeed,
+    setStreakDensity,
+    getStreakDensity,
+    setSparkleGain,
+    getSparkleGain,
     update,
     dispose,
   };
@@ -137,3 +218,21 @@ export function createRaindropOverlay({ intensity = DEFAULT_INTENSITY } = {}) {
 export function clampRaindropOverlayIntensity(value) {
   return clamp(value, MIN_INTENSITY, MAX_INTENSITY);
 }
+
+export function clampRaindropOverlayWindSpeed(value) {
+  return clampWindSpeed(Number.isFinite(value) ? value : DEFAULT_WIND_SPEED);
+}
+
+export function clampRaindropOverlayStreakDensity(value) {
+  return clampStreakDensity(Number.isFinite(value) ? value : DEFAULT_STREAK_DENSITY);
+}
+
+export function clampRaindropOverlaySparkleGain(value) {
+  return clampSparkleGain(Number.isFinite(value) ? value : DEFAULT_SPARKLE_GAIN);
+}
+
+export {
+  DEFAULT_WIND_SPEED as DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+  DEFAULT_STREAK_DENSITY as DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+  DEFAULT_SPARKLE_GAIN as DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
+};

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -4,6 +4,11 @@ import * as THREE from 'three';
 
 const { createWeatherManager } = await import('../weather/weather-manager.js');
 const { createParticleSystem } = await import('../../rendering/particle-system.js');
+const {
+  clampRaindropOverlayWindSpeed,
+  clampRaindropOverlayStreakDensity,
+  clampRaindropOverlaySparkleGain,
+} = await import('../../rendering/effects/raindrop-overlay.js');
 
 const RAIN_OVERLAY_TEST_MIN = 0.24;
 const RAIN_OVERLAY_TEST_MAX = 1.35;
@@ -52,6 +57,25 @@ function expectedOverlayIntensity(precipIntensity) {
   return Math.min(raised, RAIN_OVERLAY_TEST_MAX);
 }
 
+function expectedOverlayUniforms(precipIntensity, overrides = {}) {
+  const normalised = Math.min(Math.max(precipIntensity, 0), 2.6) / 2.6;
+  const windBase =
+    overrides.windSpeed !== undefined ? overrides.windSpeed : normalised * 1.8;
+  const streakBase =
+    overrides.streakDensity !== undefined
+      ? overrides.streakDensity
+      : 0.9 + normalised * (2.4 - 0.9);
+  const sparkleBase =
+    overrides.sparkleGain !== undefined
+      ? overrides.sparkleGain
+      : 0.55 + normalised * (1.65 - 0.55);
+  return {
+    windSpeed: clampRaindropOverlayWindSpeed(windBase),
+    streakDensity: clampRaindropOverlayStreakDensity(streakBase),
+    sparkleGain: clampRaindropOverlaySparkleGain(sparkleBase),
+  };
+}
+
 test('setWeather emits precipitation for rainy presets', () => {
   let emitCount = 0;
   const handles = [];
@@ -72,7 +96,7 @@ test('setWeather emits precipitation for rainy presets', () => {
 });
 
 test('raindrop overlay intensity follows precipitation tuning', () => {
-  const { manager } = createManager({
+  const { manager, scene } = createManager({
     emitImplementation: (emitter) => ({
       ...emitter,
       stop() {},
@@ -82,6 +106,49 @@ test('raindrop overlay intensity follows precipitation tuning', () => {
     }),
   });
 
+  const assertOverlaySnapshot = ({
+    overlay,
+    expectedIntensity,
+    expectedUniforms,
+    label,
+  }) => {
+    assert.ok(overlay.enabled, `expected overlay to enable for ${label}`);
+    assert.ok(overlay.visible, `expected overlay mesh to exist for ${label}`);
+    assert.ok(
+      approxEqual(overlay.baseIntensity, expectedIntensity, 1e-4),
+      `expected ${label} overlay intensity (${overlay.baseIntensity}) to match tuning (${expectedIntensity})`,
+    );
+    assert.ok(
+      approxEqual(overlay.baseWindSpeed, expectedUniforms.windSpeed, 1e-4),
+      `expected ${label} overlay wind speed to match derived value`,
+    );
+    assert.ok(
+      approxEqual(overlay.baseStreakDensity, expectedUniforms.streakDensity, 1e-4),
+      `expected ${label} overlay streak density to match derived value`,
+    );
+    assert.ok(
+      approxEqual(overlay.baseSparkleGain, expectedUniforms.sparkleGain, 1e-4),
+      `expected ${label} overlay sparkle gain to match derived value`,
+    );
+    const metadata = scene.userData.weather?.raindropOverlay ?? {};
+    assert.ok(
+      approxEqual(metadata.intensity ?? 0, overlay.intensity, 1e-4),
+      'expected overlay metadata to publish intensity',
+    );
+    assert.ok(
+      approxEqual(metadata.windSpeed ?? 0, expectedUniforms.windSpeed, 1e-4),
+      'expected overlay metadata to publish wind speed',
+    );
+    assert.ok(
+      approxEqual(metadata.streakDensity ?? 0, expectedUniforms.streakDensity, 1e-4),
+      'expected overlay metadata to publish streak density',
+    );
+    assert.ok(
+      approxEqual(metadata.sparkleGain ?? 0, expectedUniforms.sparkleGain, 1e-4),
+      'expected overlay metadata to publish sparkle gain',
+    );
+  };
+
   manager.setWeather('misty_rain');
   manager.update({ delta: 0.016, elapsedTime: 1 });
 
@@ -89,12 +156,13 @@ test('raindrop overlay intensity follows precipitation tuning', () => {
   let weather = manager.getCurrentWeather();
   let precipitationIntensity = weather?.effects?.precipitation?.intensity ?? 0;
   let expected = expectedOverlayIntensity(precipitationIntensity);
-  assert.ok(overlay.enabled, 'expected raindrop overlay to enable for rainy preset');
-  assert.ok(overlay.visible, 'expected raindrop overlay mesh to be created for rainy preset');
-  assert.ok(
-    approxEqual(overlay.baseIntensity, expected, 1e-4),
-    `expected misty rain overlay intensity (${overlay.baseIntensity}) to match tuning (${expected})`,
-  );
+  let expectedUniforms = expectedOverlayUniforms(precipitationIntensity);
+  assertOverlaySnapshot({
+    overlay,
+    expectedIntensity: expected,
+    expectedUniforms,
+    label: 'misty rain',
+  });
 
   manager.registerWeatherPreset({
     id: 'qa_downpour',
@@ -116,15 +184,17 @@ test('raindrop overlay intensity follows precipitation tuning', () => {
   weather = manager.getCurrentWeather();
   precipitationIntensity = weather?.effects?.precipitation?.intensity ?? 0;
   expected = expectedOverlayIntensity(precipitationIntensity);
-  assert.ok(overlay.enabled, 'expected overlay to remain enabled for heavy rain');
+  expectedUniforms = expectedOverlayUniforms(precipitationIntensity);
   assert.ok(
     overlay.baseIntensity > expectedOverlayIntensity(0.45),
     'expected heavier precipitation to drive a stronger overlay response',
   );
-  assert.ok(
-    approxEqual(overlay.baseIntensity, expected, 1e-4),
-    `expected heavy rain overlay intensity (${overlay.baseIntensity}) to clamp using tuning (${expected})`,
-  );
+  assertOverlaySnapshot({
+    overlay,
+    expectedIntensity: expected,
+    expectedUniforms,
+    label: 'heavy rain',
+  });
 
   manager.registerWeatherPreset({
     id: 'qa_extreme_downpour',
@@ -142,18 +212,147 @@ test('raindrop overlay intensity follows precipitation tuning', () => {
   manager.setWeather('qa_extreme_downpour');
   manager.update({ delta: 0.016, elapsedTime: 3 });
 
-  const extremeOverlay = manager.getRaindropOverlayState();
-  const extremeWeather = manager.getCurrentWeather();
-  const extremePrecipitationIntensity = extremeWeather?.effects?.precipitation?.intensity ?? 0;
-  const extremeExpected = expectedOverlayIntensity(extremePrecipitationIntensity);
+  overlay = manager.getRaindropOverlayState();
+  weather = manager.getCurrentWeather();
+  precipitationIntensity = weather?.effects?.precipitation?.intensity ?? 0;
+  expected = expectedOverlayIntensity(precipitationIntensity);
+  expectedUniforms = expectedOverlayUniforms(precipitationIntensity);
+  assertOverlaySnapshot({
+    overlay,
+    expectedIntensity: expected,
+    expectedUniforms,
+    label: 'extreme rain',
+  });
+
+  manager.registerWeatherPreset({
+    id: 'qa_overlay_override',
+    label: 'QA Overlay Override',
+    category: 'storm',
+    intensity: 1.1,
+    effects: {
+      precipitation: {
+        type: 'rain',
+        intensity: 0.8,
+        raindropOverlay: {
+          windSpeed: 3.25,
+          streakDensity: 0.2,
+          sparkleGain: 2.5,
+        },
+      },
+    },
+  });
+
+  manager.setWeather('qa_overlay_override');
+  manager.update({ delta: 0.016, elapsedTime: 4 });
+
+  overlay = manager.getRaindropOverlayState();
+  weather = manager.getCurrentWeather();
+  precipitationIntensity = weather?.effects?.precipitation?.intensity ?? 0;
+  expected = expectedOverlayIntensity(precipitationIntensity);
+  expectedUniforms = expectedOverlayUniforms(precipitationIntensity, {
+    windSpeed: 3.25,
+    streakDensity: 0.2,
+    sparkleGain: 2.5,
+  });
+  assertOverlaySnapshot({
+    overlay,
+    expectedIntensity: expected,
+    expectedUniforms,
+    label: 'override rain',
+  });
+  const metadata = scene.userData.weather?.raindropOverlay ?? {};
   assert.ok(
-    approxEqual(extremeOverlay.baseIntensity, extremeExpected, 1e-4),
-    `expected extreme rain overlay intensity (${extremeOverlay.baseIntensity}) to clamp to tuned maximum (${extremeExpected})`,
+    approxEqual(metadata.baseWindSpeed ?? 0, overlay.baseWindSpeed, 1e-4),
+    'expected metadata to store base wind speed overrides',
   );
   assert.ok(
-    approxEqual(extremeOverlay.baseIntensity, overlay.baseIntensity, 1e-4),
-    'expected overlay to clamp so extreme rain matches heavy rain output',
+    approxEqual(metadata.baseStreakDensity ?? 0, overlay.baseStreakDensity, 1e-4),
+    'expected metadata to store base streak density overrides',
   );
+});
+
+test('raindrop overlay manual uniform overrides clamp and persist', () => {
+  const { manager, scene } = createManager({
+    emitImplementation: (emitter) => ({
+      ...emitter,
+      stop() {},
+      getActiveParticleCount() {
+        return 28;
+      },
+    }),
+  });
+
+  manager.setWeather('misty_rain');
+  manager.update({ delta: 0.016, elapsedTime: 0.5 });
+
+  const weather = manager.getCurrentWeather();
+  const precipitationIntensity = weather?.effects?.precipitation?.intensity ?? 0;
+  const baseUniforms = expectedOverlayUniforms(precipitationIntensity);
+
+  manager.setRaindropOverlayManualWindSpeed(9);
+  manager.setRaindropOverlayManualStreakDensity(-1);
+  manager.setRaindropOverlayManualSparkleGain(5);
+
+  let overlay = manager.getRaindropOverlayState();
+  assert.ok(
+    approxEqual(overlay.windSpeed, clampRaindropOverlayWindSpeed(9), 1e-4),
+    'expected manual wind override to clamp to allowable range',
+  );
+  assert.ok(
+    approxEqual(
+      overlay.streakDensity,
+      clampRaindropOverlayStreakDensity(-1),
+      1e-4,
+    ),
+    'expected manual density override to clamp to allowable range',
+  );
+  assert.ok(
+    approxEqual(overlay.sparkleGain, clampRaindropOverlaySparkleGain(5), 1e-4),
+    'expected manual sparkle override to clamp to allowable range',
+  );
+  const metadata = scene.userData.weather?.raindropOverlay ?? {};
+  assert.ok(
+    approxEqual(metadata.manualWindSpeed ?? 0, clampRaindropOverlayWindSpeed(9), 1e-4),
+    'expected metadata to record clamped manual wind override',
+  );
+  assert.ok(
+    approxEqual(
+      metadata.manualStreakDensity ?? 0,
+      clampRaindropOverlayStreakDensity(-1),
+      1e-4,
+    ),
+    'expected metadata to record clamped manual density override',
+  );
+  assert.ok(
+    approxEqual(
+      metadata.manualSparkleGain ?? 0,
+      clampRaindropOverlaySparkleGain(5),
+      1e-4,
+    ),
+    'expected metadata to record clamped manual sparkle override',
+  );
+
+  manager.setRaindropOverlayManualWindSpeed(null);
+  manager.setRaindropOverlayManualStreakDensity(null);
+  manager.setRaindropOverlayManualSparkleGain(null);
+
+  overlay = manager.getRaindropOverlayState();
+  assert.ok(
+    approxEqual(overlay.windSpeed, baseUniforms.windSpeed, 1e-4),
+    'expected clearing manual wind override to restore base response',
+  );
+  assert.ok(
+    approxEqual(overlay.streakDensity, baseUniforms.streakDensity, 1e-4),
+    'expected clearing manual density override to restore base response',
+  );
+  assert.ok(
+    approxEqual(overlay.sparkleGain, baseUniforms.sparkleGain, 1e-4),
+    'expected clearing manual sparkle override to restore base response',
+  );
+  const clearedMetadata = scene.userData.weather?.raindropOverlay ?? {};
+  assert.equal(clearedMetadata.manualWindSpeed, null);
+  assert.equal(clearedMetadata.manualStreakDensity, null);
+  assert.equal(clearedMetadata.manualSparkleGain, null);
 });
 
 test('failed precipitation spawns are recorded for diagnostics', () => {

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -3,7 +3,13 @@ import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain
 import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
 import {
   clampRaindropOverlayIntensity,
+  clampRaindropOverlayWindSpeed,
+  clampRaindropOverlayStreakDensity,
+  clampRaindropOverlaySparkleGain,
   createRaindropOverlay,
+  DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+  DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+  DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
 } from '../../rendering/effects/raindrop-overlay.js';
 import { createWeatherAudioController } from '../../audio/weather-audio.js';
 import { createWeatherDebugOverlay } from '../../ui/weather-debug-overlay.js';
@@ -181,6 +187,25 @@ function normalisePrecipitationEffect(weather, effect) {
   const minAnchorDistance = Number.isFinite(effect.minAnchorDistance)
     ? effect.minAnchorDistance
     : null;
+  const overlayEffect = effect.raindropOverlay ?? null;
+  let raindropOverlay = null;
+  if (overlayEffect) {
+    const overlayConfig = {};
+    if (Number.isFinite(overlayEffect.windSpeed)) {
+      overlayConfig.windSpeed = clampRaindropOverlayWindSpeed(overlayEffect.windSpeed);
+    }
+    if (Number.isFinite(overlayEffect.streakDensity)) {
+      overlayConfig.streakDensity = clampRaindropOverlayStreakDensity(
+        overlayEffect.streakDensity,
+      );
+    }
+    if (Number.isFinite(overlayEffect.sparkleGain)) {
+      overlayConfig.sparkleGain = clampRaindropOverlaySparkleGain(overlayEffect.sparkleGain);
+    }
+    if (Object.keys(overlayConfig).length > 0) {
+      raindropOverlay = overlayConfig;
+    }
+  }
   return {
     type,
     intensity: clamp(baseIntensity, 0.15, 2.6),
@@ -188,6 +213,7 @@ function normalisePrecipitationEffect(weather, effect) {
     anchorHeight,
     updateInterval: updateInterval ?? null,
     minAnchorDistance: minAnchorDistance ?? null,
+    raindropOverlay,
   };
 }
 
@@ -226,13 +252,43 @@ function normaliseAuroraEffect(weather, effect) {
   };
 }
 
-function resolveRainOverlayIntensity(precipitation) {
+function resolveRainOverlayResponse(precipitation) {
+  const defaults = {
+    active: false,
+    intensity: 0,
+    windSpeed: DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+    streakDensity: DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+    sparkleGain: DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
+  };
   if (!precipitation) {
-    return 0;
+    return defaults;
   }
   const base = Number.isFinite(precipitation.intensity) ? precipitation.intensity : 0;
-  const scaled = clamp(base * RAIN_OVERLAY_INTENSITY_SCALE, RAIN_OVERLAY_INTENSITY_MIN, RAIN_OVERLAY_INTENSITY_MAX);
-  return clampRaindropOverlayIntensity(scaled);
+  const scaled = clamp(
+    base * RAIN_OVERLAY_INTENSITY_SCALE,
+    RAIN_OVERLAY_INTENSITY_MIN,
+    RAIN_OVERLAY_INTENSITY_MAX,
+  );
+  const intensity = clampRaindropOverlayIntensity(scaled);
+  const normalised = clamp(base / 2.6, 0, 1);
+  const overlayConfig = precipitation.raindropOverlay ?? {};
+  const windSource =
+    overlayConfig.windSpeed !== undefined ? overlayConfig.windSpeed : normalised * 1.8;
+  const streakSource =
+    overlayConfig.streakDensity !== undefined
+      ? overlayConfig.streakDensity
+      : 0.9 + normalised * (2.4 - 0.9);
+  const sparkleSource =
+    overlayConfig.sparkleGain !== undefined
+      ? overlayConfig.sparkleGain
+      : 0.55 + normalised * (1.65 - 0.55);
+  return {
+    active: intensity > 0,
+    intensity,
+    windSpeed: clampRaindropOverlayWindSpeed(windSource),
+    streakDensity: clampRaindropOverlayStreakDensity(streakSource),
+    sparkleGain: clampRaindropOverlaySparkleGain(sparkleSource),
+  };
 }
 
 export function createWeatherManager({
@@ -275,8 +331,48 @@ export function createWeatherManager({
   const raindropOverlayState = {
     baseActive: false,
     baseIntensity: 0,
+    baseWindSpeed: DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+    baseStreakDensity: DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+    baseSparkleGain: DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
     manualEnabled: null,
     manualIntensity: null,
+    manualWindSpeed: null,
+    manualStreakDensity: null,
+    manualSparkleGain: null,
+  };
+
+  const resolveOverlayTargets = () => {
+    const pickValue = (manualValue, baseValue, clampFn, fallback) => {
+      if (manualValue === null || manualValue === undefined) {
+        const source = Number.isFinite(baseValue) ? baseValue : fallback;
+        return clampFn(source);
+      }
+      return clampFn(manualValue);
+    };
+
+    const intensitySource =
+      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity;
+    return {
+      intensity: clampRaindropOverlayIntensity(intensitySource),
+      windSpeed: pickValue(
+        raindropOverlayState.manualWindSpeed,
+        raindropOverlayState.baseWindSpeed,
+        clampRaindropOverlayWindSpeed,
+        DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+      ),
+      streakDensity: pickValue(
+        raindropOverlayState.manualStreakDensity,
+        raindropOverlayState.baseStreakDensity,
+        clampRaindropOverlayStreakDensity,
+        DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+      ),
+      sparkleGain: pickValue(
+        raindropOverlayState.manualSparkleGain,
+        raindropOverlayState.baseSparkleGain,
+        clampRaindropOverlaySparkleGain,
+        DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
+      ),
+    };
   };
 
   const ensureWeatherState = () => {
@@ -331,10 +427,19 @@ export function createWeatherManager({
       state.raindropOverlay = {
         baseActive: false,
         baseIntensity: 0,
+        baseWindSpeed: DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+        baseStreakDensity: DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+        baseSparkleGain: DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
         manualEnabled: null,
         manualIntensity: null,
+        manualWindSpeed: null,
+        manualStreakDensity: null,
+        manualSparkleGain: null,
         enabled: false,
         intensity: 0,
+        windSpeed: DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+        streakDensity: DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+        sparkleGain: DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
         visible: false,
       };
     }
@@ -389,10 +494,22 @@ export function createWeatherManager({
     const baseActive = raindropOverlayState.baseActive;
     overlay.baseActive = baseActive;
     overlay.baseIntensity = raindropOverlayState.baseIntensity;
+    overlay.baseWindSpeed = raindropOverlayState.baseWindSpeed;
+    overlay.baseStreakDensity = raindropOverlayState.baseStreakDensity;
+    overlay.baseSparkleGain = raindropOverlayState.baseSparkleGain;
     overlay.manualEnabled = manualEnabled;
     overlay.manualIntensity = raindropOverlayState.manualIntensity;
-    overlay.enabled = Boolean((manualEnabled ?? baseActive) && targetIntensity > 0);
-    overlay.intensity = raindropOverlay?.getIntensity?.() ?? targetIntensity;
+    overlay.manualWindSpeed = raindropOverlayState.manualWindSpeed;
+    overlay.manualStreakDensity = raindropOverlayState.manualStreakDensity;
+    overlay.manualSparkleGain = raindropOverlayState.manualSparkleGain;
+    const targets = resolveOverlayTargets();
+    overlay.enabled = Boolean((manualEnabled ?? baseActive) && targets.intensity > 0);
+    overlay.intensity = raindropOverlay?.getIntensity?.() ?? targets.intensity;
+    overlay.windSpeed = raindropOverlay?.getWindSpeed?.() ?? targets.windSpeed;
+    overlay.streakDensity =
+      raindropOverlay?.getStreakDensity?.() ?? targets.streakDensity;
+    overlay.sparkleGain =
+      raindropOverlay?.getSparkleGain?.() ?? targets.sparkleGain;
     overlay.visible = Boolean(raindropOverlay);
   };
 
@@ -422,14 +539,22 @@ export function createWeatherManager({
     };
   };
 
-  const ensureRaindropOverlayEffect = (intensity) => {
+  const ensureRaindropOverlayEffect = (targets) => {
     if (raindropOverlay || !scene) {
-      if (raindropOverlay && Number.isFinite(intensity)) {
-        raindropOverlay.setIntensity(intensity);
+      if (raindropOverlay && targets) {
+        raindropOverlay.setIntensity(targets.intensity);
+        raindropOverlay.setWindSpeed(targets.windSpeed);
+        raindropOverlay.setStreakDensity(targets.streakDensity);
+        raindropOverlay.setSparkleGain(targets.sparkleGain);
       }
       return raindropOverlay;
     }
-    const overlay = createRaindropOverlay({ intensity });
+    const overlay = createRaindropOverlay({
+      intensity: targets?.intensity,
+      windSpeed: targets?.windSpeed,
+      streakDensity: targets?.streakDensity,
+      sparkleGain: targets?.sparkleGain,
+    });
     if (!overlay?.mesh) {
       return null;
     }
@@ -457,10 +582,8 @@ export function createWeatherManager({
     const manualEnabled = raindropOverlayState.manualEnabled;
     const baseActive = raindropOverlayState.baseActive;
     const shouldShow = manualEnabled !== null ? manualEnabled : baseActive;
-    const intensityTarget = clampRaindropOverlayIntensity(
-      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity,
-    );
-    if (!shouldShow || intensityTarget <= 0) {
+    const targets = resolveOverlayTargets();
+    if (!shouldShow || targets.intensity <= 0) {
       if (raindropOverlay) {
         disposeRaindropOverlayEffect();
       } else {
@@ -468,9 +591,12 @@ export function createWeatherManager({
       }
       return;
     }
-    const overlay = ensureRaindropOverlayEffect(intensityTarget);
+    const overlay = ensureRaindropOverlayEffect(targets);
     if (overlay) {
-      overlay.setIntensity(intensityTarget);
+      overlay.setIntensity(targets.intensity);
+      overlay.setWindSpeed(targets.windSpeed);
+      overlay.setStreakDensity(targets.streakDensity);
+      overlay.setSparkleGain(targets.sparkleGain);
       if (overlay.mesh) {
         overlay.mesh.visible = true;
       }
@@ -478,19 +604,40 @@ export function createWeatherManager({
     updateRaindropOverlayMetadata();
   };
 
-  const setRaindropOverlayBaseState = ({ active, intensity }) => {
+  const setRaindropOverlayBaseState = ({
+    active,
+    intensity,
+    windSpeed,
+    streakDensity,
+    sparkleGain,
+  }) => {
     const nextActive = Boolean(active);
     const nextIntensity = Number.isFinite(intensity)
       ? clampRaindropOverlayIntensity(intensity)
       : 0;
+    const nextWindSpeed = Number.isFinite(windSpeed)
+      ? clampRaindropOverlayWindSpeed(windSpeed)
+      : DEFAULT_RAIN_OVERLAY_WIND_SPEED;
+    const nextStreakDensity = Number.isFinite(streakDensity)
+      ? clampRaindropOverlayStreakDensity(streakDensity)
+      : DEFAULT_RAIN_OVERLAY_STREAK_DENSITY;
+    const nextSparkleGain = Number.isFinite(sparkleGain)
+      ? clampRaindropOverlaySparkleGain(sparkleGain)
+      : DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN;
     if (
       raindropOverlayState.baseActive === nextActive &&
-      raindropOverlayState.baseIntensity === nextIntensity
+      raindropOverlayState.baseIntensity === nextIntensity &&
+      raindropOverlayState.baseWindSpeed === nextWindSpeed &&
+      raindropOverlayState.baseStreakDensity === nextStreakDensity &&
+      raindropOverlayState.baseSparkleGain === nextSparkleGain
     ) {
       return;
     }
     raindropOverlayState.baseActive = nextActive;
     raindropOverlayState.baseIntensity = nextIntensity;
+    raindropOverlayState.baseWindSpeed = nextWindSpeed;
+    raindropOverlayState.baseStreakDensity = nextStreakDensity;
+    raindropOverlayState.baseSparkleGain = nextSparkleGain;
     syncRaindropOverlay();
   };
 
@@ -519,20 +666,79 @@ export function createWeatherManager({
     syncRaindropOverlay();
   };
 
+  const setRaindropOverlayManualWindSpeed = (value) => {
+    let next = null;
+    if (value !== null && value !== undefined) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return;
+      }
+      next = clampRaindropOverlayWindSpeed(numeric);
+    }
+    if (raindropOverlayState.manualWindSpeed === next) {
+      return;
+    }
+    raindropOverlayState.manualWindSpeed = next;
+    syncRaindropOverlay();
+  };
+
+  const setRaindropOverlayManualStreakDensity = (value) => {
+    let next = null;
+    if (value !== null && value !== undefined) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return;
+      }
+      next = clampRaindropOverlayStreakDensity(numeric);
+    }
+    if (raindropOverlayState.manualStreakDensity === next) {
+      return;
+    }
+    raindropOverlayState.manualStreakDensity = next;
+    syncRaindropOverlay();
+  };
+
+  const setRaindropOverlayManualSparkleGain = (value) => {
+    let next = null;
+    if (value !== null && value !== undefined) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return;
+      }
+      next = clampRaindropOverlaySparkleGain(numeric);
+    }
+    if (raindropOverlayState.manualSparkleGain === next) {
+      return;
+    }
+    raindropOverlayState.manualSparkleGain = next;
+    syncRaindropOverlay();
+  };
+
   const getRaindropOverlayState = () => {
     const manualEnabled = raindropOverlayState.manualEnabled;
     const baseActive = raindropOverlayState.baseActive;
-    const intensity = raindropOverlay?.getIntensity?.() ?? clampRaindropOverlayIntensity(
-      raindropOverlayState.manualIntensity ?? raindropOverlayState.baseIntensity,
-    );
+    const targets = resolveOverlayTargets();
+    const intensity = raindropOverlay?.getIntensity?.() ?? targets.intensity;
+    const windSpeed = raindropOverlay?.getWindSpeed?.() ?? targets.windSpeed;
+    const streakDensity = raindropOverlay?.getStreakDensity?.() ?? targets.streakDensity;
+    const sparkleGain = raindropOverlay?.getSparkleGain?.() ?? targets.sparkleGain;
     return {
       enabled: Boolean((manualEnabled ?? baseActive) && intensity > 0),
       visible: Boolean(raindropOverlay),
       intensity,
+      windSpeed,
+      streakDensity,
+      sparkleGain,
       baseActive,
       baseIntensity: raindropOverlayState.baseIntensity,
+      baseWindSpeed: raindropOverlayState.baseWindSpeed,
+      baseStreakDensity: raindropOverlayState.baseStreakDensity,
+      baseSparkleGain: raindropOverlayState.baseSparkleGain,
       manualEnabled,
       manualIntensity: raindropOverlayState.manualIntensity,
+      manualWindSpeed: raindropOverlayState.manualWindSpeed,
+      manualStreakDensity: raindropOverlayState.manualStreakDensity,
+      manualSparkleGain: raindropOverlayState.manualSparkleGain,
     };
   };
 
@@ -1271,13 +1477,23 @@ export function createWeatherManager({
     }
     const resolved = resolveWeatherEffects(activeWeather);
     const precipitation = normalisePrecipitationEffect(activeWeather, resolved.precipitation);
-    let overlayBaseState = { active: false, intensity: 0 };
+    let overlayBaseState = {
+      active: false,
+      intensity: 0,
+      windSpeed: DEFAULT_RAIN_OVERLAY_WIND_SPEED,
+      streakDensity: DEFAULT_RAIN_OVERLAY_STREAK_DENSITY,
+      sparkleGain: DEFAULT_RAIN_OVERLAY_SPARKLE_GAIN,
+    };
     if (precipitation) {
       spawnPrecipitationEffect(precipitation, context);
       if (precipitation.type === 'rain') {
+        const overlayResponse = resolveRainOverlayResponse(precipitation);
         overlayBaseState = {
-          active: true,
-          intensity: resolveRainOverlayIntensity(precipitation),
+          active: overlayResponse.active,
+          intensity: overlayResponse.intensity,
+          windSpeed: overlayResponse.windSpeed,
+          streakDensity: overlayResponse.streakDensity,
+          sparkleGain: overlayResponse.sparkleGain,
         };
       }
     }
@@ -1749,6 +1965,9 @@ export function createWeatherManager({
     getRaindropOverlayState,
     setRaindropOverlayManualEnabled,
     setRaindropOverlayManualIntensity,
+    setRaindropOverlayManualWindSpeed,
+    setRaindropOverlayManualStreakDensity,
+    setRaindropOverlayManualSparkleGain,
     dispose,
   };
 }


### PR DESCRIPTION
## Summary
- replace the raindrop overlay shader with a multi-layer parallax effect that exposes wind speed, streak density, and sparkle gain uniforms
- wire precipitation configs, developer commands, and scene metadata into the new overlay uniforms and document the updated QA expectations
- extend the weather-manager regression suite to cover overlay uniform clamps and manual overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db0b532414832a9918970c99ba3f03