### PR TITLE
Ensure crowned ghost variants fall back to playable clips

### DIFF
--- a/three-demo/src/entities/crowned-ghost.js
+++ b/three-demo/src/entities/crowned-ghost.js
@@ -188,6 +188,15 @@ export class CrownedGhostEntity extends BaseEntity {
       });
     }
 
+    const declaredVariants = Object.keys(MODEL_CONFIG.variantUrls ?? {});
+    declaredVariants.forEach((variantId) => {
+      if (!variantMap.has(variantId)) {
+        console.warn(
+          `CrownedGhostEntity: Missing animation variant "${variantId}" from loaded assets.`,
+        );
+      }
+    });
+
     return variantMap;
   }
 
@@ -217,6 +226,12 @@ export class CrownedGhostEntity extends BaseEntity {
     const desired = this.desiredAnimationVariant ?? DEFAULT_ANIMATION_VARIANT;
     const action = this.animationController.playVariant(desired);
     if (!action && desired !== DEFAULT_ANIMATION_VARIANT) {
+      const availableVariants = Array.from(this.variantClipMap.keys());
+      console.warn(
+        `CrownedGhostEntity: Failed to play animation variant "${desired}". Available variants: ${availableVariants.join(
+          ', ',
+        ) || 'none'}.`,
+      );
       if (this.variantClipMap.has(DEFAULT_ANIMATION_VARIANT)) {
         this.animationController.playVariant(DEFAULT_ANIMATION_VARIANT);
         this.desiredAnimationVariant = DEFAULT_ANIMATION_VARIANT;

--- a/three-demo/src/entities/entity-asset-loader.js
+++ b/three-demo/src/entities/entity-asset-loader.js
@@ -289,30 +289,77 @@ export class EntityAssetLoader {
       const variantGltf = await this.loadGLTF(url);
       const renameMap = animationMapping.get(name) ?? new Map();
       const retargetedClips = [];
+      const sourceClips = Array.isArray(variantGltf.animations)
+        ? variantGltf.animations.filter((clip) => !!clip)
+        : [];
+      let retargetFailureReason = null;
 
-      if (Array.isArray(variantGltf.animations) && variantGltf.animations.length > 0) {
+      if (sourceClips.length > 0) {
         const targetRig = cloneSkeleton(baseScene);
         const sourceRig = cloneSkeleton(variantGltf.scene);
         const target = findFirstSkinnedMesh(targetRig);
         const source = findFirstSkinnedMesh(sourceRig);
 
+        const applyRename = (clip, originalName) => {
+          const directRename = renameMap.get(originalName ?? clip.name) ?? renameMap.get(clip.name);
+          const wildcardRename = renameMap.get('*');
+          if (directRename) {
+            clip.name = directRename;
+          } else if (wildcardRename) {
+            clip.name = wildcardRename;
+          }
+          return clip;
+        };
+
         if (target?.skeleton && source?.skeleton) {
-          variantGltf.animations.forEach((clip) => {
+          sourceClips.forEach((clip) => {
+            const originalName = typeof clip?.name === 'string' ? clip.name : null;
             const clonedClip = clip.clone();
             const remappedClip = retargetClip(target, source, clonedClip);
             if (!remappedClip) {
               return;
             }
-            const directRename = renameMap.get(clonedClip.name) ?? renameMap.get(clip.name);
-            const wildcardRename = renameMap.get('*');
-            if (directRename) {
-              remappedClip.name = directRename;
-            } else if (wildcardRename) {
-              remappedClip.name = wildcardRename;
-            }
-            retargetedClips.push(remappedClip);
+            retargetedClips.push(applyRename(remappedClip, originalName));
           });
+          if (retargetedClips.length === 0) {
+            retargetFailureReason =
+              'Retargeting produced no animation tracks despite variant clips being present.';
+          }
+        } else {
+          retargetFailureReason =
+            'Unable to locate compatible skinned meshes on the base or variant model for retargeting.';
         }
+
+        if (retargetedClips.length === 0) {
+          const fallbackClips = sourceClips
+            .map((clip) => {
+              if (!clip?.clone) {
+                return null;
+              }
+              const clonedClip = clip.clone();
+              return applyRename(clonedClip, typeof clip.name === 'string' ? clip.name : null);
+            })
+            .filter(Boolean);
+
+          if (fallbackClips.length > 0) {
+            if (retargetFailureReason) {
+              console.warn(
+                `EntityAssetLoader: ${retargetFailureReason} Falling back to source clips for variant "${name}" from ${url}.`,
+              );
+            }
+            retargetedClips.push(...fallbackClips);
+          } else {
+            console.error(
+              `EntityAssetLoader: Unable to clone fallback clips for variant "${name}" from ${url}.`,
+            );
+          }
+        }
+      }
+
+      if (retargetedClips.length === 0 && sourceClips.length === 0) {
+        console.warn(
+          `EntityAssetLoader: Variant "${name}" at ${url} does not provide any animation clips.`,
+        );
       }
 
       results[name] = retargetedClips;


### PR DESCRIPTION
## Summary
- ensure the entity asset loader falls back to cloned source clips when retargeting variants fails and logs actionable warnings
- surface crowned ghost warnings when declared variants are missing and when a requested clip falls back to idle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6d0122c0832a92f144358dcb45a3