### PR TITLE
Add mob AI core scheduler and behavior registry

### DIFF
--- a/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
+++ b/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
@@ -1,0 +1,108 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { MobAICore } from '../mob-ai-core.js';
+import { ActionNode } from '../behavior-nodes.js';
+
+const createLoggingNode = (name, logs) =>
+  new ActionNode(name, {
+    onInitialize: () => logs.push(`${name}:initialize`),
+    onAttach: () => logs.push(`${name}:attach`),
+    onUpdate: () => logs.push(`${name}:update`),
+  });
+
+describe('MobAICore', () => {
+  let logs;
+  let core;
+
+  beforeEach(() => {
+    logs = [];
+    core = new MobAICore({
+      random: () => 0,
+    });
+  });
+
+  it('updates behavior layers according to priority order', () => {
+    const lowPriority = createLoggingNode('low', logs);
+    const highPriority = createLoggingNode('high', logs);
+
+    core.addBehaviorLayer({ name: 'low', node: lowPriority, priority: 0 });
+    core.addBehaviorLayer({ name: 'high', node: highPriority, priority: 10 });
+
+    core.initialize({ logs });
+    core.attachToEntity({ id: 'entity-1' });
+    core.update(16);
+
+    assert.deepStrictEqual(logs, [
+      'high:initialize',
+      'low:initialize',
+      'high:attach',
+      'low:attach',
+      'high:update',
+      'low:update',
+    ]);
+  });
+
+  it('evaluates loop transitions using registry definitions', () => {
+    const sequence = [];
+    const loop = core.useBehaviorLoop('idle', {
+      priority: 5,
+      shouldWander: (context) => context.flags?.wander ?? false,
+      canSeeTarget: (context) => context.percepts?.targetVisible ?? false,
+      lostTarget: (context) => !context.percepts?.targetVisible,
+      onEnterIdle: (context) => sequence.push(`enter:${context.behaviorState['mob-idle']}`),
+      onEnterWander: (context) => sequence.push(`enter:${context.behaviorState['mob-idle']}`),
+      onEnterChase: (context) => sequence.push(`enter:${context.behaviorState['mob-idle']}`),
+      onStateChange: ({ state }) => sequence.push(`state:${state}`),
+    });
+
+    core.initialize({ flags: { wander: false }, percepts: { targetVisible: false } });
+    core.attachToEntity({ id: 'entity-2' });
+
+    core.update(1);
+    assert.strictEqual(loop.currentState, 'idle');
+
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: false } });
+    assert.strictEqual(loop.currentState, 'wander');
+
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: true } });
+    assert.strictEqual(loop.currentState, 'chase');
+
+    core.update(1, { flags: { wander: false }, percepts: { targetVisible: false } });
+    assert.strictEqual(loop.currentState, 'idle');
+
+    assert.deepStrictEqual(sequence, [
+      'state:idle',
+      'enter:idle',
+      'state:wander',
+      'enter:wander',
+      'state:chase',
+      'enter:chase',
+      'state:idle',
+      'enter:idle',
+    ]);
+  });
+
+  it('wraps behavior layer errors with layer metadata', () => {
+    const errorNode = new ActionNode('broken', {
+      onUpdate: () => {
+        throw new Error('boom');
+      },
+    });
+
+    core.addBehaviorLayer({ name: 'broken', node: errorNode, priority: 0 });
+    core.initialize();
+    core.attachToEntity({ id: 'entity-3' });
+
+    assert.throws(
+      () => {
+        core.update(16);
+      },
+      (error) => {
+        assert.match(error.message, /broken/);
+        assert.ok(error.cause instanceof Error, 'expected original error to be exposed as cause');
+        assert.strictEqual(error.cause.message, 'boom');
+        return true;
+      },
+    );
+  });
+});

--- a/three-demo/src/entities/ai/behavior-nodes.js
+++ b/three-demo/src/entities/ai/behavior-nodes.js
@@ -1,0 +1,251 @@
+const noop = () => {};
+
+export class BehaviorNode {
+  constructor(name = 'behavior-node') {
+    this.name = name;
+  }
+
+  initialize(context) {
+    void context;
+  }
+
+  attachToEntity(entity, context) {
+    void entity;
+    void context;
+  }
+
+  update(delta, context) {
+    void delta;
+    void context;
+  }
+}
+
+export class ActionNode extends BehaviorNode {
+  constructor(name, { onInitialize = noop, onAttach = noop, onUpdate = noop } = {}) {
+    super(name);
+    this._onInitialize = onInitialize;
+    this._onAttach = onAttach;
+    this._onUpdate = onUpdate;
+  }
+
+  initialize(context) {
+    this._onInitialize(context);
+  }
+
+  attachToEntity(entity, context) {
+    this._onAttach(entity, context);
+  }
+
+  update(delta, context) {
+    return this._onUpdate(delta, context);
+  }
+}
+
+export class BehaviorLoop extends BehaviorNode {
+  constructor(name, definition, options = {}) {
+    super(name);
+    this.definition = definition;
+    this.currentState = options.initialState ?? definition.initialState;
+    this._onStateChange = options.onStateChange ?? noop;
+  }
+
+  initialize(context) {
+    this.context = context;
+    if (!this.currentState) {
+      throw new Error(`Behavior loop "${this.name}" has no initial state.`);
+    }
+    this._enterState(this.currentState, context, true);
+  }
+
+  attachToEntity(entity, context) {
+    if (this.definition.onAttach) {
+      this.definition.onAttach(entity, context, this);
+    }
+  }
+
+  update(delta, context) {
+    const stateDefinition = this._getStateDefinition(this.currentState);
+    if (!stateDefinition) {
+      throw new Error(`Behavior loop "${this.name}" is missing definition for state "${this.currentState}".`);
+    }
+
+    if (stateDefinition.onUpdate) {
+      stateDefinition.onUpdate(delta, context, this);
+    }
+
+    const transitions = stateDefinition.transitions ?? [];
+    for (const transition of transitions) {
+      if (transition.condition?.(context, this)) {
+        this._enterState(transition.target, context);
+        break;
+      }
+    }
+  }
+
+  _getStateDefinition(state) {
+    return this.definition.states?.[state];
+  }
+
+  _enterState(nextState, context, initializing = false) {
+    const stateDefinition = this._getStateDefinition(nextState);
+    if (!stateDefinition) {
+      throw new Error(`Behavior loop "${this.name}" cannot transition to undefined state "${nextState}".`);
+    }
+
+    const previousState = this.currentState;
+    if (!initializing && previousState && previousState !== nextState) {
+      const previousDefinition = this._getStateDefinition(previousState);
+      previousDefinition?.onExit?.(context, this);
+    }
+
+    this.currentState = nextState;
+    context.behaviorState ??= {};
+    context.behaviorState[this.name] = nextState;
+    this._onStateChange({
+      state: nextState,
+      previousState,
+      context,
+      loop: this,
+    });
+
+    const stateSpecificEnter = stateDefinition.onEnter ?? noop;
+    stateSpecificEnter(context, this);
+  }
+}
+
+export class BehaviorRegistry {
+  constructor() {
+    this._loops = new Map();
+    this._installDefaultLoops();
+  }
+
+  registerLoop(name, factory) {
+    if (this._loops.has(name)) {
+      throw new Error(`Behavior loop "${name}" is already registered.`);
+    }
+    this._loops.set(name, factory);
+  }
+
+  createLoop(name, options = {}, dependencies = {}) {
+    const factory = this._loops.get(name);
+    if (!factory) {
+      throw new Error(`Behavior loop "${name}" is not registered.`);
+    }
+    return factory(options, dependencies);
+  }
+
+  _installDefaultLoops() {
+    const createLoop = (initialState) => (options = {}, dependencies = {}) => {
+      const {
+        wanderChance = 0.05,
+        idleChance = 0.15,
+        onEnterIdle = noop,
+        onEnterWander = noop,
+        onEnterChase = noop,
+        onUpdateIdle = noop,
+        onUpdateWander = noop,
+        onUpdateChase = noop,
+        onExitChase = noop,
+        shouldWander,
+        shouldIdle,
+        canSeeTarget,
+        lostTarget,
+        onStateChange,
+      } = options;
+
+      const rng = options.random ?? dependencies.random ?? Math.random;
+
+      const resolve = (value, fallback) => {
+        if (typeof value === 'function') {
+          return value;
+        }
+        return fallback;
+      };
+
+      const pickWander = resolve(
+        shouldWander,
+        (context) => (context.flags?.wander ?? false) || rng() < wanderChance,
+      );
+      const pickIdle = resolve(
+        shouldIdle,
+        (context) => (context.flags?.idle ?? false) || rng() < idleChance,
+      );
+      const seeTarget = resolve(
+        canSeeTarget,
+        (context) => Boolean(context.percepts?.targetVisible),
+      );
+      const targetLost = resolve(
+        lostTarget,
+        (context) => !context.percepts?.targetVisible,
+      );
+
+      return new BehaviorLoop(`mob-${initialState}`, {
+        initialState,
+        states: {
+          idle: {
+            onEnter: onEnterIdle,
+            onUpdate: (delta, context, loop) => {
+              context.ticks ??= {};
+              context.ticks.idle = (context.ticks.idle ?? 0) + 1;
+              onUpdateIdle(delta, context, loop);
+            },
+            transitions: [
+              {
+                target: 'chase',
+                condition: (context) => seeTarget(context),
+              },
+              {
+                target: 'wander',
+                condition: (context) => pickWander(context),
+              },
+            ],
+          },
+          wander: {
+            onEnter: onEnterWander,
+            onUpdate: (delta, context, loop) => {
+              context.ticks ??= {};
+              context.ticks.wander = (context.ticks.wander ?? 0) + 1;
+              onUpdateWander(delta, context, loop);
+            },
+            transitions: [
+              {
+                target: 'chase',
+                condition: (context) => seeTarget(context),
+              },
+              {
+                target: 'idle',
+                condition: (context) => pickIdle(context),
+              },
+            ],
+          },
+          chase: {
+            onEnter: onEnterChase,
+            onUpdate: (delta, context, loop) => {
+              context.ticks ??= {};
+              context.ticks.chase = (context.ticks.chase ?? 0) + 1;
+              onUpdateChase(delta, context, loop);
+            },
+            onExit: onExitChase,
+            transitions: [
+              {
+                target: 'idle',
+                condition: (context) => targetLost(context),
+              },
+            ],
+          },
+        },
+      }, {
+        initialState,
+        onStateChange,
+      });
+    };
+
+    this.registerLoop('idle', createLoop('idle'));
+    this.registerLoop('wander', createLoop('wander'));
+    this.registerLoop('chase', createLoop('chase'));
+  }
+}
+
+export function createBehaviorRegistry() {
+  return new BehaviorRegistry();
+}

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -1,0 +1,195 @@
+import { BehaviorRegistry } from './behavior-nodes.js';
+
+class BehaviorScheduler {
+  constructor() {
+    this.layers = [];
+    this.initialized = false;
+    this._order = 0;
+  }
+
+  addLayer({ name, node, priority = 0 }) {
+    if (!name) {
+      throw new Error('Behavior layers require a name.');
+    }
+    if (!node) {
+      throw new Error(`Behavior layer "${name}" is missing its node.`);
+    }
+    if (this.layers.some((layer) => layer.name === name)) {
+      throw new Error(`Behavior layer "${name}" is already registered.`);
+    }
+
+    const entry = {
+      name,
+      node,
+      priority,
+      order: this._order++,
+    };
+    this.layers.push(entry);
+    this.layers.sort((a, b) => {
+      if (b.priority === a.priority) {
+        return a.order - b.order;
+      }
+      return b.priority - a.priority;
+    });
+  }
+
+  initialize(context) {
+    if (this.initialized) {
+      return;
+    }
+    for (const layer of this.layers) {
+      layer.node.initialize?.(context, layer);
+    }
+    this.initialized = true;
+  }
+
+  attachToEntity(entity, context) {
+    for (const layer of this.layers) {
+      layer.node.attachToEntity?.(entity, context, layer);
+    }
+  }
+
+  tick(delta, context) {
+    for (const layer of this.layers) {
+      try {
+        layer.node.update?.(delta, context, layer);
+      } catch (error) {
+        throw new Error(`Error in behavior layer "${layer.name}": ${error?.message ?? error}` , {
+          cause: error,
+        });
+      }
+    }
+  }
+}
+
+export class MobAICore {
+  constructor(options = {}) {
+    const {
+      random = Math.random,
+      chunkManager = null,
+      audioManager = null,
+      behaviorRegistry = new BehaviorRegistry(),
+    } = options;
+
+    this.dependencies = {
+      random,
+      chunkManager,
+      audioManager,
+    };
+
+    this.scheduler = new BehaviorScheduler();
+    this.behaviorRegistry = behaviorRegistry;
+    this.personas = new Map();
+    this.traits = new Map();
+    this.context = null;
+    this.currentPersona = null;
+    this.initialized = false;
+  }
+
+  registerPersona(name, definition) {
+    if (!name) {
+      throw new Error('Persona name is required.');
+    }
+    this.personas.set(name, { ...definition });
+    return this;
+  }
+
+  usePersona(name) {
+    const persona = typeof name === 'string' ? this.personas.get(name) : name;
+    if (!persona) {
+      throw new Error(`Unknown persona "${name}".`);
+    }
+    this.currentPersona = persona;
+    if (this.context) {
+      this.context.persona = persona;
+    }
+    return persona;
+  }
+
+  registerTrait(name, trait) {
+    if (!name) {
+      throw new Error('Trait name is required.');
+    }
+    this.traits.set(name, trait);
+    if (this.context) {
+      this.context.traits = this.traits;
+    }
+    return this;
+  }
+
+  removeTrait(name) {
+    this.traits.delete(name);
+    if (this.context) {
+      this.context.traits = this.traits;
+    }
+    return this;
+  }
+
+  addBehaviorLayer({ name, node, priority = 0 }) {
+    this.scheduler.addLayer({ name, node, priority });
+    if (this.initialized && this.context) {
+      node.initialize?.(this.context, { name, priority });
+      if (this.context.entity) {
+        node.attachToEntity?.(this.context.entity, this.context, { name, priority });
+      }
+    }
+    return node;
+  }
+
+  useBehaviorLoop(loopName, options = {}) {
+    const loop = this.behaviorRegistry.createLoop(loopName, options, this.dependencies);
+    this.addBehaviorLayer({ name: loop.name, node: loop, priority: options.priority ?? 0 });
+    return loop;
+  }
+
+  initialize(initialContext = {}) {
+    if (this.initialized) {
+      this.context = {
+        ...this.context,
+        ...initialContext,
+      };
+      this.context.dependencies = this.dependencies;
+      this.context.traits = this.traits;
+      if (this.currentPersona) {
+        this.context.persona = this.currentPersona;
+      }
+      return this.context;
+    }
+
+    this.context = {
+      time: 0,
+      delta: 0,
+      entity: null,
+      memory: new Map(),
+      ...initialContext,
+      dependencies: this.dependencies,
+      traits: this.traits,
+      persona: this.currentPersona,
+    };
+    this.scheduler.initialize(this.context);
+    this.initialized = true;
+    return this.context;
+  }
+
+  attachToEntity(entity) {
+    if (!this.initialized) {
+      this.initialize();
+    }
+    this.context.entity = entity;
+    this.scheduler.attachToEntity(entity, this.context);
+    return entity;
+  }
+
+  update(delta, contextUpdates = {}) {
+    if (!this.initialized) {
+      throw new Error('MobAICore must be initialized before update.');
+    }
+
+    Object.assign(this.context, contextUpdates);
+    this.context.delta = delta;
+    this.context.time += delta;
+    this.scheduler.tick(delta, this.context);
+  }
+}
+
+export default MobAICore;


### PR DESCRIPTION
## Summary
- add a MobAICore scheduler that wires lifecycle hooks, dependency injection, and persona/trait management for mobs
- introduce behavior node primitives plus a registry of idle/wander/chase loops with configurable transitions
- cover scheduler ordering, transition flow, and error wrapping with new Node-based unit tests

## Testing
- npm test *(fails: existing CrownedGhostRunnerEntity asset assertion and unrelated emitter noise)*
- node --test ./src/entities/ai/__tests__/mob-ai-core.test.js


------
https://chatgpt.com/codex/tasks/task_e_68dedc6c7330832a8e455c01863cbdae