### PR TITLE
Add crowned ghost runner wander AI variant

### DIFF
--- a/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
+++ b/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+const SENTINEL_ACTION = { id: 'ghost-runner-action' };
+
+class StubAnimationController {
+  static instances = [];
+
+  constructor({ variantClips } = {}) {
+    this.variantClips = variantClips ?? new Map();
+    this.playCalls = [];
+    this.setVariantClipCalls = [];
+    this.activeVariantId = null;
+    this.disposeCalled = false;
+    StubAnimationController.instances.push(this);
+  }
+
+  setVariantClips(next) {
+    this.variantClips = next;
+    this.setVariantClipCalls.push(next);
+  }
+
+  playVariant(variantId) {
+    this.playCalls.push(variantId);
+    this.activeVariantId = variantId;
+    return SENTINEL_ACTION;
+  }
+
+  dispose() {
+    this.disposeCalled = true;
+  }
+}
+
+test('CrownedGhostRunnerEntity alternates between idle and walk states with animation swaps', async () => {
+  const fakeLoader = {
+    createVariantInstance: async () => ({
+      scene: new THREE.Group(),
+      animations: [new THREE.AnimationClip('Idle', -1, [])],
+      variants: {
+        runner: [new THREE.AnimationClip('Runner', -1, [])],
+      },
+      dispose() {},
+    }),
+  };
+
+  const randomValues = [0.25, 0.35, 0.8, 0.6, 0.4];
+  const random = () => {
+    if (randomValues.length === 0) {
+      return 0.5;
+    }
+    return randomValues.shift();
+  };
+
+  const { CrownedGhostRunnerEntity } = await import('../crowned-ghost-runner.js');
+
+  StubAnimationController.instances.length = 0;
+
+  const entity = new CrownedGhostRunnerEntity({
+    THREE,
+    assetLoader: fakeLoader,
+    animationControllerClass: StubAnimationController,
+    random,
+    behavior: {
+      walkDurationRange: [0.3, 0.3],
+      idleDurationRange: [0.2, 0.2],
+      walkSpeed: 2,
+      idleYawAmount: 0.2,
+      idleYawSpeed: 1.5,
+      collisionIdleDuration: 0.15,
+      walkHeadingJitter: Math.PI / 3,
+    },
+  });
+
+  entity.onSpawn();
+  await entity.assetLoadPromise;
+
+  assert.equal(StubAnimationController.instances.length, 1, 'should create one animation controller');
+  const controller = StubAnimationController.instances[0];
+
+  assert.equal(entity.behaviorState, 'idle', 'entity should begin in idle state');
+  assert.ok(controller.playCalls.includes('idle'), 'idle animation should play on spawn');
+
+  let elapsed = 0;
+  const step = (dt) => {
+    elapsed += dt;
+    entity.update({ delta: dt, elapsedTime: elapsed });
+  };
+
+  const initialYaw = entity.root.rotation.y;
+  step(0.1);
+  assert.ok(
+    Math.abs(entity.root.rotation.y - initialYaw) > 1e-5,
+    'idle update should adjust yaw over time',
+  );
+
+  step(0.12);
+  assert.equal(entity.behaviorState, 'walk', 'entity should transition to walk after idle timer');
+  assert.ok(controller.playCalls.includes('runner'), 'runner animation should play during walk');
+  assert.ok(
+    Math.abs(entity.angleDifference(entity.headingAngle, entity.previousHeadingAngle)) > 0.05,
+    'walk state should select a new heading angle',
+  );
+
+  const collisionSchedule = [
+    [],
+    [
+      {
+        label: 'forward',
+        isSolid: true,
+      },
+    ],
+  ];
+  entity.gatherCollisionSamples = () => collisionSchedule.shift() ?? [];
+
+  const walkStart = entity.root.position.clone();
+  step(0.1);
+  assert.ok(
+    entity.root.position.distanceTo(walkStart) > 0.05,
+    'walk update should move the entity forward',
+  );
+
+  const preCollisionPlayCount = controller.playCalls.length;
+  step(0.1);
+  assert.equal(entity.behaviorState, 'idle', 'collision should force an early return to idle');
+  assert.ok(
+    controller.playCalls.length > preCollisionPlayCount && controller.playCalls.at(-1) === 'idle',
+    'idle animation should resume after collision stop',
+  );
+
+  entity.dispose();
+  assert.ok(controller.disposeCalled, 'dispose should propagate to the animation controller');
+});

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -1,0 +1,205 @@
+import { CrownedGhostEntity } from './crowned-ghost.js';
+
+const WALK_STATE = 'walk';
+const IDLE_STATE = 'idle';
+
+export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
+  constructor(params = {}) {
+    super(params);
+
+    const behavior = params.behavior ?? params.options?.behavior ?? {};
+    this.random = typeof params.random === 'function' ? params.random : Math.random;
+
+    this.walkDurationRange =
+      Array.isArray(behavior.walkDurationRange) && behavior.walkDurationRange.length >= 1
+        ? behavior.walkDurationRange
+        : [3.5, 6];
+    this.idleDurationRange =
+      Array.isArray(behavior.idleDurationRange) && behavior.idleDurationRange.length >= 1
+        ? behavior.idleDurationRange
+        : [2, 4];
+
+    this.walkSpeed = Number.isFinite(behavior.walkSpeed) ? behavior.walkSpeed : 0.9;
+    this.idleYawAmount = Number.isFinite(behavior.idleYawAmount)
+      ? behavior.idleYawAmount
+      : 0.35;
+    this.idleYawSpeed = Number.isFinite(behavior.idleYawSpeed) ? behavior.idleYawSpeed : 0.7;
+    this.walkHeadingJitter = Number.isFinite(behavior.walkHeadingJitter)
+      ? behavior.walkHeadingJitter
+      : Math.PI / 2;
+    this.collisionIdleDuration = Number.isFinite(behavior.collisionIdleDuration)
+      ? Math.max(0.15, behavior.collisionIdleDuration)
+      : Math.max(0.6, this.idleDurationRange[0] ?? 0.6);
+
+    this.behaviorState = IDLE_STATE;
+    this.behaviorTime = 0;
+    this.behaviorDuration = this.chooseIdleDuration();
+    this.heading = new this.THREE.Vector3(0, 0, 1);
+    this.headingAngle = 0;
+    this.previousHeadingAngle = 0;
+
+    this.idleBaseYaw = 0;
+    this.idleYawPhase = this.random() * Math.PI * 2;
+
+    this._scratchPreviousPosition = new this.THREE.Vector3();
+  }
+
+  onSpawn(spawnContext, options = {}) {
+    super.onSpawn(spawnContext, options);
+    this.enterIdleState({});
+  }
+
+  enterIdleState({ duration } = {}) {
+    this.behaviorState = IDLE_STATE;
+    this.behaviorTime = 0;
+    this.behaviorDuration = Number.isFinite(duration)
+      ? Math.max(0.1, duration)
+      : this.chooseIdleDuration();
+    this.idleBaseYaw = this.normalizeAngle(this.root.rotation.y || this.headingAngle || 0);
+    this.idleYawPhase = this.random() * Math.PI * 2;
+    this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
+  }
+
+  enterWalkState({ duration, headingAngle } = {}) {
+    this.behaviorState = WALK_STATE;
+    this.behaviorTime = 0;
+    const nextDuration = Number.isFinite(duration)
+      ? Math.max(0.1, duration)
+      : this.chooseWalkDuration();
+    this.behaviorDuration = nextDuration;
+
+    const candidateHeading =
+      typeof headingAngle === 'number' ? headingAngle : this.chooseNextHeadingAngle();
+    this.setHeadingAngle(candidateHeading);
+    this.playAnimationVariant('runner', { loopMode: this.THREE.LoopRepeat });
+  }
+
+  chooseWalkDuration() {
+    return this.sampleRange(this.walkDurationRange, 4.5);
+  }
+
+  chooseIdleDuration() {
+    return this.sampleRange(this.idleDurationRange, 2.6);
+  }
+
+  chooseNextHeadingAngle() {
+    const jitterRange = Math.max(0, this.walkHeadingJitter || 0);
+    let attempts = 4;
+    let candidate = this.root.rotation.y || this.headingAngle || 0;
+    if (jitterRange === 0) {
+      return candidate;
+    }
+    do {
+      const offset = (this.random() * 2 - 1) * jitterRange;
+      candidate = (this.root.rotation.y || this.headingAngle || 0) + offset;
+      attempts -= 1;
+    } while (attempts > 0 && Math.abs(this.angleDifference(candidate, this.headingAngle)) < 0.3);
+    return candidate;
+  }
+
+  sampleRange(range, fallback) {
+    if (!Array.isArray(range) || range.length === 0) {
+      return Math.max(0.1, fallback);
+    }
+    const [minRaw, maxRaw = minRaw] = range;
+    const min = Number.isFinite(minRaw) ? minRaw : fallback;
+    const max = Number.isFinite(maxRaw) ? maxRaw : min;
+    if (max <= min) {
+      return Math.max(0.1, min);
+    }
+    const t = this.random();
+    return min + (max - min) * t;
+  }
+
+  setHeadingAngle(angle) {
+    const normalized = this.normalizeAngle(angle);
+    this.previousHeadingAngle = this.headingAngle;
+    this.headingAngle = normalized;
+    this.heading.set(Math.sin(normalized), 0, Math.cos(normalized)).normalize();
+    this.root.rotation.y = normalized;
+    this.markBoundsDirty();
+  }
+
+  normalizeAngle(angle) {
+    if (!Number.isFinite(angle)) {
+      return 0;
+    }
+    let result = angle % (Math.PI * 2);
+    if (result <= -Math.PI) {
+      result += Math.PI * 2;
+    } else if (result > Math.PI) {
+      result -= Math.PI * 2;
+    }
+    return result;
+  }
+
+  angleDifference(a, b) {
+    const diff = this.normalizeAngle(a) - this.normalizeAngle(b);
+    return this.normalizeAngle(diff);
+  }
+
+  update({ delta = 0, elapsedTime = 0 } = {}) {
+    if (!this.visualRoot) {
+      return;
+    }
+
+    const hoverValue = Math.sin(elapsedTime * this.hoverSpeed + this.hoverPhase);
+    this.visualRoot.position.y = this.baseHoverOffset + hoverValue * this.hoverAmplitude;
+
+    const swayValue = Math.sin(elapsedTime * this.swaySpeed + this.swayPhase);
+    this.visualRoot.position.x = swayValue * this.swayAmplitude;
+
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return;
+    }
+
+    this.behaviorTime += delta;
+    if (this.behaviorState === WALK_STATE) {
+      this.updateWalkState(delta);
+    } else {
+      this.updateIdleState(delta, elapsedTime);
+    }
+
+    if (this.behaviorTime >= this.behaviorDuration) {
+      if (this.behaviorState === WALK_STATE) {
+        this.enterIdleState({});
+      } else {
+        this.enterWalkState({});
+      }
+    }
+  }
+
+  updateWalkState(delta) {
+    const step = Math.max(0, delta) * this.walkSpeed;
+    if (step <= 0) {
+      return;
+    }
+    this._scratchPreviousPosition.copy(this.root.position);
+    this.root.position.addScaledVector(this.heading, step);
+    this.root.rotation.y = this.headingAngle;
+    this.markBoundsDirty();
+
+    const samples = this.gatherCollisionSamples();
+    const blocked = Array.isArray(samples)
+      ? samples.some((sample) => sample?.isSolid && (sample.label === 'forward' || sample.label === 'center'))
+      : false;
+    if (blocked) {
+      this.root.position.copy(this._scratchPreviousPosition);
+      this.markBoundsDirty();
+      this.enterIdleState({ duration: this.collisionIdleDuration });
+    }
+  }
+
+  updateIdleState(delta, elapsedTime) {
+    const yawOffset = Math.sin(elapsedTime * this.idleYawSpeed + this.idleYawPhase) * this.idleYawAmount;
+    const targetYaw = this.normalizeAngle(this.idleBaseYaw + yawOffset);
+    this.root.rotation.y = targetYaw;
+    this.headingAngle = targetYaw;
+  }
+
+  dispose() {
+    this.behaviorState = IDLE_STATE;
+    super.dispose();
+  }
+}
+

--- a/three-demo/src/entities/index.js
+++ b/three-demo/src/entities/index.js
@@ -14,6 +14,7 @@ import {
 } from './entity-asset-loader.js';
 import { EntityAnimationController } from './entity-animation-controller.js';
 import { CrownedGhostEntity } from './crowned-ghost.js';
+import { CrownedGhostRunnerEntity } from './crowned-ghost-runner.js';
 
 export {
   createEntityManager,
@@ -28,6 +29,7 @@ export {
   getSharedEntityAssetLoader,
   EntityAnimationController,
   CrownedGhostEntity,
+  CrownedGhostRunnerEntity,
 };
 
 export function registerEntityFactory(idOrDefinition, factory, options = {}) {
@@ -108,6 +110,31 @@ export function registerBuiltinEntities() {
             idle: 'Default hover idle loop from the base rig.',
             runner: 'High-energy chase loop suitable for pursuit.',
             walker: 'Leisurely patrol loop for ambient wandering.',
+          },
+        },
+      },
+    });
+  }
+
+  const existingRunner = getEntityDefinition('crowned_ghost_2');
+  if (!existingRunner) {
+    registerEntityClass({
+      id: 'crowned_ghost_2',
+      label: 'Crowned Ghost Runner',
+      EntityClass: CrownedGhostRunnerEntity,
+      metadata: {
+        aliases: {
+          numeric: [2],
+        },
+        tags: {
+          biomes: ['haunted', 'mistwood', 'luminous_cavern'],
+          weather: ['clear', 'foggy', 'storm'],
+        },
+        animations: {
+          default: 'idle',
+          variants: {
+            idle: 'Base hover idle loop shared with the crowned ghost.',
+            runner: 'Ghost guy runner loop used for high-energy wandering.',
           },
         },
       },


### PR DESCRIPTION
## Summary
- add a CrownedGhostRunnerEntity that alternates between idle hovering and runner locomotion with randomized headings and collision-aware wandering
- register the crowned_ghost_2 builtin definition and export the new entity for factory helpers
- cover the new behavior with a deterministic node:test verifying animation swaps, movement, and collision fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd6c33c44c832aa55dc8717a5ddfa4