### PR TITLE
Brighten rain streaks in daylight

### DIFF
--- a/three-demo/src/rendering/particles/weather-rain.js
+++ b/three-demo/src/rendering/particles/weather-rain.js
@@ -129,13 +129,13 @@ export function createWeatherRainEmitter({
     spawnRate: Math.min(560 * density, 960),
     maxParticles: Math.ceil(Math.min(900 * density, 1180)),
     lifetime: { min: 1.35, max: 2.25 },
-    baseColor: '#204c7a',
+    baseColor: '#3f8bdb',
     colorRamp: [
-      { time: 0, color: '#081629' },
-      { time: 0.18, color: '#0f2f57' },
-      { time: 0.45, color: '#1e6bc0' },
-      { time: 0.78, color: '#6faef5' },
-      { time: 1, color: '#d6ecff' },
+      { time: 0, color: '#0d213b' },
+      { time: 0.18, color: '#17477e' },
+      { time: 0.45, color: '#2f88ec' },
+      { time: 0.78, color: '#7bd2ff' },
+      { time: 1, color: '#eef9ff' },
     ],
     sizeOverLifetime: [
       { time: 0, size: 1.5 },
@@ -155,7 +155,7 @@ export function createWeatherRainEmitter({
     fadeIn: 0.06,
     fadeOut: 0.34,
     opacity: 0.94,
-    blending: THREE.NormalBlending,
+    blending: THREE.AdditiveBlending,
     depthWrite: false,
     renderOrder: 4,
     materialFactory: ({ defaultFactory }) => {

--- a/three-demo/src/rendering/shaders/weather-rain-advanced.glsl.js
+++ b/three-demo/src/rendering/shaders/weather-rain-advanced.glsl.js
@@ -120,9 +120,13 @@ void main() {
   float rippleStrength = clamp(1.0 - rippleHeight * 4.0, 0.0, 1.0);
   float rippleHighlight = smoothstep(0.1, 0.85, rippleStrength);
 
-  float brightness = clamp(body * 0.9 + shimmer * 0.75 + rippleHighlight * 0.6, 0.0, 1.95);
-  vec3 color = vColor.rgb * (0.6 + brightness);
-  float alpha = vColor.a * clamp(body * 0.85 + shimmer * 0.45, 0.0, 1.0) * taper;
+  float brightness = clamp(
+    body * 0.95 + shimmer * 0.9 + rippleHighlight * 0.75,
+    0.0,
+    2.6
+  );
+  vec3 color = vColor.rgb * (0.85 + brightness * 1.1);
+  float alpha = vColor.a * clamp(body * 0.85 + shimmer * 0.55, 0.0, 1.35) * taper;
   alpha *= mix(0.85, 1.25, rippleHighlight);
 
   gl_FragColor = vec4(color, alpha);


### PR DESCRIPTION
## Summary
- retune the rain particle material with additive blending and brighter color ramps to keep streaks visible in daylight
- relax rain fragment shader brightness and alpha clamps so highlights remain punchy under bright lighting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db357c50fc832abd23adc8cf526731