### PR TITLE
Add entity animation controller helper

### DIFF
--- a/three-demo/src/entities/entity-animation-controller.js
+++ b/three-demo/src/entities/entity-animation-controller.js
@@ -1,0 +1,247 @@
+export class EntityAnimationController {
+  constructor({
+    THREE,
+    manager = null,
+    entityId,
+    root,
+    variantClips = null,
+  } = {}) {
+    if (!THREE) {
+      throw new Error('EntityAnimationController requires a THREE reference.');
+    }
+    if (!root?.isObject3D) {
+      throw new Error('EntityAnimationController requires a valid Object3D root.');
+    }
+    this.THREE = THREE;
+    this.manager = manager;
+    this.entityId = entityId ?? null;
+    this.root = root;
+    this.mixer = this.#createMixer();
+    this.variantClips = this.#normalizeVariantClips(variantClips);
+    this.actions = new Map();
+    this.activeAction = null;
+    this.activeVariantId = null;
+    this.speed = 1;
+    this.disposed = false;
+  }
+
+  #createMixer() {
+    let mixer = null;
+    if (this.manager?.registerMixerForEntity && this.entityId) {
+      try {
+        mixer = this.manager.registerMixerForEntity(this.entityId, this.root);
+      } catch (error) {
+        console.warn('Failed to register mixer with entity manager; falling back.', error);
+      }
+    }
+    if (!mixer) {
+      mixer = new this.THREE.AnimationMixer(this.root);
+    }
+    return mixer;
+  }
+
+  #normalizeVariantClips(variantClips) {
+    const normalized = new Map();
+    if (!variantClips) {
+      return normalized;
+    }
+    if (variantClips instanceof Map) {
+      variantClips.forEach((value, key) => {
+        const clips = this.#toClipArray(value);
+        if (clips.length > 0) {
+          normalized.set(String(key), clips);
+        }
+      });
+      return normalized;
+    }
+    if (Array.isArray(variantClips)) {
+      variantClips.forEach((value, index) => {
+        const clips = this.#toClipArray(value);
+        if (clips.length > 0) {
+          normalized.set(String(index), clips);
+        }
+      });
+      return normalized;
+    }
+    if (typeof variantClips === 'object') {
+      Object.entries(variantClips).forEach(([key, value]) => {
+        const clips = this.#toClipArray(value);
+        if (clips.length > 0) {
+          normalized.set(String(key), clips);
+        }
+      });
+    }
+    return normalized;
+  }
+
+  #toClipArray(value) {
+    if (!value) {
+      return [];
+    }
+    if (Array.isArray(value)) {
+      return value.filter((clip) => !!clip);
+    }
+    return [value];
+  }
+
+  #getClipsForVariant(variantId) {
+    if (!variantId) {
+      return null;
+    }
+    return this.variantClips.get(String(variantId)) ?? null;
+  }
+
+  #getOrCreateAction(variantId) {
+    if (this.actions.has(variantId)) {
+      return this.actions.get(variantId);
+    }
+    const clips = this.#getClipsForVariant(variantId);
+    if (!clips || clips.length === 0) {
+      return null;
+    }
+    const clip = clips[0];
+    if (!clip) {
+      return null;
+    }
+    const action = this.mixer.clipAction(clip);
+    action.enabled = true;
+    action.clampWhenFinished = false;
+    action.setEffectiveWeight(1);
+    action.setEffectiveTimeScale(this.speed);
+    this.actions.set(variantId, action);
+    return action;
+  }
+
+  playVariant(variantId, { fadeDuration = 0.25, loopMode = this.THREE.LoopRepeat } = {}) {
+    if (this.disposed) {
+      return null;
+    }
+    const action = this.#getOrCreateAction(String(variantId));
+    if (!action) {
+      console.warn(`Unknown animation variant: ${variantId}`);
+      return null;
+    }
+
+    const loopSetting = this.#resolveLoopMode(loopMode);
+    action.setLoop(loopSetting.mode, loopSetting.repetitions);
+    action.clampWhenFinished = loopSetting.mode === this.THREE.LoopOnce;
+    action.setEffectiveTimeScale(this.speed);
+    action.reset();
+
+    if (this.activeAction && this.activeAction !== action) {
+      if (fadeDuration > 0) {
+        action.play();
+        this.activeAction.crossFadeTo(action, fadeDuration, false);
+      } else {
+        this.activeAction.stop();
+        action.play();
+      }
+    } else if (!this.activeAction) {
+      action.play();
+    } else {
+      action.play();
+    }
+
+    this.activeAction = action;
+    this.activeVariantId = String(variantId);
+    return action;
+  }
+
+  stop({ fadeDuration = 0.2 } = {}) {
+    if (!this.activeAction) {
+      return;
+    }
+    if (fadeDuration > 0 && this.activeAction.fadeOut) {
+      this.activeAction.fadeOut(fadeDuration);
+    } else {
+      try {
+        this.activeAction.stop();
+      } catch (error) {
+        console.warn('Failed to stop animation action cleanly.', error);
+      }
+    }
+    this.activeAction = null;
+    this.activeVariantId = null;
+  }
+
+  setSpeed(speed = 1) {
+    if (!Number.isFinite(speed) || speed <= 0) {
+      return;
+    }
+    this.speed = speed;
+    this.actions.forEach((action) => {
+      if (typeof action.setEffectiveTimeScale === 'function') {
+        action.setEffectiveTimeScale(speed);
+      } else {
+        action.timeScale = speed;
+      }
+    });
+  }
+
+  dispose() {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+
+    try {
+      this.stop({ fadeDuration: 0 });
+    } catch (error) {
+      console.warn('Failed to stop active animation during dispose.', error);
+    }
+
+    this.actions.forEach((action) => {
+      try {
+        action.stop?.();
+        action.reset?.();
+        action.enabled = false;
+      } catch (error) {
+        console.warn('Failed to dispose animation action.', error);
+      }
+    });
+    this.actions.clear();
+
+    if (this.mixer) {
+      try {
+        this.mixer.stopAllAction?.();
+        this.mixer.uncacheRoot?.(this.root);
+      } catch (error) {
+        console.warn('Failed to dispose animation mixer.', error);
+      }
+      if (this.manager?.releaseMixerForEntity && this.entityId) {
+        try {
+          this.manager.releaseMixerForEntity(this.entityId, this.mixer);
+        } catch (error) {
+          console.warn('Failed to release mixer registration.', error);
+        }
+      }
+    }
+
+    this.activeAction = null;
+    this.mixer = null;
+    this.root = null;
+    this.manager = null;
+    this.variantClips.clear();
+  }
+
+  #resolveLoopMode(loopMode) {
+    if (typeof loopMode === 'number') {
+      return { mode: loopMode, repetitions: Infinity };
+    }
+    if (typeof loopMode === 'object' && loopMode) {
+      const mode = loopMode.mode ?? this.THREE.LoopRepeat;
+      const repetitions =
+        loopMode.repetitions ?? (mode === this.THREE.LoopOnce ? 1 : Infinity);
+      return { mode, repetitions };
+    }
+    switch (loopMode) {
+      case 'once':
+        return { mode: this.THREE.LoopOnce, repetitions: 0 };
+      case 'pingpong':
+        return { mode: this.THREE.LoopPingPong, repetitions: Infinity };
+      case 'repeat':
+      default:
+        return { mode: this.THREE.LoopRepeat, repetitions: Infinity };
+    }
+  }
+}

--- a/three-demo/src/entities/index.js
+++ b/three-demo/src/entities/index.js
@@ -12,6 +12,7 @@ import {
   createEntityAssetLoader,
   getSharedEntityAssetLoader,
 } from './entity-asset-loader.js';
+import { EntityAnimationController } from './entity-animation-controller.js';
 import { CrownedGhostEntity } from './crowned-ghost.js';
 
 export {
@@ -25,6 +26,7 @@ export {
   EntityAssetLoader,
   createEntityAssetLoader,
   getSharedEntityAssetLoader,
+  EntityAnimationController,
   CrownedGhostEntity,
 };
 


### PR DESCRIPTION
## Summary
- add an `EntityAnimationController` utility that manages animation mixers and variant actions for entity rigs
- expose the new controller through the entities module index for use in entity definitions

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68dc60fabed4832a9c4b3a9824a7fb15