### PR TITLE
Add Crowned Ghost entity and shared asset loader

### DIFF
--- a/three-demo/src/entities/crowned-ghost.js
+++ b/three-demo/src/entities/crowned-ghost.js
@@ -1,0 +1,204 @@
+import { BaseEntity } from './entity-base.js';
+import { getSharedEntityAssetLoader } from './entity-asset-loader.js';
+
+const MODEL_URL = new URL('../models/entity_ghost_guy_1_runner.glb', import.meta.url).href;
+const DESIRED_HEIGHT = 1.6;
+
+export class CrownedGhostEntity extends BaseEntity {
+  constructor(params = {}) {
+    super(params);
+
+    this.assetLoader = params.assetLoader ?? getSharedEntityAssetLoader({ THREE: this.THREE });
+    this.visualRoot = new this.THREE.Group();
+    this.visualRoot.name = 'CrownedGhost.VisualRoot';
+    this.root.add(this.visualRoot);
+
+    this.mixer = null;
+    this.activeAction = null;
+    this.assetInstance = null;
+    this.assetLoadPromise = null;
+    this.isSpawned = false;
+
+    this.hoverPhase = Math.random() * Math.PI * 2;
+    this.hoverSpeed = 1.15 + Math.random() * 0.35;
+    this.hoverAmplitude = 0.22;
+    this.baseHoverOffset = 0.35;
+
+    this.swayPhase = Math.random() * Math.PI * 2;
+    this.swaySpeed = 0.6 + Math.random() * 0.25;
+    this.swayAmplitude = 0.18;
+
+    this.forwardBaseAngle = Math.random() * Math.PI * 2;
+    this.forwardDriftAmplitude = 0.35;
+    this.forwardDriftFrequency = 0.25 + Math.random() * 0.15;
+    this.forwardSpeed = 0.35 + Math.random() * 0.25;
+    this.forwardDirection = new this.THREE.Vector3(0, 0, 1);
+
+    this.assetLoadPromise = this.assetLoader
+      .createInstance(MODEL_URL)
+      .then((instance) => {
+        if (this.isDisposed) {
+          instance.dispose?.();
+          return null;
+        }
+        this.assetInstance = instance;
+        this.tryAttachAsset();
+        return instance;
+      })
+      .catch((error) => {
+        console.error('Failed to load Crowned Ghost model:', error);
+        return null;
+      });
+  }
+
+  onSpawn() {
+    this.isSpawned = true;
+    this.tryAttachAsset();
+  }
+
+  tryAttachAsset() {
+    if (!this.isSpawned || !this.assetInstance || this.visualRoot.children.length > 0) {
+      return;
+    }
+
+    const scene = this.assetInstance.scene;
+    scene.name = 'CrownedGhost.Scene';
+    this.visualRoot.add(scene);
+
+    this.normalizeScene(scene);
+    this.enableShadows(scene);
+    this.setupAnimation();
+  }
+
+  normalizeScene(scene) {
+    if (!scene) {
+      return;
+    }
+    scene.updateMatrixWorld(true);
+    const box = new this.THREE.Box3().setFromObject(scene);
+    if (box.isEmpty()) {
+      return;
+    }
+    const size = new this.THREE.Vector3();
+    box.getSize(size);
+    const height = size.y || 1;
+    const scale = DESIRED_HEIGHT / height;
+    scene.scale.setScalar(scale);
+
+    scene.updateMatrixWorld(true);
+    const scaledBox = new this.THREE.Box3().setFromObject(scene);
+    const center = new this.THREE.Vector3();
+    scaledBox.getCenter(center);
+    scene.position.sub(center);
+    scene.position.y -= scaledBox.min.y;
+    scene.rotation.y = Math.PI;
+  }
+
+  enableShadows(scene) {
+    scene.traverse((child) => {
+      if (child.isLight) {
+        return;
+      }
+      child.castShadow = true;
+      child.receiveShadow = true;
+    });
+  }
+
+  setupAnimation() {
+    if (!this.assetInstance || !this.manager) {
+      return;
+    }
+    const animations = this.assetInstance.animations ?? [];
+    if (animations.length === 0) {
+      return;
+    }
+    const runningClip =
+      animations.find((clip) =>
+        typeof clip?.name === 'string' && clip.name.toLowerCase().includes('run'),
+      ) ?? animations[0];
+
+    if (!runningClip) {
+      return;
+    }
+
+    let mixer = null;
+    try {
+      mixer = this.manager.registerMixerForEntity?.(this.id, this.visualRoot);
+    } catch (error) {
+      console.warn('Failed to register mixer with manager; using local mixer.', error);
+    }
+    if (!mixer) {
+      mixer = new this.THREE.AnimationMixer(this.visualRoot);
+    }
+
+    this.mixer = mixer;
+    this.activeAction = mixer.clipAction(runningClip);
+    this.activeAction.setLoop(this.THREE.LoopRepeat, Infinity);
+    this.activeAction.clampWhenFinished = false;
+    this.activeAction.enable = true;
+    this.activeAction.play();
+  }
+
+  update({ delta = 0, elapsedTime = 0 } = {}) {
+    if (!this.visualRoot) {
+      return;
+    }
+    const hoverValue = Math.sin(elapsedTime * this.hoverSpeed + this.hoverPhase);
+    this.visualRoot.position.y = this.baseHoverOffset + hoverValue * this.hoverAmplitude;
+
+    const swayValue = Math.sin(elapsedTime * this.swaySpeed + this.swayPhase);
+    this.visualRoot.position.x = swayValue * this.swayAmplitude;
+
+    const driftAngle =
+      this.forwardBaseAngle +
+      Math.sin(elapsedTime * this.forwardDriftFrequency + this.hoverPhase) * this.forwardDriftAmplitude;
+    this.forwardDirection.set(Math.sin(driftAngle), 0, Math.cos(driftAngle));
+
+    const step = Math.max(0, delta) * this.forwardSpeed;
+    if (step > 0) {
+      this.root.position.addScaledVector(this.forwardDirection, step);
+      this.root.rotation.y = Math.atan2(this.forwardDirection.x, this.forwardDirection.z);
+      this.markBoundsDirty();
+    }
+  }
+
+  dispose() {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+
+    if (this.activeAction) {
+      try {
+        this.activeAction.stop();
+      } catch (error) {
+        console.warn('Failed to stop Crowned Ghost animation action.', error);
+      }
+    }
+
+    if (this.mixer) {
+      try {
+        this.mixer.stopAllAction?.();
+        this.mixer.uncacheRoot?.(this.visualRoot);
+      } catch (error) {
+        console.warn('Failed to dispose Crowned Ghost mixer.', error);
+      }
+    }
+    this.activeAction = null;
+    this.mixer = null;
+
+    if (this.visualRoot?.parent === this.root) {
+      this.root.remove(this.visualRoot);
+    }
+    if (this.assetInstance) {
+      if (this.assetInstance.scene?.parent) {
+        this.assetInstance.scene.parent.remove(this.assetInstance.scene);
+      }
+      this.assetInstance.dispose?.();
+      this.assetInstance = null;
+    }
+    this.visualRoot?.clear();
+    this.assetLoadPromise = null;
+    this.isSpawned = false;
+  }
+}

--- a/three-demo/src/entities/entity-asset-loader.js
+++ b/three-demo/src/entities/entity-asset-loader.js
@@ -1,0 +1,144 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+function ensureArray(value) {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function cloneMeshResources(object) {
+  const clonedMaterials = new WeakMap();
+  const clonedGeometries = new WeakMap();
+
+  object.traverse((child) => {
+    if (!child.isMesh && !child.isSkinnedMesh) {
+      return;
+    }
+    if (child.material) {
+      const materials = ensureArray(child.material);
+      const nextMaterials = materials.map((material) => {
+        if (!material || typeof material.clone !== 'function') {
+          return material;
+        }
+        if (clonedMaterials.has(material)) {
+          return clonedMaterials.get(material);
+        }
+        const cloned = material.clone();
+        clonedMaterials.set(material, cloned);
+        return cloned;
+      });
+      child.material = Array.isArray(child.material)
+        ? nextMaterials
+        : nextMaterials[0] ?? child.material;
+    }
+    if (child.geometry && typeof child.geometry.clone === 'function') {
+      if (clonedGeometries.has(child.geometry)) {
+        child.geometry = clonedGeometries.get(child.geometry);
+      } else {
+        const clonedGeometry = child.geometry.clone();
+        clonedGeometries.set(child.geometry, clonedGeometry);
+        child.geometry = clonedGeometry;
+      }
+    }
+    child.castShadow = true;
+    child.receiveShadow = true;
+  });
+}
+
+function disposeMeshResources(object) {
+  const disposedMaterials = new WeakSet();
+  const disposedGeometries = new WeakSet();
+
+  object.traverse((child) => {
+    if (!child.isMesh && !child.isSkinnedMesh) {
+      return;
+    }
+    if (child.geometry && !disposedGeometries.has(child.geometry)) {
+      disposedGeometries.add(child.geometry);
+      child.geometry.dispose?.();
+    }
+    const materials = ensureArray(child.material);
+    materials.forEach((material) => {
+      if (material && !disposedMaterials.has(material)) {
+        disposedMaterials.add(material);
+        material.dispose?.();
+      }
+    });
+  });
+}
+
+export class EntityAssetLoader {
+  constructor({ THREE: injectedTHREE = THREE } = {}) {
+    this.THREE = injectedTHREE ?? THREE;
+    this.loader = new GLTFLoader();
+    this.cache = new Map();
+  }
+
+  async loadGLTF(url) {
+    const source = String(url);
+    if (!source) {
+      throw new Error('EntityAssetLoader.loadGLTF requires a URL.');
+    }
+
+    if (this.cache.has(source)) {
+      const entry = this.cache.get(source);
+      if (entry.asset) {
+        return entry.asset;
+      }
+      return entry.promise;
+    }
+
+    const entry = {};
+    const promise = this.loader.loadAsync(source).then((gltf) => {
+      entry.asset = gltf;
+      return gltf;
+    });
+    entry.promise = promise.catch((error) => {
+      this.cache.delete(source);
+      throw error;
+    });
+    this.cache.set(source, entry);
+    return entry.promise;
+  }
+
+  async createInstance(url) {
+    const gltf = await this.loadGLTF(url);
+    const clonedScene = cloneSkeleton(gltf.scene);
+    cloneMeshResources(clonedScene);
+    return {
+      scene: clonedScene,
+      animations: gltf.animations ?? [],
+      dispose: () => {
+        disposeMeshResources(clonedScene);
+      },
+    };
+  }
+
+  evict(url) {
+    const source = String(url ?? '');
+    if (!source || !this.cache.has(source)) {
+      return;
+    }
+    this.cache.delete(source);
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+let sharedLoader = null;
+
+export function getSharedEntityAssetLoader(options = {}) {
+  if (!sharedLoader) {
+    sharedLoader = new EntityAssetLoader(options);
+  }
+  return sharedLoader;
+}
+
+export function createEntityAssetLoader(options = {}) {
+  return new EntityAssetLoader(options);
+}

--- a/three-demo/src/entities/index.js
+++ b/three-demo/src/entities/index.js
@@ -7,6 +7,12 @@ import {
   listEntityDefinitions,
   applyRegistryToManager,
 } from './entity-registry.js';
+import {
+  EntityAssetLoader,
+  createEntityAssetLoader,
+  getSharedEntityAssetLoader,
+} from './entity-asset-loader.js';
+import { CrownedGhostEntity } from './crowned-ghost.js';
 
 export {
   createEntityManager,
@@ -16,6 +22,10 @@ export {
   getEntityDefinition,
   listEntityDefinitions,
   applyRegistryToManager,
+  EntityAssetLoader,
+  createEntityAssetLoader,
+  getSharedEntityAssetLoader,
+  CrownedGhostEntity,
 };
 
 export function registerEntityFactory(idOrDefinition, factory, options = {}) {
@@ -67,4 +77,32 @@ export function registerEntityClass({
     autoload,
     create: factory,
   });
+}
+
+let builtinsRegistered = false;
+
+export function registerBuiltinEntities() {
+  if (builtinsRegistered) {
+    return;
+  }
+
+  const existing = getEntityDefinition('crowned_ghost');
+  if (!existing) {
+    registerEntityClass({
+      id: 'crowned_ghost',
+      label: 'Crowned Ghost',
+      EntityClass: CrownedGhostEntity,
+      metadata: {
+        aliases: {
+          numeric: [1],
+        },
+        tags: {
+          biomes: ['haunted', 'mistwood', 'luminous_cavern'],
+          weather: ['clear', 'foggy', 'storm'],
+        },
+      },
+    });
+  }
+
+  builtinsRegistered = true;
 }

--- a/three-demo/src/main.js
+++ b/three-demo/src/main.js
@@ -26,7 +26,7 @@ import { createWaterSurfaceMistEmitter } from './rendering/particles/water-effec
 import { createAuroraRibbonEmitter } from './rendering/particles/aurora-effects.js'
 import { createLumenBloomMotesEmitter } from './rendering/particles/lumen-bloom-effects.js'
 import { createWeatherManager } from './world/weather/weather-manager.js'
-import { createEntityManager } from './entities/index.js'
+import { createEntityManager, registerBuiltinEntities } from './entities/index.js'
 
 const overlay = document.getElementById('overlay')
 const overlayStatus = overlay?.querySelector('#overlay-status')
@@ -331,6 +331,8 @@ try {
 
   chunkManager.update(playerControls.getPosition(), { camera })
   updateHud(playerControls.getState())
+
+  registerBuiltinEntities()
 
   entityManager = createEntityManager({
     THREE,


### PR DESCRIPTION
## Summary
- Implement a shared GLTF asset loader that caches downloads and produces per-spawn scene clones for entities.
- Add the Crowned Ghost entity with hover drift behavior, looping animation playback, and resource cleanup via the shared loader.
- Register the Crowned Ghost as a builtin entity and invoke registration during application bootstrap.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2e93a1c0832ab67eb8d3fdb2f39c