### PR TITLE
Add rain splash particle layer and update weather coverage

### DIFF
--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -80,6 +80,15 @@ Please continue appending follow-up findings or configuration changes here whene
 - `/weather overlay wind|density` commands apply those manual overrides, extend the status readout, and a new regression checks the clamps, metadata persistence, and override clearing so CI guards the documented intensity scale—update this plan alongside future tuning shifts.【F:src/player/dev-commands.js†L1780-L1900】【F:src/world/__tests__/weather-manager.test.js†L132-L268】
 - **Reminder:** keep this section synchronized whenever you touch the overlay shader, uniform maths, or console tooling so QA expectations, metadata snapshots, and tests stay aligned.
 
+## 2025-12 Rain Splash Layer
+- Introduced `createWeatherRainSplashEmitter`, a short-lived additive spark emitter that jitters around the player using the active precipitation radius so rainy presets now feature upward splash bursts near ground contact.【F:src/rendering/particles/weather-rain-splashes.js†L1-L54】
+- Weather manager spawns the splash layer alongside rain streaks, anchors it with the same radius/height offsets, and stops both handles together when presets change, preventing orphan emitters during retries.【F:src/world/weather/weather-manager.js†L1193-L1428】【F:src/world/weather/weather-manager.js†L1849-L1886】
+- Regression coverage now asserts that rainy presets surface a splash handle, validates it is disposed when weather clears, and updates retry expectations to account for the extra emitter—future tweaks must adjust these tests and this plan in tandem.【F:src/world/__tests__/weather-manager.test.js†L83-L158】【F:src/world/__tests__/weather-manager.test.js†L430-L640】
+- **QA checklist:**
+  - Trigger `/weather misty_rain` (or cycle via the harness) and stand near ground; confirm bright streaks are accompanied by fast upward splash sparks within the precipitation radius, concentrated around the player’s feet.【F:src/rendering/particles/weather-rain-splashes.js†L15-L47】
+  - Watch the weather debug overlay for both the bright-streak and splash debug labels, ensuring the splash handle appears/disappears as presets switch and that retries clean up the previous layer.【F:src/world/weather/weather-manager.js†L1334-L1418】【F:src/world/__tests__/weather-manager.test.js†L94-L158】
+- **Reminder:** Keep this splash section current whenever you retune intensity, spawn budgets, or cleanup logic so QA and diagnostics stay aligned.
+
 ## Work Orders
 1. **Gameplay-driven rotation**
    - Sample the player’s biome each frame (reusing the `sampleBiomeAt` helper from `/weather status`) and resolve the preset rotation with `resolveBiomeWeatherRotation`, storing timing metadata per biome.【F:src/player/dev-commands.js†L1532-L1562】【F:src/world/weather/weather-manager.js†L76-L127】

--- a/three-demo/src/rendering/particles/weather-rain-splashes.js
+++ b/three-demo/src/rendering/particles/weather-rain-splashes.js
@@ -1,0 +1,56 @@
+import * as THREE from 'three'
+import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js'
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function createWeatherRainSplashEmitter({
+  intensity = 0.6,
+  radius = 12,
+  anchorHeight = 14,
+} = {}) {
+  const density = clamp(intensity, 0.2, 2.6)
+  const spawnRadius = Math.max(4, radius)
+  const heightOffset = Number.isFinite(anchorHeight) ? anchorHeight : 14
+  const normalized = clamp((density - 0.2) / (2.6 - 0.2), 0, 1)
+  const upwardVelocity = THREE.MathUtils.lerp(2.1, 5.2, normalized)
+  const splashSizeMin = THREE.MathUtils.lerp(0.22, 0.32, normalized)
+  const splashSizeMax = THREE.MathUtils.lerp(0.38, 0.68, normalized)
+  const emitter = createGpuBillboardEmitter({
+    spawnRate: Math.min(260 * density, 420),
+    maxParticles: Math.ceil(Math.min(420 * density, 620)),
+    lifetime: { min: 0.18, max: 0.36 },
+    baseColor: '#6ec7ff',
+    colorRamp: [
+      { time: 0, color: '#2c8dd8' },
+      { time: 0.32, color: '#7bd4ff' },
+      { time: 1, color: '#e8f9ff' },
+    ],
+    sizeOverLifetime: [
+      { time: 0, size: splashSizeMax },
+      { time: 0.3, size: splashSizeMax * 1.08 },
+      { time: 1, size: splashSizeMin * 0.2 },
+    ],
+    position: { x: 0, y: -heightOffset + 0.35, z: 0 },
+    positionJitter: { x: spawnRadius, y: 0.45, z: spawnRadius },
+    velocity: { x: 0, y: upwardVelocity, z: 0 },
+    velocityJitter: { x: 0.95, y: 0.6, z: 0.95 },
+    size: { min: splashSizeMin, max: splashSizeMax },
+    sizeJitter: 0.16,
+    lengthMultiplier: { min: 0.55, max: 0.85 },
+    gravity: { x: 0, y: -12.8, z: 0 },
+    drag: 1.25,
+    fadeIn: 0.04,
+    fadeOut: 0.24,
+    opacity: 0.88,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    renderOrder: 6,
+  })
+  emitter.debugLabel = 'WeatherRainSplashEmitter'
+  emitter.weatherAnchorOffset = { x: 0, y: heightOffset, z: 0 }
+  emitter.weatherUpdateInterval = 0.12
+  emitter.weatherMinAnchorDistance = Math.max(spawnRadius * 0.18, 1.2)
+  return emitter
+}

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -77,12 +77,10 @@ function expectedOverlayUniforms(precipIntensity, overrides = {}) {
 }
 
 test('setWeather emits precipitation for rainy presets', () => {
-  let emitCount = 0;
-  const handles = [];
+  const emitLabels = [];
   const { manager, particleSystem } = createManager({
     emitImplementation: (emitter) => {
-      emitCount += 1;
-      handles.push(emitter);
+      emitLabels.push(emitter.debugLabel ?? 'unknown');
       return { stop() {} };
     },
   });
@@ -90,9 +88,62 @@ test('setWeather emits precipitation for rainy presets', () => {
   manager.setWeather('misty_rain');
   manager.update({ delta: 0.1, elapsedTime: 1 });
 
-  assert.equal(emitCount, 1, 'expected precipitation emitter to be spawned once');
-  assert.equal(particleSystem.emitted.length, 1, 'expected particle handle to be stored');
-  assert.ok(handles[0], 'expected precipitation emitter details to be captured');
+  assert.equal(
+    emitLabels.length,
+    2,
+    'expected rain weather to spawn both primary precipitation and splash emitters',
+  );
+  assert.ok(
+    emitLabels.includes('WeatherRainEmitter/BrightStreakPass'),
+    'expected rain streak emitter to spawn',
+  );
+  assert.ok(
+    emitLabels.includes('WeatherRainSplashEmitter'),
+    'expected rain splash emitter to spawn',
+  );
+  assert.equal(
+    particleSystem.emitted.length,
+    2,
+    'expected precipitation emitters to be tracked',
+  );
+});
+
+test('rain splash attachment stops when weather clears', () => {
+  const stoppedLabels = [];
+  const { manager } = createManager({
+    emitImplementation: (emitter) => ({
+      stop() {
+        stoppedLabels.push(emitter.debugLabel ?? 'unknown');
+      },
+      getActiveParticleCount() {
+        return emitter.debugLabel === 'WeatherRainEmitter/BrightStreakPass' ? 24 : 12;
+      },
+    }),
+  });
+
+  manager.setWeather('misty_rain');
+  manager.update({ delta: 0.05, elapsedTime: 1 });
+  manager.setWeather('clear_skies');
+  manager.update({ delta: 0.05, elapsedTime: 1.1 });
+
+  assert.ok(
+    stoppedLabels.includes('WeatherRainEmitter/BrightStreakPass'),
+    'expected primary rain emitter to be stopped when weather clears',
+  );
+  assert.ok(
+    stoppedLabels.includes('WeatherRainSplashEmitter'),
+    'expected rain splash emitter to be stopped when weather clears',
+  );
+  assert.equal(
+    stoppedLabels.filter((label) => label === 'WeatherRainEmitter/BrightStreakPass').length,
+    1,
+    'expected primary emitter to be stopped exactly once',
+  );
+  assert.equal(
+    stoppedLabels.filter((label) => label === 'WeatherRainSplashEmitter').length,
+    1,
+    'expected splash emitter to be stopped exactly once',
+  );
 });
 
 test('raindrop overlay intensity follows precipitation tuning', () => {
@@ -390,11 +441,13 @@ test('manual precipitation overrides adjust rain uniforms', () => {
   let capturedEmitter = null;
   const { manager, scene } = createManager({
     emitImplementation: (emitter) => {
-      capturedEmitter = emitter;
+      if (emitter.debugLabel === 'WeatherRainEmitter/BrightStreakPass') {
+        capturedEmitter = emitter;
+      }
       return {
         stop() {},
         getActiveParticleCount() {
-          return 42;
+          return emitter.debugLabel === 'WeatherRainEmitter/BrightStreakPass' ? 42 : 18;
         },
       };
     },
@@ -431,13 +484,26 @@ test('manual precipitation overrides adjust rain uniforms', () => {
 });
 
 test('precipitation spawn retries recover after missing handles', () => {
-  let emitCount = 0;
-  const handles = [null, null, { stop() {}, getActiveParticleCount() { return 12; } }];
+  let primaryEmitCount = 0;
+  let splashEmitCount = 0;
+  const primaryHandles = [null, null, { stop() {}, getActiveParticleCount() { return 12; } }];
 
   const { manager, scene, particleSystem } = createManager({
-    emitImplementation: () => {
-      const handle = emitCount < handles.length ? handles[emitCount] : handles.at(-1);
-      emitCount += 1;
+    emitImplementation: (emitter) => {
+      if (emitter.debugLabel === 'WeatherRainSplashEmitter') {
+        splashEmitCount += 1;
+        return {
+          stop() {},
+          getActiveParticleCount() {
+            return 10;
+          },
+        };
+      }
+      const handle =
+        primaryEmitCount < primaryHandles.length
+          ? primaryHandles[primaryEmitCount]
+          : primaryHandles.at(-1);
+      primaryEmitCount += 1;
       return handle;
     },
   });
@@ -447,7 +513,7 @@ test('precipitation spawn retries recover after missing handles', () => {
   manager.update({ delta: 0.1, elapsedTime: 0.1 });
 
   let weatherState = scene.userData.weather;
-  assert.equal(emitCount, 1, 'expected initial precipitation emit call');
+  assert.equal(primaryEmitCount, 1, 'expected initial precipitation emit call');
   assert.equal(weatherState.failedPrecipitationSpawns, 1);
   assert.equal(weatherState.precipitationRecoveryAttempts, 1);
   assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
@@ -455,12 +521,12 @@ test('precipitation spawn retries recover after missing handles', () => {
 
   manager.update({ delta: 0.4, elapsedTime: 0.5 });
   weatherState = scene.userData.weather;
-  assert.equal(emitCount, 1, 'expected retry to wait until the interval has elapsed');
+  assert.equal(primaryEmitCount, 1, 'expected retry to wait until the interval has elapsed');
   assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
 
   manager.update({ delta: 0.3, elapsedTime: 0.8 });
   weatherState = scene.userData.weather;
-  assert.equal(emitCount, 2, 'expected queued retry to fire after the interval');
+  assert.equal(primaryEmitCount, 2, 'expected queued retry to fire after the interval');
   assert.equal(weatherState.failedPrecipitationSpawns, 2);
   assert.equal(weatherState.precipitationRecoveryAttempts, 2);
   assert.equal(weatherState.pendingPrecipitationRetries.length, 1);
@@ -468,20 +534,23 @@ test('precipitation spawn retries recover after missing handles', () => {
 
   manager.update({ delta: 0.7, elapsedTime: 1.5 });
   weatherState = scene.userData.weather;
-  assert.equal(emitCount, 3, 'expected final retry to execute');
-  assert.equal(particleSystem.emitted.length, 1, 'expected successful handle to be recorded');
+  assert.equal(primaryEmitCount, 3, 'expected final retry to execute');
+  assert.equal(splashEmitCount, 1, 'expected splash emitter to spawn once after recovery');
+  assert.equal(particleSystem.emitted.length, 2, 'expected successful handles to be recorded');
   assert.equal(weatherState.pendingPrecipitationRetries.length, 0);
   assert.equal(weatherState.failedPrecipitationSpawns, 2);
   assert.equal(weatherState.precipitationRecoveryAttempts, 2);
 });
 
 test('zero-particle precipitation handles trigger retries and diagnostics', () => {
-  let stopCalls = 0;
-  let emitCount = 0;
-  const handles = [
+  let primaryStopCalls = 0;
+  let splashStopCalls = 0;
+  let primaryEmitCount = 0;
+  let splashEmitCount = 0;
+  const primaryHandles = [
     {
       stop() {
-        stopCalls += 1;
+        primaryStopCalls += 1;
       },
       getActiveParticleCount() {
         return 0;
@@ -496,9 +565,20 @@ test('zero-particle precipitation handles trigger retries and diagnostics', () =
   ];
 
   const { manager, scene, particleSystem } = createManager({
-    emitImplementation: () => {
-      const handle = handles[emitCount] ?? null;
-      emitCount += 1;
+    emitImplementation: (emitter) => {
+      if (emitter.debugLabel === 'WeatherRainSplashEmitter') {
+        splashEmitCount += 1;
+        return {
+          stop() {
+            splashStopCalls += 1;
+          },
+          getActiveParticleCount() {
+            return 6;
+          },
+        };
+      }
+      const handle = primaryHandles[primaryEmitCount] ?? primaryHandles.at(-1);
+      primaryEmitCount += 1;
       return handle;
     },
   });
@@ -511,9 +591,15 @@ test('zero-particle precipitation handles trigger retries and diagnostics', () =
 
   const weatherState = scene.userData.weather;
 
-  assert.equal(emitCount, 2, 'expected precipitation spawn to retry once');
-  assert.equal(stopCalls, 1, 'expected inactive precipitation handle to be stopped');
-  assert.equal(particleSystem.emitted.length, 2, 'expected two precipitation handles to be tracked');
+  assert.equal(primaryEmitCount, 2, 'expected precipitation spawn to retry once');
+  assert.equal(
+    splashEmitCount,
+    2,
+    'expected splash emitter to spawn alongside each precipitation attempt',
+  );
+  assert.equal(primaryStopCalls, 1, 'expected inactive precipitation handle to be stopped');
+  assert.equal(splashStopCalls, 1, 'expected splash handle to stop when the primary emitter fails');
+  assert.equal(particleSystem.emitted.length, 4, 'expected both primary and splash handles to be tracked');
   assert.equal(weatherState.failedPrecipitationSpawns, 1);
   assert.equal(weatherState.precipitationRecoveryAttempts, 1);
   assert.deepEqual(weatherState.lastPrecipitationFailure, {

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -1,5 +1,6 @@
 import { createAuroraRibbonEmitter } from '../../rendering/particles/aurora-effects.js';
 import { createWeatherRainEmitter } from '../../rendering/particles/weather-rain.js';
+import { createWeatherRainSplashEmitter } from '../../rendering/particles/weather-rain-splashes.js';
 import { createWeatherSnowEmitter } from '../../rendering/particles/weather-snow.js';
 import {
   clampRaindropOverlayIntensity,
@@ -1187,6 +1188,24 @@ export function createWeatherManager({
     syncEmitterState();
   };
 
+  const stopLinkedPrecipitationAttachments = (source) => {
+    if (!source?.precipitationGroup) {
+      return;
+    }
+    for (let i = activeParticleEffects.length - 1; i >= 0; i -= 1) {
+      const attachment = activeParticleEffects[i];
+      if (attachment === source) {
+        continue;
+      }
+      if (attachment.precipitationGroup !== source.precipitationGroup) {
+        continue;
+      }
+      stopAttachmentHandle(attachment);
+      activeParticleEffects.splice(i, 1);
+    }
+    syncEmitterState();
+  };
+
   const disposeWeatherEffects = () => {
     for (const attachment of activeParticleEffects) {
       stopAttachmentHandle(attachment);
@@ -1272,6 +1291,10 @@ export function createWeatherManager({
       }
       return;
     }
+    const resolvedAnchorHeight = Number.isFinite(config.anchorHeight)
+      ? config.anchorHeight
+      : 0;
+    const groupId = config.type === 'rain' ? Symbol('weather-precipitation-group') : null;
     let updateInterval = config.updateInterval;
     if (!Number.isFinite(updateInterval) && Number.isFinite(emitter.weatherUpdateInterval)) {
       updateInterval = emitter.weatherUpdateInterval;
@@ -1283,67 +1306,133 @@ export function createWeatherManager({
     ) {
       minAnchorDistance = emitter.weatherMinAnchorDistance;
     }
-    const attachment = {
+    const resolvedUpdateInterval = Number.isFinite(updateInterval)
+      ? Math.max(0.05, updateInterval)
+      : DEFAULT_PRECIPITATION_UPDATE_INTERVAL;
+    const resolvedMinAnchorDistance = Number.isFinite(minAnchorDistance)
+      ? Math.max(0, minAnchorDistance)
+      : emitter.weatherMinAnchorDistance ?? 0;
+    const attachments = [];
+    const precipitationAttachment = {
       type: 'precipitation',
       handle,
       emitter,
-      anchorOffsetY: config.anchorHeight,
-      updateInterval: Number.isFinite(updateInterval)
-        ? Math.max(0.05, updateInterval)
-        : DEFAULT_PRECIPITATION_UPDATE_INTERVAL,
-      minDistanceSq: Number.isFinite(minAnchorDistance)
-        ? Math.max(0, minAnchorDistance) ** 2
-        : (emitter.weatherMinAnchorDistance ?? 0) ** 2,
+      anchorOffsetY: resolvedAnchorHeight,
+      updateInterval: resolvedUpdateInterval,
+      minDistanceSq: resolvedMinAnchorDistance ** 2,
       lastUpdateTime: -Infinity,
       lastAnchor: {
         x: Number.POSITIVE_INFINITY,
         y: Number.POSITIVE_INFINITY,
         z: Number.POSITIVE_INFINITY,
       },
+      precipitationGroup: groupId,
     };
+    attachments.push(precipitationAttachment);
+
+    if (config.type === 'rain') {
+      const splashEmitter = createWeatherRainSplashEmitter({
+        intensity: appliedIntensity,
+        radius: config.radius,
+        anchorHeight: resolvedAnchorHeight,
+      });
+      const splashHandle = particleSystem.emit(splashEmitter);
+      if (splashHandle) {
+        let splashInterval = config.updateInterval;
+        if (
+          !Number.isFinite(splashInterval) &&
+          Number.isFinite(splashEmitter.weatherUpdateInterval)
+        ) {
+          splashInterval = splashEmitter.weatherUpdateInterval;
+        }
+        let splashDistance = config.minAnchorDistance;
+        if (
+          !Number.isFinite(splashDistance) &&
+          Number.isFinite(splashEmitter.weatherMinAnchorDistance)
+        ) {
+          splashDistance = splashEmitter.weatherMinAnchorDistance;
+        }
+        const splashAttachment = {
+          type: 'precipitation_splash',
+          handle: splashHandle,
+          emitter: splashEmitter,
+          anchorOffsetY: resolvedAnchorHeight,
+          updateInterval: Number.isFinite(splashInterval)
+            ? Math.max(0.05, splashInterval)
+            : resolvedUpdateInterval,
+          minDistanceSq: (Number.isFinite(splashDistance)
+            ? Math.max(0, splashDistance)
+            : splashEmitter.weatherMinAnchorDistance ?? resolvedMinAnchorDistance) ** 2,
+          lastUpdateTime: -Infinity,
+          lastAnchor: {
+            x: Number.POSITIVE_INFINITY,
+            y: Number.POSITIVE_INFINITY,
+            z: Number.POSITIVE_INFINITY,
+          },
+          precipitationGroup: groupId,
+          spawnConfig: { ...config, intensity: appliedIntensity },
+          spawnAttempt: attempt,
+          spawnElapsedTime: context.elapsedTime ?? 0,
+        };
+        attachments.push(splashAttachment);
+      } else {
+        console.warn('Weather rain splash emitter failed to spawn.', {
+          type: config.type,
+        });
+      }
+    }
+
     const playerPosition = context.playerControls?.getPosition?.();
     const elapsedTime = context.elapsedTime ?? 0;
     if (playerPosition) {
-      emitter.setBasePosition?.({
-        x: playerPosition.x,
-        y: playerPosition.y + config.anchorHeight,
-        z: playerPosition.z,
-      });
-      attachment.lastAnchor = {
-        x: playerPosition.x,
-        y: playerPosition.y,
-        z: playerPosition.z,
-      };
-      attachment.lastUpdateTime = elapsedTime;
+      for (const attachment of attachments) {
+        attachment.emitter?.setBasePosition?.({
+          x: playerPosition.x,
+          y: playerPosition.y + attachment.anchorOffsetY,
+          z: playerPosition.z,
+        });
+        attachment.lastAnchor = {
+          x: playerPosition.x,
+          y: playerPosition.y,
+          z: playerPosition.z,
+        };
+        attachment.lastUpdateTime = elapsedTime;
+      }
       recordAnchorUpdate(elapsedTime);
     }
-    activeParticleEffects.push(attachment);
-    attachment.spawnConfig = { ...config, intensity: appliedIntensity };
-    attachment.spawnAttempt = attempt;
-    attachment.spawnElapsedTime = elapsedTime;
-    attachment.validationReadyTime = Number.isFinite(elapsedTime)
-      ? elapsedTime + PRECIPITATION_HANDLE_VALIDATION_DELAY
-      : Number.POSITIVE_INFINITY;
-    attachment.validationStatus = 'pending';
-    attachment.validationRetryAfter = null;
-    attachment.validationPendingSince = null;
-    recordPrecipitationSpawn({ type: config.type, elapsedTime });
-    attachment.appliedIntensity = appliedIntensity;
-    attachment.manualOverrides = manualOverrides;
-    if (typeof emitter.getWeatherRainShaderBaseUniforms === 'function') {
-      attachment.baseRainUniforms = emitter.getWeatherRainShaderBaseUniforms();
-    }
-    if (typeof emitter.getWeatherRainShaderUniforms === 'function') {
-      const uniforms = emitter.getWeatherRainShaderUniforms();
-      if (!attachment.baseRainUniforms) {
-        attachment.baseRainUniforms = { ...uniforms };
+
+    for (const attachment of attachments) {
+      attachment.spawnConfig = attachment.spawnConfig ?? { ...config, intensity: appliedIntensity };
+      attachment.spawnAttempt = attachment.spawnAttempt ?? attempt;
+      attachment.spawnElapsedTime = attachment.spawnElapsedTime ?? elapsedTime;
+      if (attachment.type === 'precipitation') {
+        attachment.validationReadyTime = Number.isFinite(elapsedTime)
+          ? elapsedTime + PRECIPITATION_HANDLE_VALIDATION_DELAY
+          : Number.POSITIVE_INFINITY;
+        attachment.validationStatus = 'pending';
+        attachment.validationRetryAfter = null;
+        attachment.validationPendingSince = null;
+        attachment.appliedIntensity = appliedIntensity;
+        attachment.manualOverrides = manualOverrides;
+        if (typeof emitter.getWeatherRainShaderBaseUniforms === 'function') {
+          attachment.baseRainUniforms = emitter.getWeatherRainShaderBaseUniforms();
+        }
+        if (typeof emitter.getWeatherRainShaderUniforms === 'function') {
+          const uniforms = emitter.getWeatherRainShaderUniforms();
+          if (!attachment.baseRainUniforms) {
+            attachment.baseRainUniforms = { ...uniforms };
+          }
+          attachment.lastAppliedRainOverrides = {
+            windTilt: uniforms?.windTilt,
+            streakNoise: uniforms?.streakNoise,
+            highlightWidth: uniforms?.highlightWidth,
+          };
+        }
       }
-      attachment.lastAppliedRainOverrides = {
-        windTilt: uniforms?.windTilt,
-        streakNoise: uniforms?.streakNoise,
-        highlightWidth: uniforms?.highlightWidth,
-      };
+      activeParticleEffects.push(attachment);
     }
+
+    recordPrecipitationSpawn({ type: config.type, elapsedTime });
     syncEmitterState();
   };
 
@@ -1524,7 +1613,7 @@ export function createWeatherManager({
       if (interval > 0 && elapsedTime - (attachment.lastUpdateTime ?? -Infinity) < interval) {
         continue;
       }
-      if (attachment.type === 'precipitation') {
+      if (attachment.type === 'precipitation' || attachment.type === 'precipitation_splash') {
         const dx = playerPosition.x - attachment.lastAnchor.x;
         const dy = playerPosition.y - attachment.lastAnchor.y;
         const dz = playerPosition.z - attachment.lastAnchor.z;
@@ -1783,6 +1872,7 @@ export function createWeatherManager({
         reason: 'zero_particles',
       });
       stopAttachmentHandle(attachment);
+      stopLinkedPrecipitationAttachments(attachment);
       removeAttachment(attachment);
 
       const state = ensureWeatherState();


### PR DESCRIPTION
## Summary
- add a rain splash GPU billboard emitter for rainy presets
- spawn and dispose the splash attachment in the weather manager alongside existing precipitation handles
- expand weather manager tests and remediation docs with splash coverage expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db126bbe7c832a94389f51c81584f8