### PR TITLE
Fix runner animation retries for crowned ghost

### DIFF
--- a/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
+++ b/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
@@ -137,6 +137,11 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
 
   step(0.12);
   assert.equal(entity.behaviorState, 'walk', 'entity should transition to walk after idle timer');
+  assert.equal(
+    entity.pendingRunnerAnimation,
+    false,
+    'runner animation should start immediately when clips are already loaded',
+  );
   assert.ok(
     controller.playCalls.some((call) => call.variantId === 'runner' && call.hasClips),
     'runner animation should play during walk',
@@ -171,6 +176,11 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
     controller.playCalls.length > preCollisionPlayCount &&
       controller.playCalls.at(-1)?.variantId === 'idle',
     'idle animation should resume after collision stop',
+  );
+  assert.equal(
+    entity.pendingRunnerAnimation,
+    false,
+    'leaving the walk state should clear pending runner animation attempts',
   );
 
   step(0.1);
@@ -218,6 +228,11 @@ test('CrownedGhostRunnerEntity retries runner animation once clips become availa
     false,
     'should disable default fallback while awaiting runner clips',
   );
+  assert.equal(
+    entity.pendingRunnerAnimation,
+    true,
+    'runner animation should be marked as pending until clips resolve',
+  );
 
   const initialRunnerIndex = controller.playCalls.length - 1;
   const idleFallbackDuringPending = controller.playCalls.some(
@@ -249,10 +264,19 @@ test('CrownedGhostRunnerEntity retries runner animation once clips become availa
 
   entity.update({ delta: 0.016, elapsedTime: 0.016 });
 
-  const successfulRunnerCall = controller.playCalls.find(
+  const runnerCallsWithClips = controller.playCalls.filter(
     (call) => call.variantId === 'runner' && call.hasClips,
   );
-  assert.ok(successfulRunnerCall, 'runner animation should begin once clips are available');
+  assert.ok(runnerCallsWithClips.length > 0, 'runner animation should begin once clips are available');
+  assert.ok(
+    runnerCallsWithClips.some((call) => call.options?.fallbackToDefault === false),
+    'runner retry should continue to disable the default fallback',
+  );
+  assert.equal(
+    entity.pendingRunnerAnimation,
+    false,
+    'pending runner flag should clear after a successful retry',
+  );
   assert.equal(
     controller.activeVariantId,
     'runner',

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -91,6 +91,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
 
     this._scratchPreviousPosition = new this.THREE.Vector3();
     this.pendingRunnerAnimation = false;
+    this.currentRunnerAction = null;
     this.currentMoveSpeed = 0;
     this.recentBlockedHeadings = [];
     this.headingProbeDistances = [
@@ -124,6 +125,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.visualYawOffset = 0;
     this.applyVisualYaw();
     this.pendingRunnerAnimation = false;
+    this.currentRunnerAction = null;
     this.updateRunnerAnimationSpeed();
   }
 
@@ -150,8 +152,10 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       loopMode: this.THREE.LoopRepeat,
       fallbackToDefault: false,
     });
-    if (runnerAction) {
-      this.pendingRunnerAnimation = false;
+    const runnerActionStarted = Boolean(runnerAction);
+    this.pendingRunnerAnimation = !runnerActionStarted;
+    this.currentRunnerAction = runnerActionStarted ? runnerAction : null;
+    if (runnerActionStarted) {
       this.updateRunnerAnimationSpeed();
       return;
     }
@@ -165,11 +169,13 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
         'CrownedGhostRunnerEntity: Missing "runner" animation variant after assets finished loading.',
       );
       this.pendingRunnerAnimation = false;
+      this.currentRunnerAction = null;
       this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
       return;
     }
 
     this.pendingRunnerAnimation = true;
+    this.currentRunnerAction = null;
     this.updateRunnerAnimationSpeed();
   }
 
@@ -186,6 +192,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.visualYawOffset = 0;
     this.applyVisualYaw();
     this.pendingRunnerAnimation = false;
+    this.currentRunnerAction = null;
     this.updateRunnerAnimationSpeed();
   }
 
@@ -520,7 +527,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       return;
     }
 
-    if (this.animationController?.activeVariantId === 'runner') {
+    if (this.animationController?.activeVariantId === 'runner' && this.currentRunnerAction) {
       this.pendingRunnerAnimation = false;
       return;
     }
@@ -536,6 +543,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
         'CrownedGhostRunnerEntity: Runner animation clips are missing from the loaded variant set.',
       );
       this.pendingRunnerAnimation = false;
+      this.currentRunnerAction = null;
       this.playAnimationVariant('idle', { loopMode: this.THREE.LoopRepeat });
       return;
     }
@@ -546,6 +554,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     });
     if (action) {
       this.pendingRunnerAnimation = false;
+      this.currentRunnerAction = action;
       this.updateRunnerAnimationSpeed();
     }
   }
@@ -553,6 +562,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
   dispose() {
     this.behaviorState = IDLE_STATE;
     this.pendingRunnerAnimation = false;
+    this.currentRunnerAction = null;
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- ensure the crowned ghost runner keeps retrying its dedicated movement clip after entering the walk state
- track pending runner playback attempts and clear the flag when the entity leaves walking
- expand the crowned ghost runner tests to cover delayed asset loads and pending runner retries

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dd95d37420832a8a8b81a4a4640f72