### PR TITLE
Handle runner animation alias speed

### DIFF
--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -732,7 +732,18 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     if (!this.animationController) {
       return;
     }
-    if (this.animationController.activeVariantId === 'runner') {
+
+    const activeVariant = this.animationController.activeVariantId;
+    const runnerAlias =
+      this.variantAliasMap instanceof Map ? this.variantAliasMap.get('runner') ?? null : null;
+
+    const shouldTreatAliasAsRunner =
+      typeof runnerAlias === 'string' &&
+      runnerAlias.length > 0 &&
+      activeVariant === runnerAlias &&
+      (this.behaviorState === WALK_STATE || this.pendingRunnerAnimation);
+
+    if (activeVariant === 'runner' || shouldTreatAliasAsRunner) {
       const normalized = this.walkSpeed > 0 ? this.currentMoveSpeed / this.walkSpeed : 0;
       const scaled = Number.isFinite(normalized) ? normalized * this.runnerAnimationSpeedScale : 0;
       const clamped = this.THREE.MathUtils.clamp(
@@ -743,6 +754,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       this.animationController.setSpeed(Math.max(this.runnerAnimationSpeedFloor, clamped));
       return;
     }
+
     if (Math.abs((this.animationController.speed ?? 1) - 1) > 1e-3) {
       this.animationController.setSpeed(1);
     }


### PR DESCRIPTION
## Summary
- update the crowned ghost runner animation speed check to treat alias-resolved runner variants as active during movement
- preserve idle reset behaviour while continuing to clamp runner animation speeds within the configured range

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc8330d70832aa5b1615a4a52383b