### PR TITLE
Fix variant clip retarget track remapping

### DIFF
--- a/three-demo/src/entities/entity-asset-loader.js
+++ b/three-demo/src/entities/entity-asset-loader.js
@@ -514,10 +514,23 @@ export class EntityAssetLoader {
               return;
             }
             if (remappedClip.tracks?.length && targetBoneNames.size > 0) {
-              remappedClip.tracks = remappedClip.tracks.filter((track) => {
-                const boneName = extractTrackBoneName(track?.name);
-                return boneName ? targetBoneNames.has(boneName) : false;
-              });
+              const remappedTracks = remappedClip.tracks
+                .map((track) => {
+                  const boneName = extractTrackBoneName(track?.name);
+                  if (!boneName) {
+                    return null;
+                  }
+                  const targetBoneName = resolveTargetBoneName(boneName);
+                  if (!targetBoneName || !targetBoneNames.has(targetBoneName)) {
+                    return null;
+                  }
+                  if (targetBoneName !== boneName) {
+                    track.name = rewriteTrackName(track.name, targetBoneName);
+                  }
+                  return track;
+                })
+                .filter(Boolean);
+              remappedClip.tracks = remappedTracks;
             }
             if (!remappedClip.tracks?.length) {
               return;


### PR DESCRIPTION
## Summary
- resolve retargeted variant clip track names using resolveTargetBoneName and rewriteTrackName so sanitized bones map to the base rig

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5d3a0634832ab58a51b09069e85f