### PR TITLE
Fix crowned ghost runner animation fallback handling

### DIFF
--- a/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
+++ b/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
@@ -2,13 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import * as THREE from 'three';
 
-const SENTINEL_ACTION = { id: 'ghost-runner-action' };
-
 class StubAnimationController {
   static instances = [];
 
   constructor({ variantClips } = {}) {
-    this.variantClips = variantClips ?? new Map();
+    this.variantClips = variantClips instanceof Map ? new Map(variantClips) : new Map();
     this.playCalls = [];
     this.setVariantClipCalls = [];
     this.activeVariantId = null;
@@ -17,14 +15,20 @@ class StubAnimationController {
   }
 
   setVariantClips(next) {
-    this.variantClips = next;
-    this.setVariantClipCalls.push(next);
+    this.variantClips = next instanceof Map ? new Map(next) : new Map();
+    this.setVariantClipCalls.push(this.variantClips);
   }
 
-  playVariant(variantId) {
-    this.playCalls.push(variantId);
+  playVariant(variantId, options = {}) {
+    const clips = this.variantClips.get(variantId) ?? [];
+    const hasClips = Array.isArray(clips) ? clips.length > 0 : false;
+    const call = { variantId, options, hasClips };
+    this.playCalls.push(call);
+    if (!hasClips) {
+      return null;
+    }
     this.activeVariantId = variantId;
-    return SENTINEL_ACTION;
+    return { id: `ghost-runner-action-${variantId}` };
   }
 
   dispose() {
@@ -79,7 +83,10 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
   const controller = StubAnimationController.instances[0];
 
   assert.equal(entity.behaviorState, 'idle', 'entity should begin in idle state');
-  assert.ok(controller.playCalls.includes('idle'), 'idle animation should play on spawn');
+  assert.ok(
+    controller.playCalls.some((call) => call.variantId === 'idle'),
+    'idle animation should play on spawn',
+  );
 
   let elapsed = 0;
   const step = (dt) => {
@@ -96,7 +103,10 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
 
   step(0.12);
   assert.equal(entity.behaviorState, 'walk', 'entity should transition to walk after idle timer');
-  assert.ok(controller.playCalls.includes('runner'), 'runner animation should play during walk');
+  assert.ok(
+    controller.playCalls.some((call) => call.variantId === 'runner' && call.hasClips),
+    'runner animation should play during walk',
+  );
   assert.ok(
     Math.abs(entity.angleDifference(entity.headingAngle, entity.previousHeadingAngle)) > 0.05,
     'walk state should select a new heading angle',
@@ -124,10 +134,80 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
   step(0.1);
   assert.equal(entity.behaviorState, 'idle', 'collision should force an early return to idle');
   assert.ok(
-    controller.playCalls.length > preCollisionPlayCount && controller.playCalls.at(-1) === 'idle',
+    controller.playCalls.length > preCollisionPlayCount &&
+      controller.playCalls.at(-1)?.variantId === 'idle',
     'idle animation should resume after collision stop',
   );
 
   entity.dispose();
   assert.ok(controller.disposeCalled, 'dispose should propagate to the animation controller');
+});
+
+test('CrownedGhostRunnerEntity retries runner animation once clips become available', async () => {
+  let resolveInstance;
+  const deferredInstance = new Promise((resolve) => {
+    resolveInstance = resolve;
+  });
+
+  const fakeLoader = {
+    createVariantInstance: async () => deferredInstance,
+  };
+
+  const { CrownedGhostRunnerEntity } = await import('../crowned-ghost-runner.js');
+
+  StubAnimationController.instances.length = 0;
+
+  const entity = new CrownedGhostRunnerEntity({
+    THREE,
+    assetLoader: fakeLoader,
+    animationControllerClass: StubAnimationController,
+  });
+
+  entity.onSpawn();
+
+  assert.equal(StubAnimationController.instances.length, 1, 'should create an animation controller');
+  const controller = StubAnimationController.instances[0];
+
+  entity.enterWalkState({});
+
+  const initialRunnerCall = controller.playCalls.at(-1);
+  assert.equal(initialRunnerCall?.variantId, 'runner', 'should request runner variant immediately');
+  assert.equal(
+    initialRunnerCall?.options?.fallbackToDefault,
+    false,
+    'should disable default fallback while awaiting runner clips',
+  );
+
+  const initialRunnerIndex = controller.playCalls.length - 1;
+  const idleFallbackDuringPending = controller.playCalls.some(
+    (call, index) => index > initialRunnerIndex && call.variantId === 'idle',
+  );
+  assert.equal(
+    idleFallbackDuringPending,
+    false,
+    'should not fall back to idle while runner clips are still pending',
+  );
+
+  resolveInstance({
+    scene: new THREE.Group(),
+    animations: [new THREE.AnimationClip('Idle', -1, [])],
+    variants: {
+      runner: [new THREE.AnimationClip('Runner', -1, [])],
+    },
+    dispose() {},
+  });
+
+  await entity.assetLoadPromise;
+
+  entity.update({ delta: 0.016, elapsedTime: 0.016 });
+
+  const successfulRunnerCall = controller.playCalls.find(
+    (call) => call.variantId === 'runner' && call.hasClips,
+  );
+  assert.ok(successfulRunnerCall, 'runner animation should begin once clips are available');
+  assert.equal(
+    controller.activeVariantId,
+    'runner',
+    'runner variant should be active after clips resolve',
+  );
 });

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -42,6 +42,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.idleYawPhase = this.random() * Math.PI * 2;
 
     this._scratchPreviousPosition = new this.THREE.Vector3();
+    this._pendingRunnerAnimation = false;
   }
 
   onSpawn(spawnContext, options = {}) {
@@ -58,6 +59,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.idleBaseYaw = this.normalizeAngle(this.root.rotation.y || this.headingAngle || 0);
     this.idleYawPhase = this.random() * Math.PI * 2;
     this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
+    this._pendingRunnerAnimation = false;
   }
 
   enterWalkState({ duration, headingAngle } = {}) {
@@ -71,7 +73,29 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     const candidateHeading =
       typeof headingAngle === 'number' ? headingAngle : this.chooseNextHeadingAngle();
     this.setHeadingAngle(candidateHeading);
-    this.playAnimationVariant('runner', { loopMode: this.THREE.LoopRepeat });
+    const runnerAction = this.playAnimationVariant('runner', {
+      loopMode: this.THREE.LoopRepeat,
+      fallbackToDefault: false,
+    });
+    if (runnerAction) {
+      this._pendingRunnerAnimation = false;
+      return;
+    }
+
+    const variantsLoaded = this.areAnimationVariantsLoaded();
+    const hasRunnerVariant = this.hasAnimationVariant('runner');
+
+    if (variantsLoaded && !hasRunnerVariant) {
+      console.assert(
+        false,
+        'CrownedGhostRunnerEntity: Missing "runner" animation variant after assets finished loading.',
+      );
+      this._pendingRunnerAnimation = false;
+      this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
+      return;
+    }
+
+    this._pendingRunnerAnimation = true;
   }
 
   chooseWalkDuration() {
@@ -166,6 +190,11 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       } else {
         this.enterWalkState({});
       }
+      return;
+    }
+
+    if (this.behaviorState === WALK_STATE) {
+      this.retryRunnerAnimation();
     }
   }
 
@@ -197,8 +226,47 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.headingAngle = targetYaw;
   }
 
+  updateAnimationVariantsFromAsset() {
+    super.updateAnimationVariantsFromAsset();
+    this.retryRunnerAnimation();
+  }
+
+  retryRunnerAnimation() {
+    if (!this._pendingRunnerAnimation || this.behaviorState !== WALK_STATE) {
+      return;
+    }
+
+    if (this.animationController?.activeVariantId === 'runner') {
+      this._pendingRunnerAnimation = false;
+      return;
+    }
+
+    if (!this.areAnimationVariantsLoaded()) {
+      return;
+    }
+
+    if (!this.hasAnimationVariant('runner')) {
+      console.assert(
+        false,
+        'CrownedGhostRunnerEntity: Runner animation clips are missing from the loaded variant set.',
+      );
+      this._pendingRunnerAnimation = false;
+      this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
+      return;
+    }
+
+    const action = this.playAnimationVariant('runner', {
+      loopMode: this.THREE.LoopRepeat,
+      fallbackToDefault: false,
+    });
+    if (action) {
+      this._pendingRunnerAnimation = false;
+    }
+  }
+
   dispose() {
     this.behaviorState = IDLE_STATE;
+    this._pendingRunnerAnimation = false;
     super.dispose();
   }
 }

--- a/three-demo/src/entities/crowned-ghost.js
+++ b/three-demo/src/entities/crowned-ghost.js
@@ -17,6 +17,16 @@ const MODEL_CONFIG = {
       import.meta.url,
     ).href,
   },
+  animationMap: {
+    runner: {
+      NlaTrack: 'ghost_guy_runner',
+      '*': 'ghost_guy_runner',
+    },
+    walker: {
+      NlaTrack: 'ghost_guy_walker',
+      '*': 'ghost_guy_walker',
+    },
+  },
 };
 
 const DEFAULT_ANIMATION_VARIANT = 'idle';
@@ -340,6 +350,19 @@ export class CrownedGhostEntity extends BaseEntity {
     }
     const trimmed = variantId.trim();
     return trimmed.length > 0 ? trimmed : DEFAULT_ANIMATION_VARIANT;
+  }
+
+  hasAnimationVariant(variantId) {
+    if (!variantId) {
+      return false;
+    }
+    const normalized = this.normalizeAnimationVariantId(variantId);
+    const resolved = this.variantAliasMap.get(normalized) ?? normalized;
+    return this.variantClipMap instanceof Map && this.variantClipMap.has(resolved);
+  }
+
+  areAnimationVariantsLoaded() {
+    return this.variantClipMap instanceof Map && this.variantClipMap.size > 0;
   }
 
   releaseVariantClips() {


### PR DESCRIPTION
## Summary
- ensure the crowned ghost runner only falls back to idle when the runner clips are truly missing and retry playback once they load
- expose animation variant helpers and rename runner/walker clips during asset load so the runner variant is registered consistently
- strengthen crowned ghost runner tests to cover delayed clip availability and updated animation-controller stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd7731aca8832a91614bf3e61fa5e3