### PR TITLE
Load crowned ghost runner animations from runner GLB

### DIFF
--- a/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
+++ b/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
@@ -42,15 +42,18 @@ class StubAnimationController {
 }
 
 test('CrownedGhostRunnerEntity alternates between idle and walk states with animation swaps', async () => {
+  let receivedConfig;
+  const idleClip = new THREE.AnimationClip('Ghost_Guy_Runner_Idle', -1, []);
+  const runnerClip = new THREE.AnimationClip('Ghost_Guy_Runner', -1, []);
   const fakeLoader = {
-    createVariantInstance: async () => ({
-      scene: new THREE.Group(),
-      animations: [new THREE.AnimationClip('Idle', -1, [])],
-      variants: {
-        runner: [new THREE.AnimationClip('Runner', -1, [])],
-      },
-      dispose() {},
-    }),
+    createVariantInstance: async (config) => {
+      receivedConfig = config;
+      return {
+        scene: new THREE.Group(),
+        animations: [idleClip, runnerClip],
+        dispose() {},
+      };
+    },
   };
 
   const randomValues = [0.25, 0.35, 0.8, 0.6, 0.4];
@@ -83,6 +86,32 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
 
   entity.onSpawn();
   await entity.assetLoadPromise;
+
+  assert.ok(receivedConfig, 'runner entity should request an asset config');
+  assert.match(
+    receivedConfig.baseUrl ?? '',
+    /entity_ghost_guy_1_runner\.glb$/i,
+    'runner config should point to the dedicated runner GLB',
+  );
+  const variantUrlCount =
+    receivedConfig && typeof receivedConfig.variantUrls === 'object'
+      ? Object.keys(receivedConfig.variantUrls).length
+      : 0;
+  assert.equal(
+    variantUrlCount,
+    0,
+    'runner config should not include external variant URLs',
+  );
+  assert.equal(
+    entity.variantClipMap.get('idle')?.[0],
+    idleClip,
+    'idle variant should originate from the runner asset animations',
+  );
+  assert.equal(
+    entity.variantClipMap.get('runner')?.[0],
+    runnerClip,
+    'runner variant should originate from the runner asset animations',
+  );
 
   assert.equal(StubAnimationController.instances.length, 1, 'should create one animation controller');
   const controller = StubAnimationController.instances[0];
@@ -157,8 +186,12 @@ test('CrownedGhostRunnerEntity retries runner animation once clips become availa
     resolveInstance = resolve;
   });
 
+  let receivedConfig;
   const fakeLoader = {
-    createVariantInstance: async () => deferredInstance,
+    createVariantInstance: async (config) => {
+      receivedConfig = config;
+      return deferredInstance;
+    },
   };
 
   const { CrownedGhostRunnerEntity } = await import('../crowned-ghost-runner.js');
@@ -198,14 +231,21 @@ test('CrownedGhostRunnerEntity retries runner animation once clips become availa
 
   resolveInstance({
     scene: new THREE.Group(),
-    animations: [new THREE.AnimationClip('Idle', -1, [])],
-    variants: {
-      runner: [new THREE.AnimationClip('Runner', -1, [])],
-    },
+    animations: [
+      new THREE.AnimationClip('Runner_Idle', -1, []),
+      new THREE.AnimationClip('Runner', -1, []),
+    ],
     dispose() {},
   });
 
   await entity.assetLoadPromise;
+
+  assert.ok(receivedConfig, 'runner entity should capture a config for deferred loads');
+  assert.match(
+    receivedConfig.baseUrl ?? '',
+    /entity_ghost_guy_1_runner\.glb$/i,
+    'deferred load config should reference the runner GLB',
+  );
 
   entity.update({ delta: 0.016, elapsedTime: 0.016 });
 

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -1,12 +1,20 @@
 import { CrownedGhostEntity } from './crowned-ghost.js';
 
+const RUNNER_MODEL_CONFIG = {
+  baseUrl: new URL(
+    '../models/entity_ghost_guy_1/entity_ghost_guy_1_runner.glb',
+    import.meta.url,
+  ).href,
+};
+
 const WALK_STATE = 'walk';
 const IDLE_STATE = 'idle';
 const TURN_STATE = 'turn';
 
 export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
   constructor(params = {}) {
-    super(params);
+    const modelConfig = params?.modelConfig ?? RUNNER_MODEL_CONFIG;
+    super({ ...params, modelConfig });
 
     const behavior = params.behavior ?? params.options?.behavior ?? {};
     this.random = typeof params.random === 'function' ? params.random : Math.random;
@@ -414,6 +422,92 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     if (clearance >= this.turnResumeClearance) {
       this.enterWalkState({ headingAngle: this.targetHeadingAngle ?? headingAngle });
     }
+  }
+
+  buildVariantClipMapFromInstance(instance) {
+    this.variantAliasMap = new Map();
+    const variantMap = new Map();
+    if (!instance) {
+      return variantMap;
+    }
+
+    const baseAnimations = Array.isArray(instance.animations)
+      ? instance.animations.filter(Boolean)
+      : [];
+
+    if (baseAnimations.length === 0) {
+      return variantMap;
+    }
+
+    const nameOf = (clip) => (typeof clip?.name === 'string' ? clip.name.toLowerCase() : '');
+
+    const idleCandidates = baseAnimations.filter((clip) => {
+      const name = nameOf(clip);
+      return name.includes('idle') || name.includes('hover') || name.includes('float');
+    });
+
+    const idleClip =
+      this.selectClipByName(idleCandidates, [
+        'idle',
+        'hover',
+        'ghost_guy_runner_idle',
+        'ghost_guy_idle',
+        'hover_idle',
+        'idle_hover',
+        'float',
+      ]) ?? this.selectClipByName(baseAnimations, ['idle', 'hover', 'float']);
+
+    const runnerCandidates = baseAnimations.filter((clip) => {
+      const name = nameOf(clip);
+      if (!name) {
+        return false;
+      }
+      if (name.includes('idle') || name.includes('hover') || name.includes('float')) {
+        return false;
+      }
+      return name.includes('runner') || name.includes('run') || name.includes('move');
+    });
+
+    const runnerClip =
+      this.selectClipByName(runnerCandidates, [
+        'runner',
+        'run',
+        'ghost_guy_runner',
+        'ghost_guy_run',
+        'move',
+        'loop',
+      ]) ??
+      this.selectClipByName(
+        baseAnimations.filter((clip) => {
+          const name = nameOf(clip);
+          return name && !name.includes('idle') && !name.includes('hover');
+        }),
+        ['runner', 'run', 'move'],
+      );
+
+    if (idleClip) {
+      variantMap.set('idle', [idleClip]);
+    }
+
+    if (runnerClip) {
+      variantMap.set('runner', [runnerClip]);
+    }
+
+    if (!variantMap.has('idle') && runnerClip) {
+      variantMap.set('idle', [runnerClip]);
+      this.variantAliasMap.set('idle', 'runner');
+      console.warn(
+        'CrownedGhostRunnerEntity: Missing dedicated idle clip in runner asset; aliasing to runner.',
+      );
+    } else if (!variantMap.has('runner') && idleClip) {
+      variantMap.set('runner', [idleClip]);
+      this.variantAliasMap.set('runner', 'idle');
+      console.warn(
+        'CrownedGhostRunnerEntity: Missing dedicated runner clip in runner asset; aliasing to idle.',
+      );
+    }
+
+    return variantMap;
   }
 
   updateAnimationVariantsFromAsset() {

--- a/three-demo/src/entities/crowned-ghost.js
+++ b/three-demo/src/entities/crowned-ghost.js
@@ -69,6 +69,7 @@ export class CrownedGhostEntity extends BaseEntity {
   constructor(params = {}) {
     super(params);
 
+    this.modelConfig = params?.modelConfig ?? MODEL_CONFIG;
     this.AnimationControllerClass =
       params.animationControllerClass ?? EntityAnimationController;
     this.assetLoader = params.assetLoader ?? getSharedEntityAssetLoader({ THREE: this.THREE });
@@ -102,7 +103,7 @@ export class CrownedGhostEntity extends BaseEntity {
     this.forwardDirection = new this.THREE.Vector3(0, 0, 1);
 
     this.assetLoadPromise = this.assetLoader
-      .createVariantInstance(MODEL_CONFIG)
+      .createVariantInstance(this.modelConfig)
       .then((instance) => {
         if (this.isDisposed) {
           instance.dispose?.();
@@ -235,7 +236,7 @@ export class CrownedGhostEntity extends BaseEntity {
       });
     }
 
-    const declaredVariants = Object.keys(MODEL_CONFIG.variantUrls ?? {});
+    const declaredVariants = Object.keys(this.modelConfig?.variantUrls ?? {});
     declaredVariants.forEach((variantId) => {
       if (!variantMap.has(variantId)) {
         console.warn(


### PR DESCRIPTION
## Summary
- allow CrownedGhostEntity to accept a caller-provided model configuration when loading assets
- have CrownedGhostRunnerEntity request the runner GLB directly and harvest idle/runner clips from its animations
- extend unit tests to confirm the runner entity no longer depends on the base ghost asset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dd8c28aec4832ab7f5467b981839fc