### PR TITLE
Add advanced rain ripple shader and uniform controls

### DIFF
--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { createGpuBillboardEmitter } from './gpu-billboard-emitter.js'
-import { weatherRainStreakFragmentShader } from '../shaders/weather-rain-streak.glsl.js'
+import { weatherRainAdvancedFragmentShader } from '../shaders/weather-rain-advanced.glsl.js'
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max)
@@ -13,6 +13,9 @@ export function createWeatherRainEmitter({
   windTilt = null,
   streakNoise = null,
   highlightWidth = null,
+  rippleScale = null,
+  dropDensity = null,
+  timerBias = null,
 } = {}) {
   const density = clamp(intensity, 0.2, 2.4)
   const normalized = clamp((density - 0.2) / (2.4 - 0.2), 0, 1)
@@ -20,6 +23,9 @@ export function createWeatherRainEmitter({
   const baseWindTilt = THREE.MathUtils.lerp(0.045, 0.28, normalized)
   const baseStreakNoise = THREE.MathUtils.lerp(0.38, 0.9, normalized)
   const baseHighlightWidth = THREE.MathUtils.lerp(0.22, 0.095, normalized)
+  const baseRippleScale = THREE.MathUtils.lerp(1.6, 0.95, normalized)
+  const baseDropDensity = THREE.MathUtils.lerp(0.6, 1.35, normalized)
+  const baseTimerBias = THREE.MathUtils.lerp(0.22, 0.46, normalized)
 
   const uniformState = {
     windTilt: Number.isFinite(windTilt) ? windTilt : baseWindTilt,
@@ -27,12 +33,22 @@ export function createWeatherRainEmitter({
     highlightWidth: Number.isFinite(highlightWidth)
       ? Math.max(0.02, highlightWidth)
       : baseHighlightWidth,
+    rippleScale: Number.isFinite(rippleScale)
+      ? Math.max(0.25, rippleScale)
+      : baseRippleScale,
+    dropDensity: Number.isFinite(dropDensity)
+      ? Math.max(0.1, dropDensity)
+      : baseDropDensity,
+    timerBias: Number.isFinite(timerBias) ? timerBias : baseTimerBias,
   }
 
   const baseUniforms = {
     windTilt: baseWindTilt,
     streakNoise: baseStreakNoise,
     highlightWidth: baseHighlightWidth,
+    rippleScale: baseRippleScale,
+    dropDensity: baseDropDensity,
+    timerBias: baseTimerBias,
   }
 
   let materialRef = null
@@ -49,6 +65,15 @@ export function createWeatherRainEmitter({
     }
     if (materialRef.uniforms.uHighlightWidth) {
       materialRef.uniforms.uHighlightWidth.value = uniformState.highlightWidth
+    }
+    if (materialRef.uniforms.uRippleScale) {
+      materialRef.uniforms.uRippleScale.value = uniformState.rippleScale
+    }
+    if (materialRef.uniforms.uDropDensity) {
+      materialRef.uniforms.uDropDensity.value = uniformState.dropDensity
+    }
+    if (materialRef.uniforms.uTimerBias) {
+      materialRef.uniforms.uTimerBias.value = uniformState.timerBias
     }
     materialRef.uniformsNeedUpdate = true
     materialRef.needsUpdate = true
@@ -74,6 +99,27 @@ export function createWeatherRainEmitter({
         uniformState.highlightWidth = baseUniforms.highlightWidth
       } else if (Number.isFinite(overrides.highlightWidth)) {
         uniformState.highlightWidth = Math.max(0.02, overrides.highlightWidth)
+      }
+    }
+    if (overrides.rippleScale !== undefined) {
+      if (overrides.rippleScale === null) {
+        uniformState.rippleScale = baseUniforms.rippleScale
+      } else if (Number.isFinite(overrides.rippleScale)) {
+        uniformState.rippleScale = Math.max(0.25, overrides.rippleScale)
+      }
+    }
+    if (overrides.dropDensity !== undefined) {
+      if (overrides.dropDensity === null) {
+        uniformState.dropDensity = baseUniforms.dropDensity
+      } else if (Number.isFinite(overrides.dropDensity)) {
+        uniformState.dropDensity = Math.max(0.1, overrides.dropDensity)
+      }
+    }
+    if (overrides.timerBias !== undefined) {
+      if (overrides.timerBias === null) {
+        uniformState.timerBias = baseUniforms.timerBias
+      } else if (Number.isFinite(overrides.timerBias)) {
+        uniformState.timerBias = overrides.timerBias
       }
     }
     applyUniforms()
@@ -114,10 +160,13 @@ export function createWeatherRainEmitter({
     renderOrder: 4,
     materialFactory: ({ defaultFactory }) => {
       const material = defaultFactory()
-      material.fragmentShader = weatherRainStreakFragmentShader
+      material.fragmentShader = weatherRainAdvancedFragmentShader
       material.uniforms.uWindTilt = { value: uniformState.windTilt }
       material.uniforms.uStreakNoise = { value: uniformState.streakNoise }
       material.uniforms.uHighlightWidth = { value: uniformState.highlightWidth }
+      material.uniforms.uRippleScale = { value: uniformState.rippleScale }
+      material.uniforms.uDropDensity = { value: uniformState.dropDensity }
+      material.uniforms.uTimerBias = { value: uniformState.timerBias }
       materialRef = material
       applyUniforms()
       return material

--- a/three-demo/src/rendering/shaders/weather-rain-advanced.glsl.js
+++ b/three-demo/src/rendering/shaders/weather-rain-advanced.glsl.js
@@ -1,0 +1,130 @@
+export const weatherRainAdvancedFragmentShader = /* glsl */ `
+precision mediump float;
+
+uniform float uWindTilt;
+uniform float uStreakNoise;
+uniform float uHighlightWidth;
+uniform float uRippleScale;
+uniform float uDropDensity;
+uniform float uTimerBias;
+uniform float uTime;
+
+varying vec4 vColor;
+varying vec2 vLocalUv;
+varying float vNormalizedAge;
+
+const vec3 HASH_SCALE3 = vec3(0.1031, 0.1030, 0.0973);
+
+vec3 hash33(vec3 p3) {
+  p3 = fract(p3 * HASH_SCALE3);
+  p3 += dot(p3, p3.yxz + 19.19);
+  return fract((p3.xxy + p3.yxx) * p3.zyx);
+}
+
+float bias(float s, float b) {
+  float safeBias = max(b, 0.0001);
+  return s / ((((1.0 / safeBias) - 2.0) * (1.0 - s)) + 1.0);
+}
+
+float vorRain(vec3 p, float seed, float dropDensity, float timerBias) {
+  float rippleScale = max(uRippleScale, 0.0001);
+  vec3 sample = vec3(p.x, p.z, p.y);
+  sample /= rippleScale;
+  vec3 uv2 = sample;
+  vec3 cell = floor(sample);
+  float density = clamp(dropDensity, 0.0, 2.5);
+  float speed = mix(0.55, 1.45, clamp(density * 0.4, 0.0, 1.0));
+  float timeValue = uTime * speed + timerBias * 2.1 + seed * 0.17;
+  float accum = 0.0;
+
+  for (int j = -1; j <= 1; ++j) {
+    for (int k = -1; k <= 1; ++k) {
+      vec3 offset = vec3(float(j), float(k), 0.0);
+      vec3 s1 = hash33(cell + offset + vec3(127.43 + seed));
+      vec2 timerState = floor(vec2(s1.x) + timeValue);
+      vec2 dropHash = hash33(
+        cell + offset + vec3(timerState.x, timerState.y, seed)
+      ).xz;
+      s1 = fract(s1 + timeValue);
+
+      float opacity = bias(1.0 - s1.x, 0.21 + clamp(timerBias, -0.5, 1.5) * 0.35);
+      float fade = bias(s1.x, 0.62);
+      float size = mix(4.0, 1.0, fade);
+      float size2 = mix(0.005, 2.0, fade);
+
+      vec2 rippleDelta = (cell.xy + dropHash) - (uv2.xy - offset.xy);
+      float ripple = length(rippleDelta) * size;
+      ripple = 1.0 - ripple;
+      ripple *= size2;
+      ripple = clamp(ripple, 0.0, 1.2);
+      ripple = mix(ripple * ripple, ripple, 0.5);
+      ripple = smoothstep(0.0, 1.0, ripple);
+      ripple *= opacity;
+
+      accum = 1.0 - ((1.0 - accum) * (1.0 - ripple));
+    }
+  }
+
+  return accum * 0.1;
+}
+
+float dfRipples(vec3 p, float dropDensity, float timerBias) {
+  float layers = clamp(dropDensity * 3.0, 1.0, 4.0);
+  float total = 0.0;
+
+  for (int i = 0; i < 4; ++i) {
+    float active = step(float(i), layers - 0.001);
+    total += vorRain(p, float(i) + 1.0, dropDensity, timerBias) * active;
+  }
+
+  return (p.y + 1.0) - total;
+}
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float streakNoise(vec2 uv, float travel) {
+  vec2 cell = floor(vec2(uv.x * 18.0, uv.y * 42.0 + travel));
+  float base = hash(cell + travel);
+  float head = fract(uv.y * 18.0 + base * 6.0 + travel * 0.5);
+  float sparkle = smoothstep(0.65, 0.1, head);
+  return mix(base, sparkle, 0.75);
+}
+
+float streakMask(float offset, float highlightWidth) {
+  float core = smoothstep(0.85, 0.0, abs(offset));
+  float highlight = exp(-pow(offset / max(highlightWidth, 0.02), 2.0));
+  return clamp(core + highlight * 1.4, 0.0, 1.6);
+}
+
+void main() {
+  if (vColor.a <= 0.0001) {
+    discard;
+  }
+
+  vec2 uv = vLocalUv;
+  float tilt = uWindTilt;
+  float slantedX = (uv.x - 0.5) + tilt * (1.0 - uv.y);
+  float highlightWidth = max(uHighlightWidth, 0.025);
+  float travel = vNormalizedAge * 12.0;
+  float noiseSample = streakNoise(uv, travel + uStreakNoise * 4.0);
+
+  float streak = streakMask(slantedX, highlightWidth);
+  float taper = smoothstep(1.0, 0.25, uv.y);
+  float shimmer = smoothstep(0.15, 0.95, noiseSample + streak * uStreakNoise);
+  float body = clamp(streak * (0.6 + noiseSample * 0.5), 0.0, 1.2);
+
+  vec3 ripplePoint = vec3(uv.x * 2.0 - 1.0, uTimerBias, uv.y * 2.0 - 1.0);
+  float rippleHeight = dfRipples(ripplePoint, uDropDensity, uTimerBias);
+  float rippleStrength = clamp(1.0 - rippleHeight * 4.0, 0.0, 1.0);
+  float rippleHighlight = smoothstep(0.1, 0.85, rippleStrength);
+
+  float brightness = clamp(body * 0.9 + shimmer * 0.75 + rippleHighlight * 0.6, 0.0, 1.95);
+  vec3 color = vColor.rgb * (0.6 + brightness);
+  float alpha = vColor.a * clamp(body * 0.85 + shimmer * 0.45, 0.0, 1.0) * taper;
+  alpha *= mix(0.85, 1.25, rippleHighlight);
+
+  gl_FragColor = vec4(color, alpha);
+}
+`;


### PR DESCRIPTION
## Summary
- add an advanced rain fragment shader that ports Shadertoy-inspired ripple hashing and fade helpers
- extend the weather rain emitter to expose ripple, density, and timer bias uniforms while wiring them into the material

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2758e9ec832a9f7a7e5826089477