### PR TITLE
Clone retargeted variant tracks before renaming

### DIFF
--- a/three-demo/src/entities/entity-asset-loader.js
+++ b/three-demo/src/entities/entity-asset-loader.js
@@ -514,10 +514,28 @@ export class EntityAssetLoader {
               return;
             }
             if (remappedClip.tracks?.length && targetBoneNames.size > 0) {
-              remappedClip.tracks = remappedClip.tracks.filter((track) => {
-                const boneName = extractTrackBoneName(track?.name);
-                return boneName ? targetBoneNames.has(boneName) : false;
-              });
+              const remappedTracks = remappedClip.tracks
+                .map((track) => {
+                  const boneName = extractTrackBoneName(track?.name);
+                  if (!boneName) {
+                    return null;
+                  }
+                  const targetBoneName = resolveTargetBoneName(boneName);
+                  if (!targetBoneName || !targetBoneNames.has(targetBoneName)) {
+                    return null;
+                  }
+                  if (targetBoneName === boneName) {
+                    return track;
+                  }
+                  const nextTrack =
+                    track && typeof track.clone === 'function' ? track.clone() : track;
+                  if (nextTrack) {
+                    nextTrack.name = rewriteTrackName(nextTrack.name, targetBoneName);
+                  }
+                  return nextTrack;
+                })
+                .filter(Boolean);
+              remappedClip.tracks = remappedTracks;
             }
             if (!remappedClip.tracks?.length) {
               return;
@@ -554,8 +572,15 @@ export class EntityAssetLoader {
                     if (!targetBoneName || !targetBoneNames.has(targetBoneName)) {
                       return null;
                     }
-                    track.name = rewriteTrackName(track.name, targetBoneName);
-                    return track;
+                    if (targetBoneName === boneName) {
+                      return track;
+                    }
+                    const nextTrack =
+                      track && typeof track.clone === 'function' ? track.clone() : track;
+                    if (nextTrack) {
+                      nextTrack.name = rewriteTrackName(nextTrack.name, targetBoneName);
+                    }
+                    return nextTrack;
                   })
                   .filter(Boolean);
                 clonedClip.tracks = remappedTracks;


### PR DESCRIPTION
## Summary
- clone retargeted variant animation tracks before rewriting bone names so shared instances remain untouched
- clone fallback variant tracks when renaming to keep sanitized bone remapping consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5d3a0634832ab58a51b09069e85f