### PR TITLE
Add DOM-driven rain overlay styling

### DIFF
--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -120,6 +120,135 @@
         }
       }
 
+      /*
+        Weather overlay variables updated by the weather overlay controller:
+          --rain-intensity: overall strength of the effect (0 hides the overlay).
+          --rain-wind: horizontal drift multiplier applied to the streak animation.
+          --rain-velocity: fall-speed multiplier applied to each raindrop animation.
+          --rain-density: opacity multiplier for individual streaks.
+      */
+      #weather-overlay {
+        --rain-intensity: 0;
+        --rain-wind: 0;
+        --rain-velocity: 1;
+        --rain-density: 0;
+        position: fixed;
+        inset: 0;
+        z-index: 80;
+        pointer-events: none;
+        overflow: hidden;
+        opacity: clamp(0, var(--rain-intensity, 0), 1);
+        transition: opacity 0.35s ease, filter 0.6s ease;
+        filter: saturate(120%);
+        mix-blend-mode: screen;
+        transform: translateZ(0);
+        will-change: opacity;
+      }
+
+      #weather-overlay::before {
+        content: "";
+        position: absolute;
+        inset: -10%;
+        background: radial-gradient(
+            circle at 30% 20%,
+            rgba(180, 210, 255, 0.35),
+            transparent 45%
+          ),
+          radial-gradient(
+            circle at 70% 30%,
+            rgba(120, 180, 255, 0.22),
+            transparent 60%
+          ),
+          linear-gradient(180deg, rgba(20, 52, 92, 0.35), transparent 60%);
+        opacity: calc(clamp(0, var(--rain-intensity, 0), 1) * 0.55);
+        pointer-events: none;
+      }
+
+      #weather-overlay::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.18) 0%,
+          rgba(120, 160, 210, 0.08) 35%,
+          transparent 100%
+        );
+        mix-blend-mode: overlay;
+        opacity: calc(clamp(0, var(--rain-intensity, 0), 1) * 0.32);
+        pointer-events: none;
+      }
+
+      #weather-overlay .raindrop {
+        position: absolute;
+        top: -120vh;
+        left: var(--raindrop-left, 50%);
+        width: 2px;
+        height: calc(70vh * var(--raindrop-scale, 1));
+        background: linear-gradient(
+          to bottom,
+          rgba(220, 235, 255, 0) 0%,
+          rgba(220, 235, 255, 0.75) 45%,
+          rgba(120, 165, 220, 0.35) 80%,
+          rgba(120, 165, 220, 0) 100%
+        );
+        opacity: calc(clamp(0, var(--rain-density, 0), 1) * 0.9);
+        transform: translate3d(0, 0, 0);
+        animation-name: rainStreakFall;
+        animation-duration: calc(
+          var(--raindrop-duration, 1.4s) / max(var(--rain-velocity, 1), 0.2)
+        );
+        animation-timing-function: linear;
+        animation-delay: var(--raindrop-delay, 0s);
+        animation-iteration-count: infinite;
+        animation-play-state: paused;
+      }
+
+      #weather-overlay:not([hidden]) .raindrop {
+        animation-play-state: running;
+      }
+
+      #weather-overlay .raindrop::after {
+        content: "";
+        position: absolute;
+        inset: -120% -160% 40% -160%;
+        background: radial-gradient(
+          circle,
+          rgba(220, 235, 255, 0.4) 0%,
+          rgba(220, 235, 255, 0) 65%
+        );
+        opacity: calc(clamp(0, var(--rain-density, 0), 1) * 0.35);
+        filter: blur(10px);
+      }
+
+      @keyframes rainStreakFall {
+        0% {
+          transform: translate3d(
+            calc(var(--rain-wind, 0) * -18px),
+            -120vh,
+            0
+          );
+          opacity: 0;
+        }
+
+        12% {
+          opacity: calc(0.4 + clamp(0, var(--rain-intensity, 0), 1) * 0.5);
+        }
+
+        55% {
+          opacity: calc(0.8 + clamp(0, var(--rain-intensity, 0), 1) * 0.2);
+        }
+
+        100% {
+          transform: translate3d(
+            calc(var(--rain-wind, 0) * 22px),
+            120vh,
+            0
+          );
+          opacity: 0;
+        }
+      }
+
       #overlay {
         position: absolute;
         top: 0;
@@ -173,6 +302,7 @@
         pointer-events: none;
         min-width: 220px;
         font-size: 14px;
+        z-index: 110;
       }
 
       .hud-bar {

--- a/three-demo/src/ui/weather-overlay-controller.js
+++ b/three-demo/src/ui/weather-overlay-controller.js
@@ -1,8 +1,9 @@
 const OVERLAY_ID = 'weather-overlay'
 const RAINDROP_CLASS = 'raindrop'
-const INTENSITY_VAR = '--weather-intensity'
-const WIND_SWAY_VAR = '--weather-wind-sway'
-const DENSITY_VAR = '--weather-droplet-density'
+const INTENSITY_VAR = '--rain-intensity'
+const WIND_SWAY_VAR = '--rain-wind'
+const DENSITY_VAR = '--rain-density'
+const VELOCITY_VAR = '--rain-velocity'
 
 function parseDensityPreference(root) {
   const source = root?.dataset?.weatherDropletCount ?? document.body?.dataset?.weatherDropletCount
@@ -62,7 +63,9 @@ export function createWeatherOverlayController({ root = document.body } = {}) {
     overlayElement.style.height = '100%'
     overlayElement.style.pointerEvents = 'none'
     overlayElement.style.overflow = 'hidden'
-    overlayElement.style.zIndex = '70'
+    overlayElement.style.zIndex = '80'
+    overlayElement.hidden = true
+    overlayElement.style.display = 'none'
   }
 
   const desiredCount = parseDensityPreference(host) ?? 24
@@ -125,6 +128,18 @@ export function createWeatherOverlayController({ root = document.body } = {}) {
     overlayElement.style.setProperty(DENSITY_VAR, `${resolved}`)
   }
 
+  const setVelocity = (value) => {
+    if (!overlayElement) {
+      return
+    }
+    const resolved = sanitiseCssValue(value)
+    if (resolved === null) {
+      overlayElement.style.removeProperty(VELOCITY_VAR)
+      return
+    }
+    overlayElement.style.setProperty(VELOCITY_VAR, `${resolved}`)
+  }
+
   const update = ({ delta } = {}) => {
     void delta
   }
@@ -136,6 +151,7 @@ export function createWeatherOverlayController({ root = document.body } = {}) {
     setIntensity(null)
     setWindSway(null)
     setDropletDensity(null)
+    setVelocity(null)
     raindrops.forEach((drop) => {
       if (drop.parentElement === overlayElement) {
         overlayElement.removeChild(drop)
@@ -152,6 +168,7 @@ export function createWeatherOverlayController({ root = document.body } = {}) {
     setIntensity,
     setWindSway,
     setDropletDensity,
+    setVelocity,
     update,
     dispose,
   }

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -830,10 +830,12 @@ export function createWeatherManager({
     try {
       raindropOverlayController.setIntensity?.(0);
       raindropOverlayController.setDropletDensity?.(0);
+      raindropOverlayController.setVelocity?.(null);
     } catch (error) {
       console.warn('Failed to reset weather overlay controller state:', error);
     }
     if (raindropOverlayController.element) {
+      raindropOverlayController.element.setAttribute('aria-hidden', 'true');
       raindropOverlayController.element.hidden = true;
       raindropOverlayController.element.style.display = 'none';
     }
@@ -884,7 +886,9 @@ export function createWeatherManager({
       controller.setIntensity?.(targets.intensity);
       controller.setWindSway?.(targets.windSpeed);
       controller.setDropletDensity?.(targets.streakDensity);
+      controller.setVelocity?.(targets.dropSpeed ?? null);
       if (controller.element) {
+        controller.element.setAttribute('aria-hidden', 'false');
         controller.element.hidden = false;
         controller.element.style.display = '';
       }


### PR DESCRIPTION
## Summary
- add weather overlay styling to the HTML shell, including documented rain CSS variables and animated raindrop streaks
- align the overlay controller with the new variables, default hidden state, and expose a velocity hook
- propagate weather manager updates to drive the DOM overlay and preserve accessibility hints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe1bbdd5c832a956a446caebfcb07