### PR TITLE
Add animation variant summaries to spawn entity list output

### DIFF
--- a/three-demo/src/player/dev-commands.js
+++ b/three-demo/src/player/dev-commands.js
@@ -1318,6 +1318,13 @@ export function registerDeveloperCommands({
             : [];
           const aliasInfo = numericAliases.length > 0 ? ` (aliases: ${numericAliases.join(', ')})` : '';
           commandConsole.log(`  ${index + 1}. ${label}${aliasInfo}`);
+          const variantIds = collectAnimationVariantIds(type);
+          if (variantIds.length > 0) {
+            const summary = variantIds
+              .map((variantId, variantIndex) => `[${variantIndex + 1}] ${variantId}`)
+              .join(', ');
+            commandConsole.log(`      animations: ${summary}`);
+          }
         });
         commandConsole.log('Use /spawn entity <id|number> to create one of the entries above.');
         return;


### PR DESCRIPTION
## Summary
- show available animation variants when listing spawnable entity types
- reuse the existing variant ordering helper to map indices to animation ids

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc69c04b74832a813119cf0fc97da8