### PR TITLE
Fix command console scrollbar fade

### DIFF
--- a/three-demo/src/ui/command-console.css
+++ b/three-demo/src/ui/command-console.css
@@ -49,13 +49,29 @@
 }
 
 .command-console-log {
+  position: relative;
   max-height: min(36vh, 320px);
   overflow-y: auto;
   padding: 0.85rem 1.1rem 0.65rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  mask-image: linear-gradient(to bottom, transparent, black 12px, black);
+}
+
+.command-console-log::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 18px;
+  background: linear-gradient(
+    to bottom,
+    rgba(7, 9, 15, 0.94),
+    rgba(7, 9, 15, 0.65),
+    rgba(7, 9, 15, 0)
+  );
+  pointer-events: none;
 }
 
 .command-console-form {


### PR DESCRIPTION
## Summary
- remove the CSS mask from the command console log so the scrollbar renders
- add a gradient overlay pseudo-element to preserve the fade effect without masking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc030bb86c832aa064419b132ed98a