### PR TITLE
Add entity manager infrastructure and console diagnostics

### DIFF
--- a/three-demo/src/entities/entity-base.js
+++ b/three-demo/src/entities/entity-base.js
@@ -1,0 +1,224 @@
+import * as THREE from 'three';
+
+export class BaseEntity {
+  constructor({
+    id = null,
+    typeId = null,
+    manager = null,
+    THREE: injectedTHREE = THREE,
+    scene = null,
+    chunkManager = null,
+    terrainHeight = null,
+    spawnContext = null,
+  } = {}) {
+    if (!injectedTHREE) {
+      throw new Error('BaseEntity requires a valid THREE instance.');
+    }
+
+    this.THREE = injectedTHREE;
+    this.id = id;
+    this.typeId = typeId;
+    this.manager = manager;
+    this.scene = scene;
+    this.chunkManager = chunkManager;
+    this.terrainHeight = typeof terrainHeight === 'function' ? terrainHeight : null;
+    this.spawnContext = spawnContext;
+
+    this.root = new this.THREE.Group();
+    this.root.name = `Entity(${this.typeId ?? 'unknown'}:${this.id ?? 'unnamed'})`;
+
+    this.velocity = new this.THREE.Vector3();
+    this.acceleration = new this.THREE.Vector3();
+    this.state = new Map();
+
+    this.collisionRadius = 0.6;
+    this.collisionHalfHeight = 0.9;
+
+    this._bounds = new this.THREE.Box3();
+    this._boundsDirty = true;
+    this._scratchPosition = new this.THREE.Vector3();
+    this._scratchSamples = [
+      new this.THREE.Vector3(),
+      new this.THREE.Vector3(),
+      new this.THREE.Vector3(),
+      new this.THREE.Vector3(),
+      new this.THREE.Vector3(),
+    ];
+
+    this.isDisposed = false;
+  }
+
+  getPosition() {
+    return this.root.position;
+  }
+
+  setPosition(position) {
+    if (!position) {
+      return this.root.position;
+    }
+    this.root.position.copy(position);
+    this._boundsDirty = true;
+    return this.root.position;
+  }
+
+  translate(delta) {
+    if (!delta) {
+      return this.root.position;
+    }
+    this.root.position.add(delta);
+    this._boundsDirty = true;
+    return this.root.position;
+  }
+
+  getVelocity() {
+    return this.velocity;
+  }
+
+  setVelocity(velocity) {
+    if (!velocity) {
+      this.velocity.set(0, 0, 0);
+      return this.velocity;
+    }
+    this.velocity.copy(velocity);
+    return this.velocity;
+  }
+
+  addVelocity(delta) {
+    if (!delta) {
+      return this.velocity;
+    }
+    this.velocity.add(delta);
+    return this.velocity;
+  }
+
+  applyAcceleration(delta) {
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return;
+    }
+    if (this.acceleration.lengthSq() > 0) {
+      this.velocity.addScaledVector(this.acceleration, delta);
+    }
+  }
+
+  applyVelocity(delta) {
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return;
+    }
+    if (this.velocity.lengthSq() === 0) {
+      return;
+    }
+    this.root.position.addScaledVector(this.velocity, delta);
+    this._boundsDirty = true;
+  }
+
+  integrateForces(delta) {
+    this.applyAcceleration(delta);
+    this.applyVelocity(delta);
+  }
+
+  applyDamping(factor, delta) {
+    if (!Number.isFinite(factor) || factor <= 0 || factor >= 1) {
+      return;
+    }
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return;
+    }
+    const damping = 1 - Math.pow(1 - factor, delta * 60);
+    this.velocity.multiplyScalar(1 - damping);
+  }
+
+  markBoundsDirty() {
+    this._boundsDirty = true;
+  }
+
+  getCollisionBounds() {
+    if (this._boundsDirty) {
+      this._bounds.setFromObject(this.root);
+      this._boundsDirty = false;
+    }
+    return this._bounds;
+  }
+
+  getSolidBlockKeyAt(position) {
+    if (!position) {
+      return null;
+    }
+    const x = Math.floor(position.x);
+    const y = Math.floor(position.y);
+    const z = Math.floor(position.z);
+    return `${x}|${y}|${z}`;
+  }
+
+  isSolidAtWorld(position) {
+    if (!position || !this.chunkManager?.solidBlocks) {
+      return false;
+    }
+    const key = this.getSolidBlockKeyAt(position);
+    return key ? this.chunkManager.solidBlocks.has(key) : false;
+  }
+
+  gatherCollisionSamples() {
+    if (!this.chunkManager?.solidBlocks) {
+      return [];
+    }
+    const samples = [];
+    const radius = Math.max(0.1, this.collisionRadius);
+    const halfHeight = Math.max(0.1, this.collisionHalfHeight);
+    const base = this._scratchPosition.copy(this.root.position);
+
+    const offsets = [
+      { label: 'center', x: 0, y: -halfHeight, z: 0 },
+      { label: 'forward', x: 0, y: -halfHeight, z: radius },
+      { label: 'back', x: 0, y: -halfHeight, z: -radius },
+      { label: 'right', x: radius, y: -halfHeight, z: 0 },
+      { label: 'left', x: -radius, y: -halfHeight, z: 0 },
+    ];
+
+    offsets.forEach((offset, index) => {
+      const sample = this._scratchSamples[index % this._scratchSamples.length];
+      sample.set(base.x + offset.x, base.y + offset.y, base.z + offset.z);
+      const key = this.getSolidBlockKeyAt(sample);
+      const solid = key ? this.chunkManager.solidBlocks.has(key) : false;
+      samples.push({
+        label: offset.label,
+        position: sample.clone(),
+        blockKey: key,
+        isSolid: solid,
+      });
+    });
+
+    return samples;
+  }
+
+  resolveTerrainCollision() {
+    if (typeof this.terrainHeight !== 'function') {
+      return;
+    }
+    const groundHeight = this.terrainHeight(
+      this.root.position.x,
+      this.root.position.z,
+    );
+    if (!Number.isFinite(groundHeight)) {
+      return;
+    }
+    const minimumY = groundHeight + this.collisionHalfHeight;
+    if (this.root.position.y < minimumY) {
+      this.root.position.y = minimumY;
+      if (this.velocity.y < 0) {
+        this.velocity.y = 0;
+      }
+      this.markBoundsDirty();
+    }
+  }
+
+  onSpawn() {}
+
+  update({ delta = 0 } = {}) {
+    this.integrateForces(delta);
+    this.resolveTerrainCollision();
+  }
+
+  dispose() {
+    this.isDisposed = true;
+  }
+}

--- a/three-demo/src/entities/entity-manager.js
+++ b/three-demo/src/entities/entity-manager.js
@@ -1,0 +1,399 @@
+import * as THREE from 'three';
+
+import { listEntityDefinitions } from './entity-registry.js';
+
+function normalizeVector3(input, THREERef) {
+  const vector = new THREERef.Vector3();
+  if (!input) {
+    return vector;
+  }
+  if (input.isVector3) {
+    vector.copy(input);
+    return vector;
+  }
+  if (Array.isArray(input)) {
+    const [x = 0, y = 0, z = 0] = input;
+    vector.set(Number(x) || 0, Number(y) || 0, Number(z) || 0);
+    return vector;
+  }
+  if (typeof input === 'object') {
+    vector.set(
+      Number(input.x) || 0,
+      Number(input.y) || 0,
+      Number(input.z) || 0,
+    );
+    return vector;
+  }
+  return vector;
+}
+
+export function createEntityManager({
+  THREE: injectedTHREE = THREE,
+  scene,
+  camera = null,
+  chunkManager = null,
+  playerControls = null,
+  terrainHeight = null,
+  sampleBiomeAt = null,
+  weatherManager = null,
+  autoRegister = true,
+} = {}) {
+  if (!scene) {
+    throw new Error('createEntityManager requires a scene reference.');
+  }
+
+  const THREERef = injectedTHREE ?? THREE;
+  const entityTypes = new Map();
+  const entities = new Map();
+  const entityMixers = new Map();
+  const spawnContexts = new Map();
+  const mixers = new Set();
+  let nextEntityId = 1;
+  let disposed = false;
+  let defaultCamera = camera ?? null;
+  let defaultPlayerControls = playerControls ?? null;
+  let managerApi = null;
+
+  const defaultTimeOfDay = Object.freeze({ normalized: 0, label: 'Unknown' });
+
+  function assertActive() {
+    if (disposed) {
+      throw new Error('Entity manager has already been disposed.');
+    }
+  }
+
+  function registerEntityType(definition) {
+    assertActive();
+    const entry = definition ?? {};
+    const { id, label = id, create, metadata = {} } = entry;
+    if (!id) {
+      throw new Error('registerEntityType requires an id.');
+    }
+    if (typeof create !== 'function') {
+      throw new Error('registerEntityType requires a create factory function.');
+    }
+    if (entityTypes.has(id)) {
+      throw new Error(`Entity type ${id} is already registered.`);
+    }
+    const record = {
+      id,
+      label,
+      create,
+      metadata,
+    };
+    entityTypes.set(id, record);
+    return () => {
+      if (!entityTypes.has(id)) {
+        return;
+      }
+      const ids = Array.from(entities.keys());
+      ids.forEach((entityId) => {
+        const entity = entities.get(entityId);
+        if (entity?.typeId === id) {
+          managerApi?.despawnEntity(entityId);
+        }
+      });
+      entityTypes.delete(id);
+    };
+  }
+
+  function buildSpawnContext({ entityId, typeId, position, metadata, userData }) {
+    const contextPosition = position.clone();
+    const terrainValue =
+      typeof terrainHeight === 'function'
+        ? terrainHeight(contextPosition.x, contextPosition.z)
+        : null;
+    const biomeValue =
+      typeof sampleBiomeAt === 'function'
+        ? sampleBiomeAt(contextPosition.x, contextPosition.z)
+        : null;
+    const weatherValue = weatherManager?.getCurrentWeather?.() ?? null;
+
+    return {
+      entityId,
+      typeId,
+      position: contextPosition,
+      biome: biomeValue,
+      weather: weatherValue,
+      terrain: {
+        height: Number.isFinite(terrainValue) ? terrainValue : null,
+      },
+      timeOfDay: { ...defaultTimeOfDay },
+      metadata: metadata ?? null,
+      userData: userData ?? null,
+    };
+  }
+
+  function updateSpawnContext(entityId, entity, context) {
+    if (!context) {
+      return;
+    }
+    context.position.copy(entity.root.position);
+    if (typeof sampleBiomeAt === 'function') {
+      context.biome = sampleBiomeAt(context.position.x, context.position.z);
+    }
+    if (typeof terrainHeight === 'function') {
+      const terrainValue = terrainHeight(context.position.x, context.position.z);
+      context.terrain.height = Number.isFinite(terrainValue) ? terrainValue : null;
+    }
+    if (weatherManager?.getCurrentWeather) {
+      context.weather = weatherManager.getCurrentWeather();
+    }
+    context.timeOfDay = context.timeOfDay || { ...defaultTimeOfDay };
+  }
+
+  function registerMixerForEntity(entityId, root = null) {
+    if (!entities.has(entityId)) {
+      throw new Error(`Unknown entity ${entityId}; cannot register mixer.`);
+    }
+    const entity = entities.get(entityId);
+    const target = root ?? entity?.root;
+    if (!target?.isObject3D) {
+      throw new Error('Animation mixers require a valid Object3D root.');
+    }
+    const mixer = new THREERef.AnimationMixer(target);
+    mixers.add(mixer);
+    let bucket = entityMixers.get(entityId);
+    if (!bucket) {
+      bucket = new Set();
+      entityMixers.set(entityId, bucket);
+    }
+    bucket.add(mixer);
+    return mixer;
+  }
+
+  function spawnEntity(typeId, options = {}) {
+    assertActive();
+    if (!entityTypes.has(typeId)) {
+      throw new Error(`Unknown entity type: ${typeId}`);
+    }
+    const typeEntry = entityTypes.get(typeId);
+    const entityId = options.id ?? `${typeId}-${nextEntityId++}`;
+    if (entities.has(entityId)) {
+      throw new Error(`Entity id ${entityId} is already in use.`);
+    }
+
+    const position = normalizeVector3(options.position, THREERef);
+    const spawnContext = buildSpawnContext({
+      entityId,
+      typeId,
+      position,
+      metadata: options.metadata,
+      userData: options.userData,
+    });
+
+    const createParams = {
+      id: entityId,
+      typeId,
+      manager: managerApi,
+      THREE: THREERef,
+      scene,
+      camera: defaultCamera,
+      playerControls: defaultPlayerControls,
+      chunkManager,
+      terrainHeight,
+      sampleBiomeAt,
+      weatherManager,
+      spawnContext,
+      options,
+    };
+
+    const entity = typeEntry.create(createParams);
+    if (!entity) {
+      throw new Error(`Entity factory for ${typeId} did not return an instance.`);
+    }
+    if (!entity.root || !entity.root.isObject3D) {
+      throw new Error(
+        `Entity type ${typeId} must provide a root THREE.Object3D-compatible node.`,
+      );
+    }
+
+    entity.id = entityId;
+    entity.typeId = typeId;
+    entities.set(entityId, entity);
+    entityMixers.set(entityId, new Set());
+    spawnContexts.set(entityId, spawnContext);
+
+    entity.root.userData = entity.root.userData || {};
+    entity.root.userData.entityId = entityId;
+    entity.root.userData.entityTypeId = typeId;
+
+    scene.add(entity.root);
+    if (options.position) {
+      if (typeof entity.setPosition === 'function') {
+        entity.setPosition(position);
+      } else {
+        entity.root.position.copy(position);
+      }
+    }
+
+    try {
+      entity.onSpawn?.(spawnContext, options);
+    } catch (error) {
+      console.error(`Entity ${entityId} onSpawn hook failed:`, error);
+    }
+
+    return entity;
+  }
+
+  function disposeMixersForEntity(entityId) {
+    const bucket = entityMixers.get(entityId);
+    if (!bucket) {
+      return;
+    }
+    bucket.forEach((mixer) => {
+      try {
+        mixer.stopAllAction?.();
+        mixer.uncacheRoot?.();
+      } catch (error) {
+        console.warn('Failed to dispose animation mixer:', error);
+      }
+      mixers.delete(mixer);
+    });
+    entityMixers.delete(entityId);
+  }
+
+  function despawnEntity(entityId) {
+    if (!entities.has(entityId)) {
+      return false;
+    }
+    const entity = entities.get(entityId);
+    entities.delete(entityId);
+    spawnContexts.delete(entityId);
+    disposeMixersForEntity(entityId);
+    if (entity.root?.parent === scene) {
+      scene.remove(entity.root);
+    }
+    try {
+      entity.dispose?.({ manager: managerApi });
+    } catch (error) {
+      console.error(`Entity ${entityId} dispose hook failed:`, error);
+    }
+    return true;
+  }
+
+  function listEntityTypes() {
+    return Array.from(entityTypes.values()).map((entry) => ({
+      id: entry.id,
+      label: entry.label ?? entry.id,
+      metadata: entry.metadata ?? null,
+    }));
+  }
+
+  function getEntityById(entityId) {
+    return entities.get(entityId) ?? null;
+  }
+
+  function getEntityCount() {
+    return entities.size;
+  }
+
+  function getEntities() {
+    return Array.from(entities.entries()).map(([entityId, entity]) => ({
+      id: entityId,
+      typeId: entity.typeId,
+      entity,
+    }));
+  }
+
+  function update({
+    delta = 0,
+    elapsedTime = 0,
+    camera: overrideCamera = null,
+    playerControls: overrideControls = null,
+  } = {}) {
+    if (disposed) {
+      return;
+    }
+    const activeCamera = overrideCamera ?? defaultCamera;
+    const activeControls = overrideControls ?? defaultPlayerControls;
+    mixers.forEach((mixer) => {
+      try {
+        mixer.update(delta);
+      } catch (error) {
+        console.error('Animation mixer update failed:', error);
+      }
+    });
+    entities.forEach((entity, entityId) => {
+      const context = spawnContexts.get(entityId);
+      updateSpawnContext(entityId, entity, context);
+      try {
+        entity.update?.({
+          delta,
+          elapsedTime,
+          camera: activeCamera,
+          playerControls: activeControls,
+          manager: managerApi,
+          spawnContext: context,
+        });
+      } catch (error) {
+        console.error(`Entity ${entityId} update failed:`, error);
+      }
+    });
+  }
+
+  function setCamera(nextCamera) {
+    defaultCamera = nextCamera ?? null;
+  }
+
+  function setPlayerControls(nextControls) {
+    defaultPlayerControls = nextControls ?? null;
+  }
+
+  function dispose() {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const ids = Array.from(entities.keys());
+    ids.forEach((entityId) => {
+      try {
+        despawnEntity(entityId);
+      } catch (error) {
+        console.error(`Failed to despawn entity ${entityId} during dispose:`, error);
+      }
+    });
+    mixers.forEach((mixer) => {
+      try {
+        mixer.stopAllAction?.();
+        mixer.uncacheRoot?.();
+      } catch (error) {
+        console.warn('Failed to dispose animation mixer:', error);
+      }
+    });
+    mixers.clear();
+    entityMixers.clear();
+    spawnContexts.clear();
+    entityTypes.clear();
+  }
+
+  managerApi = {
+    registerEntityType,
+    spawnEntity,
+    despawnEntity,
+    listEntityTypes,
+    update,
+    dispose,
+    registerMixerForEntity,
+    getEntityById,
+    getEntityCount,
+    getEntities,
+    setCamera,
+    setPlayerControls,
+  };
+
+  if (autoRegister) {
+    const definitions = listEntityDefinitions({ autoloadOnly: true });
+    definitions.forEach((definition) => {
+      try {
+        if (!entityTypes.has(definition.id)) {
+          registerEntityType(definition);
+        }
+      } catch (error) {
+        console.error(`Failed to auto-register entity type ${definition.id}:`, error);
+      }
+    });
+  }
+
+  return managerApi;
+}

--- a/three-demo/src/entities/entity-registry.js
+++ b/three-demo/src/entities/entity-registry.js
@@ -1,0 +1,90 @@
+const registry = new Map();
+
+function cloneDefinition(definition) {
+  if (!definition) {
+    return null;
+  }
+  return {
+    id: definition.id,
+    label: definition.label,
+    create: definition.create,
+    metadata: definition.metadata,
+    autoload: definition.autoload,
+  };
+}
+
+export function registerEntityDefinition(definition) {
+  if (!definition || typeof definition !== 'object') {
+    throw new Error('registerEntityDefinition requires a definition object.');
+  }
+  const { id, create } = definition;
+  if (!id) {
+    throw new Error('registerEntityDefinition requires an id.');
+  }
+  if (typeof create !== 'function') {
+    throw new Error('registerEntityDefinition requires a create factory function.');
+  }
+  const entry = {
+    id,
+    label: definition.label ?? id,
+    create,
+    metadata: definition.metadata ?? null,
+    autoload: definition.autoload !== false,
+  };
+  registry.set(id, entry);
+  return () => {
+    registry.delete(id);
+  };
+}
+
+export function unregisterEntityDefinition(id) {
+  registry.delete(id);
+}
+
+export function getEntityDefinition(id) {
+  return cloneDefinition(registry.get(id));
+}
+
+export function listEntityDefinitions({ autoloadOnly = false } = {}) {
+  return Array.from(registry.values())
+    .filter((entry) => (autoloadOnly ? entry.autoload !== false : true))
+    .map((entry) => cloneDefinition(entry));
+}
+
+export function applyRegistryToManager(manager, { autoloadOnly = true } = {}) {
+  if (!manager || typeof manager.registerEntityType !== 'function') {
+    return () => {};
+  }
+  const definitions = listEntityDefinitions({ autoloadOnly });
+  const disposers = [];
+  definitions.forEach((definition) => {
+    try {
+      if (typeof manager.listEntityTypes === 'function') {
+        const alreadyRegistered = manager
+          .listEntityTypes()
+          .some((entry) => entry.id === definition.id);
+        if (alreadyRegistered) {
+          return;
+        }
+      }
+      const dispose = manager.registerEntityType(definition);
+      if (typeof dispose === 'function') {
+        disposers.push(dispose);
+      }
+    } catch (error) {
+      console.error(
+        `Failed to register entity definition ${definition.id} with manager:`,
+        error,
+      );
+    }
+  });
+  return () => {
+    disposers.splice(0, disposers.length).forEach((dispose) => {
+      try {
+        dispose();
+      } catch (error) {
+        console.error('Failed to dispose registered entity definition:', error);
+      }
+    });
+  };
+}

--- a/three-demo/src/entities/index.js
+++ b/three-demo/src/entities/index.js
@@ -1,0 +1,70 @@
+import { createEntityManager } from './entity-manager.js';
+import { BaseEntity } from './entity-base.js';
+import {
+  registerEntityDefinition,
+  unregisterEntityDefinition,
+  getEntityDefinition,
+  listEntityDefinitions,
+  applyRegistryToManager,
+} from './entity-registry.js';
+
+export {
+  createEntityManager,
+  BaseEntity,
+  registerEntityDefinition,
+  unregisterEntityDefinition,
+  getEntityDefinition,
+  listEntityDefinitions,
+  applyRegistryToManager,
+};
+
+export function registerEntityFactory(idOrDefinition, factory, options = {}) {
+  if (
+    typeof idOrDefinition === 'object' &&
+    idOrDefinition !== null &&
+    typeof idOrDefinition.id === 'string'
+  ) {
+    const definition = {
+      ...idOrDefinition,
+      create: idOrDefinition.create ?? factory,
+    };
+    return registerEntityDefinition(definition);
+  }
+  const id = idOrDefinition;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('registerEntityFactory requires a string id.');
+  }
+  if (typeof factory !== 'function') {
+    throw new Error('registerEntityFactory requires a factory function.');
+  }
+  return registerEntityDefinition({
+    id,
+    label: options.label ?? id,
+    metadata: options.metadata ?? null,
+    autoload: options.autoload,
+    create: factory,
+  });
+}
+
+export function registerEntityClass({
+  id,
+  label = id,
+  EntityClass,
+  metadata = null,
+  autoload,
+}) {
+  if (!id) {
+    throw new Error('registerEntityClass requires an id.');
+  }
+  if (typeof EntityClass !== 'function') {
+    throw new Error('registerEntityClass requires an EntityClass constructor.');
+  }
+  const factory = (params) => new EntityClass(params);
+  return registerEntityDefinition({
+    id,
+    label,
+    metadata,
+    autoload,
+    create: factory,
+  });
+}

--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -6,6 +6,7 @@ import {
   initializeWorldGeneration,
   terrainHeight,
   getWorldOptions,
+  sampleBiomeAt,
 } from './world/generation.js'
 import { createChunkManager } from './world/chunk-manager.js'
 import { createPlayerControls } from './player/controls.js'
@@ -25,6 +26,7 @@ import { createWaterSurfaceMistEmitter } from './rendering/particles/water-effec
 import { createAuroraRibbonEmitter } from './rendering/particles/aurora-effects.js'
 import { createLumenBloomMotesEmitter } from './rendering/particles/lumen-bloom-effects.js'
 import { createWeatherManager } from './world/weather/weather-manager.js'
+import { createEntityManager } from './entities/index.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -205,6 +207,7 @@ let chunkManager
 let particleSystem
 let playerControls
 let weatherManager
+let entityManager
 let initializationError = null
 
 try {
@@ -329,6 +332,17 @@ try {
   chunkManager.update(playerControls.getPosition(), { camera })
   updateHud(playerControls.getState())
 
+  entityManager = createEntityManager({
+    THREE,
+    scene,
+    camera,
+    chunkManager,
+    playerControls,
+    terrainHeight,
+    sampleBiomeAt,
+    weatherManager,
+  })
+
   if (import.meta.env.DEV) {
     const debugNamespace = (window.__VOXEL_DEBUG__ = window.__VOXEL_DEBUG__ || {})
     debugNamespace.chunkSnapshot = () => chunkManager.debugSnapshot?.()
@@ -340,6 +354,7 @@ try {
     }
     debugNamespace.registerDiagnosticOverlay = registerDiagnosticOverlay
     debugNamespace.weather = weatherManager
+    debugNamespace.entities = entityManager
 
     let perfFlightModulePromise = null
     const resolvePerfFlightModule = () => {
@@ -401,6 +416,7 @@ try {
     registerDiagnosticOverlay,
     particleSystem,
     weatherManager,
+    entityManager,
   })
 
   commandConsole.log(
@@ -445,6 +461,12 @@ if (!initializationError) {
       elapsedTime,
       playerControls,
     })
+    entityManager?.update({
+      delta,
+      elapsedTime,
+      playerControls,
+      camera,
+    })
 
     if (diagnosticOverlayCallbacks.size > 0) {
       const callbacks = Array.from(diagnosticOverlayCallbacks)
@@ -474,5 +496,6 @@ if (!initializationError) {
     musicSystem?.dispose()
     particleSystem?.dispose()
     weatherManager?.dispose?.()
+    entityManager?.dispose()
   })
 }

--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -20,6 +20,7 @@ export function registerDeveloperCommands({
   registerDiagnosticOverlay,
   particleSystem = null,
   weatherManager = null,
+  entityManager = null,
 }) {
   if (!commandConsole) {
     throw new Error('registerDeveloperCommands requires a commandConsole instance.');
@@ -1171,6 +1172,46 @@ export function registerDeveloperCommands({
       commandConsole.log(
         `Position set to X=${position.x.toFixed(2)} Y=${position.y.toFixed(2)} Z=${position.z.toFixed(2)}.`,
       );
+    },
+  });
+
+  registerCommand({
+    name: 'entities',
+    description: 'Inspect registered entity types and active runtime entities.',
+    usage: '/entities [types]',
+    handler: ({ args }) => {
+      if (!entityManager) {
+        commandConsole.log('Entity manager is not available in this build.', 'warn');
+        return;
+      }
+      const mode = (args[0] ?? '').toLowerCase();
+      if (mode === 'types') {
+        const types = entityManager.listEntityTypes?.() ?? [];
+        if (types.length === 0) {
+          commandConsole.log('No entity types are currently registered.');
+          return;
+        }
+        commandConsole.log(`Registered entity types (${types.length}):`);
+        types.forEach((type) => {
+          const label = type.label && type.label !== type.id ? `${type.label} [${type.id}]` : type.id;
+          commandConsole.log(`- ${label}`);
+        });
+        return;
+      }
+      const count = entityManager.getEntityCount?.() ?? 0;
+      commandConsole.log(`Active entities: ${count}`);
+      if (count > 0 && typeof entityManager.getEntities === 'function') {
+        const entries = entityManager.getEntities().slice(0, 12);
+        entries.forEach((entry, index) => {
+          const id = entry?.id ?? `entity-${index + 1}`;
+          const typeId = entry?.typeId ?? 'unknown';
+          commandConsole.log(`- ${id} (${typeId})`);
+        });
+        if (count > entries.length) {
+          commandConsole.log(`  (+${count - entries.length} more…)`);
+        }
+      }
+      commandConsole.log('Use /entities types to list registered entity definitions.');
     },
   });
 


### PR DESCRIPTION
## Summary
- add an entity manager, base entity class, and registry helpers for runtime entities
- integrate the entity manager into the main loop with debug exposure and cleanup hooks
- extend the developer console with entity diagnostics that leverage the new manager

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2a691664832ab54b651b8a7d6df7