### PR TITLE
Add polar snow and aurora weather rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Commands are grouped by the kind of developer workflow they support:
 - **ASCII tooling** – `/asciimap` renders a top-down ASCII slice, `/asciioptions` saves default radii/offsets/watch cadence, and `/asciiwatch` keeps the map refreshing on demand. 【F:three-demo/src/player/dev-commands.js†L919-L1039】
 - **VFX inspection** – `/vfx overlay [on|off|toggle]` adds a particle debugging overlay, while `/vfx list` dumps live emitter and fluid surface stats to the console. 【F:three-demo/src/player/dev-commands.js†L780-L823】
 
+### Weather presets
+
+Cold biomes now ship with bespoke snow and aurora presets that can be inspected directly from the console. Use `/weather soft_snowfall` to summon calm crystalline flakes with the new puff-based screen overlay, `/weather polar_aurora` to spawn high-altitude ribbon curtains, or `/weather aurora_snowfall` to blend both effects. Once you are satisfied with the manual checks, run `/weather on` to resume automated rotation so the manager can schedule the new presets naturally. 【F:three-demo/src/world/weather/weather-manager.js†L20-L150】【F:three-demo/src/player/dev-commands.js†L1508-L1714】
+
 ## Performance Instrumentation
 
 When the sandbox is running in the Vite dev server, the browser exposes a debug namespace at `window.__VOXEL_DEBUG__`. You can launch an automated "perf flight" from the DevTools console to gather renderer and world metrics while the avatar flies forward for a fixed window. 【F:three-demo/src/main.js†L250-L318】

--- a/three-demo/docs/weather-remediation-plan.md
+++ b/three-demo/docs/weather-remediation-plan.md
@@ -107,6 +107,11 @@ Please continue appending follow-up findings or configuration changes here whene
 - Reworked the derived wind, streak-density, and sparkle gains to follow the same curve, topping out at 2.35/2.75/1.8 so the DOM variables (`--rain-wind`, `--rain-density`, `--rain-intensity`) stay in lock-step with the stronger overlay response.【F:src/world/weather/weather-manager.js†L420-L455】
 - Regression coverage now includes a dedicated downpour case that expects the DOM overlay to clamp at the new ceiling, ensuring future retuning updates this plan alongside the test helpers that compute the overlay response.【F:src/world/__tests__/weather-manager.test.js†L274-L347】
 
+## 2026-03 Polar Snow & Aurora Presets
+- Introduced dedicated `soft_snowfall`, `polar_aurora`, and `aurora_snowfall` presets so QA can spawn snowflakes and aurora ribbons without tweaking ad-hoc configs. Snow presets now reuse the DOM raindrop overlay with puff-centric tuning (low wind, rounded streak density, and custom drop-speed metadata) to guarantee visibility in frozen biomes.【F:src/world/weather/weather-manager.js†L20-L150】【F:src/world/weather/weather-manager.js†L395-L470】【F:src/world/weather/weather-manager.js†L2060-L2085】
+- Updated cold and aurora biomes to favour the new weather IDs—snow is now the dominant condition in the Ice Spire Tundra and Frostbound Steppe, while aurora rotations are common across aurora-focused regions with only rare sightings in harsher tundra zones.【F:src/world/biomes/ice_spire_tundra.json†L63-L104】【F:src/world/biomes/tundra.json†L63-L106】【F:src/world/biomes/aurora_shard_expanse.json†L79-L124】【F:src/world/biomes/auroral_glass_reef.json†L60-L92】
+- Regression suite gains coverage for both the standalone snow preset and aurora combinations so CI confirms `spawnPrecipitationEffect` and `spawnAuroraEffects` keep emitting handles and updating the shared overlay metadata.【F:src/world/__tests__/weather-manager.test.js†L360-L480】
+
 ## Work Orders
 1. **Gameplay-driven rotation**
    - Sample the player’s biome each frame (reusing the `sampleBiomeAt` helper from `/weather status`) and resolve the preset rotation with `resolveBiomeWeatherRotation`, storing timing metadata per biome.【F:src/player/dev-commands.js†L1532-L1562】【F:src/world/weather/weather-manager.js†L76-L127】

--- a/three-demo/index.html
+++ b/three-demo/index.html
@@ -128,6 +128,8 @@
           --rain-velocity: fall-speed multiplier applied to each raindrop animation.
           --rain-density: opacity multiplier for individual streaks (typical range 0-3).
           --rain-density-alpha: normalized helper mapping --rain-density into [0, 1] for opacity calculations.
+        Snow presets reuse these variables with gentle wind, rounded densities, and lower velocities to render soft puff flakes
+        across the same DOM host.
       */
       #weather-overlay {
         --rain-intensity: 0;

--- a/three-demo/src/world/__tests__/weather-manager.test.js
+++ b/three-demo/src/world/__tests__/weather-manager.test.js
@@ -893,6 +893,160 @@ test('raindrop overlay intensity follows precipitation tuning', () => {
   }
 });
 
+test('snow presets spawn snow emitter and puff overlay', () => {
+  const { restore } = setupDomEnvironment();
+  const emitLabels = [];
+  const { manager, particleSystem, scene } = createManager({
+    useDomRaindropOverlay: true,
+    emitImplementation: (emitter) => {
+      emitLabels.push(emitter.debugLabel ?? 'unknown');
+      return { stop() {} };
+    },
+  });
+
+  try {
+    manager.setWeather('soft_snowfall');
+    manager.update({ delta: 0.1, elapsedTime: 1 });
+
+    const snowEmitters = emitLabels.filter((label) => label === 'WeatherSnowEmitter');
+    assert.equal(
+      snowEmitters.length,
+      1,
+      'expected snow preset to spawn a single snow emitter',
+    );
+    assert.equal(
+      particleSystem.emitted.length,
+      1,
+      'expected snow presets to only emit the primary precipitation layer',
+    );
+
+    const weatherState = scene.userData.weather ?? {};
+    assert.equal(
+      weatherState.precipitationLayers?.primary?.label,
+      'WeatherSnowEmitter',
+      'expected precipitation metadata to report the snow emitter label',
+    );
+
+    const overlayElement = document.getElementById('weather-overlay');
+    assert.ok(overlayElement, 'expected DOM weather overlay to be appended for snow presets');
+    assert.equal(overlayElement.hidden, false, 'expected weather overlay to be visible for snow');
+
+    const overlayMetadata = weatherState.raindropOverlay ?? {};
+    assert.ok(overlayMetadata.visible, 'expected snow overlay metadata to flag visibility');
+    assert.ok(
+      approxEqual(overlayMetadata.intensity ?? 0, 0.82, 1e-4),
+      'expected snow overlay intensity to follow preset puff tuning',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.windSpeed ?? 0, 0.12, 1e-4),
+      'expected snow overlay wind to remain gentle',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.streakDensity ?? 0, 0.54, 1e-4),
+      'expected snow overlay to favour rounded droplet density',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.sparkleGain ?? 0, 0.72, 1e-4),
+      'expected snow overlay sparkle gain to match preset config',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.baseDropSpeed ?? 0, 0.34, 1e-4),
+      'expected snow overlay metadata to capture puff drop speed',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.baseViscosity ?? 0, 0.88, 1e-4),
+      'expected snow overlay viscosity to match preset config',
+    );
+
+    const cssIntensity = Number.parseFloat(
+      overlayElement.style.getPropertyValue('--rain-intensity') || '0',
+    );
+    assert.ok(
+      approxEqual(cssIntensity, 0.82, 1e-4),
+      'expected DOM overlay intensity CSS variable to follow snow puff tuning',
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('aurora presets spawn ribbon emitters', () => {
+  const emitLabels = [];
+  const { manager, particleSystem, scene } = createManager({
+    emitImplementation: (emitter) => {
+      emitLabels.push(emitter.debugLabel ?? 'unknown');
+      return { stop() {} };
+    },
+  });
+
+  manager.setWeather('polar_aurora');
+  manager.update({ delta: 0.1, elapsedTime: 1 });
+
+  const ribbonCount = emitLabels.filter((label) => label === 'AuroraRibbonEmitter').length;
+  assert.equal(ribbonCount, 3, 'expected polar aurora preset to spawn three aurora ribbons');
+  assert.equal(
+    particleSystem.emitted.length,
+    3,
+    'expected aurora preset to emit one ribbon handle per spawn',
+  );
+
+  const weatherState = scene.userData.weather ?? {};
+  assert.equal(weatherState.aurora, true, 'expected aurora metadata to mark active ribbons');
+  assert.equal(
+    weatherState.precipitationLayers?.primary ?? null,
+    null,
+    'expected aurora-only preset to avoid precipitation layers',
+  );
+});
+
+test('aurora snowfall combines snow emitters and aurora ribbons', () => {
+  const { restore } = setupDomEnvironment();
+  const emitLabels = [];
+  const { manager, particleSystem, scene } = createManager({
+    useDomRaindropOverlay: true,
+    emitImplementation: (emitter) => {
+      emitLabels.push(emitter.debugLabel ?? 'unknown');
+      return { stop() {} };
+    },
+  });
+
+  try {
+    manager.setWeather('aurora_snowfall');
+    manager.update({ delta: 0.1, elapsedTime: 1 });
+
+    const snowCount = emitLabels.filter((label) => label === 'WeatherSnowEmitter').length;
+    const auroraCount = emitLabels.filter((label) => label === 'AuroraRibbonEmitter').length;
+    assert.equal(snowCount, 1, 'expected combined preset to spawn a snow emitter');
+    assert.equal(auroraCount, 2, 'expected combined preset to spawn two aurora ribbons');
+    assert.equal(
+      particleSystem.emitted.length,
+      3,
+      'expected combined preset to emit both snow and aurora handles',
+    );
+
+    const weatherState = scene.userData.weather ?? {};
+    assert.equal(weatherState.aurora, true, 'expected combined preset to flag aurora activity');
+    assert.equal(
+      weatherState.precipitationLayers?.primary?.label,
+      'WeatherSnowEmitter',
+      'expected precipitation metadata to point to snow emitter for combined preset',
+    );
+
+    const overlayMetadata = weatherState.raindropOverlay ?? {};
+    assert.ok(overlayMetadata.visible, 'expected combined preset to keep puff overlay active');
+    assert.ok(
+      approxEqual(overlayMetadata.intensity ?? 0, 0.92, 1e-4),
+      'expected combined preset to use brighter puff overlay intensity',
+    );
+    assert.ok(
+      approxEqual(overlayMetadata.windSpeed ?? 0, 0.18, 1e-4),
+      'expected combined preset to apply documented wind drift',
+    );
+  } finally {
+    restore();
+  }
+});
+
 test('raindrop overlay manual uniform overrides clamp and persist', () => {
   const { restore } = setupDomEnvironment();
   const { manager, scene } = createManager({

--- a/three-demo/src/world/biomes/aurora_shard_expanse.json
+++ b/three-demo/src/world/biomes/aurora_shard_expanse.json
@@ -83,17 +83,32 @@
     "candidates": [
       {
         "id": "clear_skies",
-        "weight": 3,
+        "weight": 2,
         "duration": { "min": 260, "max": 520 }
       },
       {
+        "id": "polar_aurora",
+        "weight": 6,
+        "duration": { "min": 260, "max": 520 }
+      },
+      {
+        "id": "aurora_snowfall",
+        "weight": 4,
+        "duration": { "min": 220, "max": 460 }
+      },
+      {
+        "id": "soft_snowfall",
+        "weight": 3,
+        "duration": { "min": 180, "max": 360 }
+      },
+      {
         "id": "misty_rain",
-        "weight": 1,
+        "weight": 0.6,
         "duration": { "min": 140, "max": 260 }
       },
       {
         "id": "charged_storm",
-        "weight": 2,
+        "weight": 0.8,
         "duration": { "min": 110, "max": 220 }
       }
     ]

--- a/three-demo/src/world/biomes/auroral_glass_reef.json
+++ b/three-demo/src/world/biomes/auroral_glass_reef.json
@@ -44,12 +44,22 @@
     "candidates": [
       {
         "id": "clear_skies",
-        "weight": 5,
+        "weight": 4,
         "duration": { "min": 260, "max": 520 }
+      },
+      {
+        "id": "polar_aurora",
+        "weight": 4,
+        "duration": { "min": 240, "max": 480 }
       },
       {
         "id": "misty_rain",
         "weight": 2,
+        "duration": { "min": 150, "max": 280 }
+      },
+      {
+        "id": "soft_snowfall",
+        "weight": 1,
         "duration": { "min": 150, "max": 280 }
       }
     ]

--- a/three-demo/src/world/biomes/ice_spire_tundra.json
+++ b/three-demo/src/world/biomes/ice_spire_tundra.json
@@ -71,14 +71,29 @@
         "duration": { "min": 200, "max": 420 }
       },
       {
-        "id": "misty_rain",
-        "weight": 1,
-        "duration": { "min": 130, "max": 240 }
+        "id": "soft_snowfall",
+        "weight": 5,
+        "duration": { "min": 160, "max": 320 }
       },
       {
         "id": "charged_storm",
-        "weight": 3,
+        "weight": 2,
         "duration": { "min": 90, "max": 180 }
+      },
+      {
+        "id": "aurora_snowfall",
+        "weight": 0.45,
+        "duration": { "min": 220, "max": 420 }
+      },
+      {
+        "id": "polar_aurora",
+        "weight": 0.25,
+        "duration": { "min": 240, "max": 460 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 0.5,
+        "duration": { "min": 120, "max": 210 }
       }
     ]
   }

--- a/three-demo/src/world/biomes/tundra.json
+++ b/three-demo/src/world/biomes/tundra.json
@@ -47,14 +47,29 @@
         "duration": { "min": 240, "max": 500 }
       },
       {
-        "id": "misty_rain",
-        "weight": 2,
-        "duration": { "min": 150, "max": 260 }
+        "id": "soft_snowfall",
+        "weight": 4,
+        "duration": { "min": 170, "max": 320 }
       },
       {
         "id": "charged_storm",
         "weight": 1,
         "duration": { "min": 100, "max": 180 }
+      },
+      {
+        "id": "aurora_snowfall",
+        "weight": 0.55,
+        "duration": { "min": 200, "max": 360 }
+      },
+      {
+        "id": "polar_aurora",
+        "weight": 0.2,
+        "duration": { "min": 220, "max": 400 }
+      },
+      {
+        "id": "misty_rain",
+        "weight": 0.8,
+        "duration": { "min": 140, "max": 260 }
       }
     ]
   }

--- a/three-demo/src/world/weather/weather-manager.js
+++ b/three-demo/src/world/weather/weather-manager.js
@@ -62,6 +62,91 @@ const DEFAULT_WEATHER_PRESETS = {
       },
     },
   },
+  soft_snowfall: {
+    id: 'soft_snowfall',
+    label: 'Soft Snowfall',
+    description: 'Gentle crystalline flakes drift through calm polar air.',
+    intensity: 0.55,
+    category: 'snow',
+    moisture: 0.7,
+    temperature: 0.18,
+    effects: {
+      precipitation: {
+        type: 'snow',
+        intensity: 0.7,
+        radius: 12,
+        anchorHeight: 15,
+        updateInterval: 0.32,
+        raindropOverlay: {
+          intensity: 0.82,
+          windSpeed: 0.12,
+          streakDensity: 0.54,
+          sparkleGain: 0.72,
+          rippleScale: 0.78,
+          dropSpeed: 0.34,
+          viscosity: 0.88,
+        },
+      },
+    },
+  },
+  polar_aurora: {
+    id: 'polar_aurora',
+    label: 'Polar Aurora',
+    description: 'Iridescent aurora curtains sweep overhead while the air stays still.',
+    intensity: 0.75,
+    category: 'aurora',
+    moisture: 0.35,
+    temperature: 0.1,
+    effects: {
+      aurora: {
+        intensity: 1.15,
+        span: 12,
+        count: 3,
+        anchorHeight: 28,
+        forwardOffset: 44,
+        lateralOffset: 12,
+        orientationJitter: Math.PI / 14,
+        alignWithHeading: true,
+      },
+    },
+  },
+  aurora_snowfall: {
+    id: 'aurora_snowfall',
+    label: 'Aurora Snowfall',
+    description: 'Soft snow puffs fall as aurora ribbons shimmer in the distance.',
+    intensity: 0.65,
+    category: 'snow',
+    moisture: 0.74,
+    temperature: 0.16,
+    effects: {
+      precipitation: {
+        type: 'snow',
+        intensity: 0.65,
+        radius: 13,
+        anchorHeight: 16,
+        updateInterval: 0.3,
+        raindropOverlay: {
+          intensity: 0.92,
+          windSpeed: 0.18,
+          streakDensity: 0.58,
+          sparkleGain: 0.78,
+          rippleScale: 0.82,
+          dropSpeed: 0.38,
+          viscosity: 0.82,
+        },
+      },
+      aurora: {
+        intensity: 0.95,
+        span: 11,
+        count: 2,
+        anchorHeight: 26,
+        forwardOffset: 42,
+        lateralOffset: 9,
+        orientationJitter: Math.PI / 12,
+        alignWithHeading: true,
+      },
+    },
+  },
 };
 
 const CATEGORY_DEFAULT_EFFECTS = {
@@ -302,6 +387,9 @@ function normalisePrecipitationEffect(weather, effect) {
   let raindropOverlay = null;
   if (overlayEffect) {
     const overlayConfig = {};
+    if (Number.isFinite(overlayEffect.intensity)) {
+      overlayConfig.intensity = clampRaindropOverlayIntensity(overlayEffect.intensity);
+    }
     if (Number.isFinite(overlayEffect.windSpeed)) {
       overlayConfig.windSpeed = clampRaindropOverlayWindSpeed(overlayEffect.windSpeed);
     }
@@ -455,6 +543,73 @@ function resolveRainOverlayResponse(precipitation) {
     overlayConfig.viscosity !== undefined && Number.isFinite(overlayConfig.viscosity)
       ? overlayConfig.viscosity
       : null;
+  return {
+    active: intensity > 0,
+    intensity,
+    windSpeed: clampRaindropOverlayWindSpeed(windSource),
+    streakDensity: clampRaindropOverlayStreakDensity(streakSource),
+    sparkleGain: clampRaindropOverlaySparkleGain(sparkleSource),
+    rippleScale: rippleScaleSource,
+    dropSpeed: dropSpeedSource,
+    viscosity: viscositySource,
+  };
+}
+
+function resolveSnowOverlayResponse(precipitation) {
+  const defaults = {
+    active: false,
+    intensity: 0,
+    windSpeed: 0,
+    streakDensity: clampRaindropOverlayStreakDensity(0.5),
+    sparkleGain: clampRaindropOverlaySparkleGain(0.65),
+    rippleScale: null,
+    dropSpeed: null,
+    viscosity: null,
+  };
+  if (!precipitation) {
+    return defaults;
+  }
+  const overlayConfig = precipitation.raindropOverlay ?? {};
+  const baseIntensitySource = (() => {
+    const raw = Number.isFinite(precipitation.intensity)
+      ? Math.max(0, precipitation.intensity)
+      : 0;
+    const curved = Math.pow(Math.min(raw, 1.6), 0.78);
+    const scaled = RAIN_OVERLAY_INTENSITY_MIN + curved * 0.68;
+    return clamp(
+      scaled,
+      RAIN_OVERLAY_INTENSITY_MIN,
+      RAIN_OVERLAY_INTENSITY_MIN + (RAIN_OVERLAY_INTENSITY_MAX - RAIN_OVERLAY_INTENSITY_MIN) * 0.55,
+    );
+  })();
+  const intensitySource = Number.isFinite(overlayConfig.intensity)
+    ? overlayConfig.intensity
+    : baseIntensitySource;
+  const intensity = clampRaindropOverlayIntensity(intensitySource);
+  const windSource =
+    overlayConfig.windSpeed !== undefined
+      ? overlayConfig.windSpeed
+      : clampRaindropOverlayWindSpeed((precipitation.intensity ?? 0.4) * 0.12);
+  const streakSource =
+    overlayConfig.streakDensity !== undefined
+      ? overlayConfig.streakDensity
+      : clampRaindropOverlayStreakDensity(0.52 + Math.min(precipitation.intensity ?? 0.6, 1) * 0.08);
+  const sparkleSource =
+    overlayConfig.sparkleGain !== undefined
+      ? overlayConfig.sparkleGain
+      : clampRaindropOverlaySparkleGain(0.7 + Math.min(precipitation.intensity ?? 0.6, 1.2) * 0.1);
+  const rippleScaleSource =
+    overlayConfig.rippleScale !== undefined && Number.isFinite(overlayConfig.rippleScale)
+      ? overlayConfig.rippleScale
+      : 0.8;
+  const dropSpeedSource =
+    overlayConfig.dropSpeed !== undefined && Number.isFinite(overlayConfig.dropSpeed)
+      ? overlayConfig.dropSpeed
+      : 0.36;
+  const viscositySource =
+    overlayConfig.viscosity !== undefined && Number.isFinite(overlayConfig.viscosity)
+      ? overlayConfig.viscosity
+      : 0.85;
   return {
     active: intensity > 0,
     intensity,
@@ -2062,6 +2217,18 @@ export function createWeatherManager({
       spawnPrecipitationEffect(precipitation, context);
       if (precipitation.type === 'rain') {
         const overlayResponse = resolveRainOverlayResponse(precipitation);
+        overlayBaseState = {
+          active: overlayResponse.active,
+          intensity: overlayResponse.intensity,
+          windSpeed: overlayResponse.windSpeed,
+          streakDensity: overlayResponse.streakDensity,
+          sparkleGain: overlayResponse.sparkleGain,
+          rippleScale: overlayResponse.rippleScale ?? null,
+          dropSpeed: overlayResponse.dropSpeed ?? null,
+          viscosity: overlayResponse.viscosity ?? null,
+        };
+      } else if (precipitation.type === 'snow') {
+        const overlayResponse = resolveSnowOverlayResponse(precipitation);
         overlayBaseState = {
           active: overlayResponse.active,
           intensity: overlayResponse.intensity,


### PR DESCRIPTION
## Summary
- add dedicated soft snow, polar aurora, and combined aurora snowfall weather presets with puff-tuned overlays
- wire the new weather ids into frozen and aurora-focused biome rotations and document the additions for QA
- expand weather regression tests to cover snow overlays and aurora ribbons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbfd8489e0832abea146a3fe935ceb