### PR TITLE
Handle command console wheel scrolling

### DIFF
--- a/three-demo/src/ui/command-console.js
+++ b/three-demo/src/ui/command-console.js
@@ -320,6 +320,14 @@ export function createCommandConsole(options = {}) {
     input.value = '';
   }
 
+  function handleWheel(event) {
+    if (!isOpen) {
+      return;
+    }
+    event.preventDefault();
+    logElement.scrollTop += event.deltaY;
+  }
+
   function handleInputKeydown(event) {
 
 
@@ -361,11 +369,13 @@ export function createCommandConsole(options = {}) {
   document.addEventListener('keydown', handleDocumentKeydown);
   form.addEventListener('submit', handleFormSubmit);
   input.addEventListener('keydown', handleInputKeydown);
+  container.addEventListener('wheel', handleWheel, { passive: false });
 
   const dispose = () => {
     document.removeEventListener('keydown', handleDocumentKeydown);
     form.removeEventListener('submit', handleFormSubmit);
     input.removeEventListener('keydown', handleInputKeydown);
+    container.removeEventListener('wheel', handleWheel);
     container.remove();
   };
 


### PR DESCRIPTION
## Summary
- add a wheel handler to the command console overlay so scroll events are captured while open
- route overlay wheel movement into the log and dispose the listener with the console

## Testing
- npm install
- npm run build
- Reloaded the dev server, opened the console overlay, and confirmed wheel scrolling moves the log regardless of cursor position

------
https://chatgpt.com/codex/tasks/task_e_68dc0de94c28832a9e263689040a61d5