### PR TITLE
Simplify spawn command invocation

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1374,11 +1374,7 @@ export function registerDeveloperCommands({
 
       let spawnedEntity = null;
       try {
-        if (manager.spawnEntity.length <= 1) {
-          spawnedEntity = await manager.spawnEntity(spawnPayload);
-        } else {
-          spawnedEntity = await manager.spawnEntity(targetType.id, spawnPayload);
-        }
+        spawnedEntity = await manager.spawnEntity(targetType.id, spawnPayload);
       } catch (error) {
         console.error('Failed to spawn entity via /spawn command:', error);
         commandConsole.log(


### PR DESCRIPTION
## Summary
- update the `/spawn` developer command to always invoke `spawnEntity` with an explicit type id and payload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc3564b8c0832abebd2e2fc919a092