### PR TITLE
Add AI sensor suite with vision, proximity, and threshold sensing

### DIFF
--- a/three-demo/src/entities/ai/__tests__/sensor-suite.test.js
+++ b/three-demo/src/entities/ai/__tests__/sensor-suite.test.js
@@ -1,0 +1,166 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Vector3 } from 'three';
+import { MobAICore } from '../mob-ai-core.js';
+import { SensorSuite } from '../sensors/sensor-suite.js';
+import { ConeVisionSensor } from '../sensors/cone-vision-sensor.js';
+import { RingProximitySensor } from '../sensors/ring-proximity-sensor.js';
+import { ThresholdSensor } from '../sensors/threshold-sensor.js';
+
+describe('SensorSuite', () => {
+  let entity;
+  let world;
+  let ai;
+
+  beforeEach(() => {
+    entity = {
+      position: new Vector3(0, 0, 0),
+      forward: new Vector3(0, 0, 1),
+    };
+    world = {
+      targets: [],
+    };
+    ai = new MobAICore();
+  });
+
+  it('detects entities within a vision cone and forwards stimuli to the AI core', () => {
+    world.targets = [
+      { id: 'ahead', position: new Vector3(0, 0, 5) },
+      { id: 'side', position: new Vector3(5, 0, 0) },
+    ];
+
+    const stimuliEvents = [];
+    ai.on('sensor:stimuli', (stimuli) => stimuliEvents.push(stimuli));
+
+    const suite = new SensorSuite({
+      sensors: [
+        new ConeVisionSensor({
+          range: 8,
+          angle: Math.PI / 2,
+          queryTargets: () => world.targets,
+        }),
+      ],
+    });
+
+    suite.configure({ entity, world, aiCore: ai });
+
+    const stimuli = suite.update(16);
+
+    assert.strictEqual(stimuli.length, 1);
+    assert.strictEqual(stimuli[0].target.id, 'ahead');
+    assert.strictEqual(stimuliEvents.length, 1);
+    assert.strictEqual(stimuliEvents[0][0].target.id, 'ahead');
+    assert.ok(stimuli[0].distance <= 8);
+    assert.ok(stimuli[0].angle <= Math.PI / 4);
+  });
+
+  it('applies decay and blocking rules for cone vision detection', () => {
+    world.targets = [
+      { id: 'visible', position: new Vector3(0, 0, 4) },
+      { id: 'blocked', position: new Vector3(0, 0, 6) },
+    ];
+
+    const sensor = new ConeVisionSensor({
+      range: 10,
+      angle: Math.PI,
+      queryTargets: () => world.targets,
+      decay: ({ distance, range }) => Number((1 - distance / range).toFixed(3)),
+      isOccluded: ({ target }) => target.id === 'blocked',
+    });
+
+    const suite = new SensorSuite({ sensors: [sensor] });
+    suite.configure({ entity, world, aiCore: ai });
+
+    const stimuli = suite.update(33);
+
+    assert.strictEqual(stimuli.length, 1);
+    assert.strictEqual(stimuli[0].target.id, 'visible');
+    assert.strictEqual(stimuli[0].intensity, Number((1 - 4 / 10).toFixed(3)));
+  });
+
+  it('throttles sensor sampling according to interval', () => {
+    world.targets = [{ id: 'ahead', position: new Vector3(0, 0, 4) }];
+    const sensor = new ConeVisionSensor({
+      range: 6,
+      interval: 100,
+      angle: Math.PI / 2,
+      queryTargets: () => world.targets,
+    });
+    const suite = new SensorSuite({ sensors: [sensor] });
+    suite.configure({ entity, world, aiCore: ai });
+
+    const first = suite.update(16);
+    const second = suite.update(16);
+    const third = suite.update(84);
+
+    assert.strictEqual(first.length, 1, 'first sample should detect target');
+    assert.strictEqual(second.length, 0, 'interval should block second sample');
+    assert.strictEqual(third.length, 1, 'third sample occurs after interval');
+  });
+
+  it('computes ring proximity intensity using custom decay', () => {
+    world.targets = [
+      { id: 'inner', position: new Vector3(0, 0, 3) },
+      { id: 'outer', position: new Vector3(0, 0, 5) },
+      { id: 'far', position: new Vector3(0, 0, 8) },
+    ];
+
+    const sensor = new RingProximitySensor({
+      innerRadius: 2,
+      outerRadius: 6,
+      queryTargets: () => world.targets,
+    });
+
+    const suite = new SensorSuite({ sensors: [sensor] });
+    suite.configure({ entity, world });
+
+    const stimuli = suite.update(20);
+
+    assert.strictEqual(stimuli.length, 2);
+    const intensities = Object.fromEntries(
+      stimuli.map((stimulus) => [stimulus.target.id, Number(stimulus.intensity.toFixed(2))]),
+    );
+
+    assert.deepStrictEqual(intensities, {
+      inner: Number((1 - (3 - 2) / 4).toFixed(2)),
+      outer: Number((1 - (5 - 2) / 4).toFixed(2)),
+    });
+  });
+
+  it('fires threshold events only when crossing the threshold', () => {
+    const timeline = [0.2, 0.7, 0.9, 0.3, 0.8];
+    let index = 0;
+    const sensor = new ThresholdSensor({
+      threshold: 0.6,
+      interval: 10,
+      getValue: () => timeline[index],
+      intensityMapper: ({ value, threshold }) => Number((value - threshold).toFixed(2)),
+    });
+
+    const suite = new SensorSuite({ sensors: [sensor] });
+    suite.configure({ entity, world, aiCore: ai });
+
+    const emissions = [];
+    ai.on('sensor:stimulus', (stimulus) => emissions.push(stimulus));
+
+    const step = (delta) => {
+      const result = suite.update(delta);
+      index = Math.min(index + 1, timeline.length - 1);
+      return result;
+    };
+
+    const first = step(16);
+    const second = step(16);
+    const third = step(16);
+    const fourth = step(16);
+    const fifth = step(16);
+
+    assert.strictEqual(first.length, 0, 'below threshold does not emit');
+    assert.strictEqual(second.length, 1, 'crossing threshold emits once');
+    assert.strictEqual(second[0].intensity, Number((0.7 - 0.6).toFixed(2)));
+    assert.strictEqual(third.length, 0, 'remaining above threshold does not re-emit');
+    assert.strictEqual(fourth.length, 0, 'dropping below resets state without emission');
+    assert.strictEqual(fifth.length, 1, 'rising again triggers emission');
+    assert.strictEqual(emissions.length, 2, 'AI core receives individual stimulus events');
+  });
+});

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { BehaviorRegistry } from './behavior-nodes.js';
 
 class BehaviorScheduler {
@@ -69,6 +70,7 @@ export class MobAICore {
       chunkManager = null,
       audioManager = null,
       behaviorRegistry = new BehaviorRegistry(),
+      events,
     } = options;
 
     this.dependencies = {
@@ -84,6 +86,7 @@ export class MobAICore {
     this.context = null;
     this.currentPersona = null;
     this.initialized = false;
+    this.events = events ?? new EventEmitter();
   }
 
   registerPersona(name, definition) {
@@ -189,6 +192,26 @@ export class MobAICore {
     this.context.delta = delta;
     this.context.time += delta;
     this.scheduler.tick(delta, this.context);
+  }
+
+  on(eventName, listener) {
+    this.events.on(eventName, listener);
+    return this;
+  }
+
+  once(eventName, listener) {
+    this.events.once(eventName, listener);
+    return this;
+  }
+
+  off(eventName, listener) {
+    this.events.off(eventName, listener);
+    return this;
+  }
+
+  emit(eventName, ...args) {
+    this.events.emit(eventName, ...args);
+    return this;
   }
 }
 

--- a/three-demo/src/entities/ai/sensors/cone-vision-sensor.js
+++ b/three-demo/src/entities/ai/sensors/cone-vision-sensor.js
@@ -1,0 +1,131 @@
+import { Vector3 } from 'three';
+import { MobSensor } from './mob-sensor.js';
+
+const tmpDirection = new Vector3();
+const tmpForward = new Vector3();
+const tmpOrigin = new Vector3();
+
+const cloneVector3 = (value) => {
+  if (!value) {
+    return new Vector3();
+  }
+  if (value.isVector3) {
+    return value.clone();
+  }
+  return new Vector3(value.x ?? 0, value.y ?? 0, value.z ?? 0);
+};
+
+export class ConeVisionSensor extends MobSensor {
+  constructor(options = {}) {
+    const {
+      id = 'cone-vision',
+      interval = options.interval ?? 0,
+      range = options.range ?? 10,
+      angle = options.angle ?? Math.PI / 3,
+    } = options;
+    super({ id, type: 'vision', label: options.label ?? 'Vision', interval });
+
+    this.range = range;
+    this.angle = angle;
+
+    this.queryTargets = options.queryTargets ?? (() => []);
+    this.getOrigin = options.getOrigin ?? ((entity) => entity?.position);
+    this.getForward =
+      options.getForward ?? ((entity) => entity?.forward ?? { x: 0, y: 0, z: 1 });
+    this.getTargetPosition =
+      options.getTargetPosition ?? ((target) => target?.position);
+    this.filterTarget = options.filterTarget ?? null;
+    this.isOccluded = options.isOccluded ?? null;
+    this.decay =
+      options.decay ??
+      (({ distance, range }) => Math.max(0, 1 - distance / Math.max(range, 1)));
+  }
+
+  sampleWorld(context) {
+    const { world, entity, time, delta } = context;
+    if (!entity || !this.range || this.range <= 0) {
+      return [];
+    }
+
+    const originSource = this.getOrigin(entity);
+    const forwardSource = this.getForward(entity);
+    if (!originSource || !forwardSource) {
+      return [];
+    }
+
+    tmpOrigin.copy(cloneVector3(originSource));
+    tmpForward.copy(cloneVector3(forwardSource));
+    if (tmpForward.lengthSq() === 0) {
+      tmpForward.set(0, 0, 1);
+    }
+    tmpForward.normalize();
+
+    const halfAngle = Math.max(0, this.angle) / 2;
+    const contextInfo = { world, entity, time, delta };
+    const candidates = this.queryTargets(contextInfo) ?? [];
+    const detections = [];
+
+    for (const target of candidates) {
+      if (this.filterTarget && !this.filterTarget(target, contextInfo)) {
+        continue;
+      }
+      const positionSource = this.getTargetPosition(target, contextInfo);
+      if (!positionSource) {
+        continue;
+      }
+      const targetPosition = cloneVector3(positionSource);
+      tmpDirection.copy(targetPosition).sub(tmpOrigin);
+      const distance = tmpDirection.length();
+      if (distance === 0) {
+        continue;
+      }
+      if (distance > this.range) {
+        continue;
+      }
+      tmpDirection.divideScalar(distance);
+      const angleToTarget = tmpForward.angleTo(tmpDirection);
+      if (angleToTarget > halfAngle) {
+        continue;
+      }
+      if (
+        this.isOccluded &&
+        this.isOccluded({
+          target,
+          origin: tmpOrigin,
+          targetPosition,
+          direction: tmpDirection,
+          distance,
+          world,
+          entity,
+          time,
+          delta,
+        })
+      ) {
+        continue;
+      }
+
+      const intensity = this.decay({
+        distance,
+        range: this.range,
+        target,
+        entity,
+        world,
+        time,
+        delta,
+      });
+
+      detections.push({
+        target,
+        position: targetPosition.clone(),
+        distance,
+        intensity,
+        angle: angleToTarget,
+        direction: tmpDirection.clone(),
+      });
+    }
+
+    return detections;
+  }
+}
+
+export default ConeVisionSensor;

--- a/three-demo/src/entities/ai/sensors/mob-sensor.js
+++ b/three-demo/src/entities/ai/sensors/mob-sensor.js
@@ -1,0 +1,130 @@
+import { EventEmitter } from 'node:events';
+
+export class MobSensor {
+  constructor(options = {}) {
+    const {
+      id = null,
+      type = 'generic',
+      label = type,
+      interval = 0,
+      enabled = true,
+    } = options;
+
+    this.id = id ?? `${type}-${Math.random().toString(36).slice(2, 8)}`;
+    this.type = type;
+    this.label = label;
+    this.interval = Math.max(0, interval);
+    this.enabled = enabled;
+
+    this.entity = null;
+    this.world = null;
+    this.onEmit = null;
+
+    this._emitter = new EventEmitter();
+    this._configured = false;
+    this._lastSampleTime = -Infinity;
+  }
+
+  on(eventName, listener) {
+    this._emitter.on(eventName, listener);
+    return this;
+  }
+
+  off(eventName, listener) {
+    this._emitter.off(eventName, listener);
+    return this;
+  }
+
+  emit(eventName, ...args) {
+    this._emitter.emit(eventName, ...args);
+  }
+
+  configure(configuration = {}) {
+    const { entity, world, onEmit } = configuration;
+    let reconfigured = false;
+    if (entity !== undefined && entity !== this.entity) {
+      this.entity = entity;
+      reconfigured = true;
+    }
+    if (world !== undefined && world !== this.world) {
+      this.world = world;
+      reconfigured = true;
+    }
+    if (onEmit !== undefined) {
+      this.onEmit = onEmit;
+    }
+    if (reconfigured || !this._configured) {
+      this.onConfigure?.({ entity: this.entity, world: this.world });
+      this._configured = true;
+    }
+    return this;
+  }
+
+  setEnabled(enabled) {
+    this.enabled = Boolean(enabled);
+    return this;
+  }
+
+  shouldSample(time) {
+    if (!this.enabled) {
+      return false;
+    }
+    if (this.interval <= 0) {
+      return true;
+    }
+    return time - this._lastSampleTime >= this.interval;
+  }
+
+  update(context = {}) {
+    const { time = 0, delta = 0, world = this.world } = context;
+    if (!this.shouldSample(time)) {
+      return [];
+    }
+    const stimuli = this.sampleWorld({
+      time,
+      delta,
+      world,
+      entity: this.entity,
+    });
+    this._lastSampleTime = time;
+    return this.emitStimuli(stimuli, { time, delta, world });
+  }
+
+  sampleWorld() {
+    throw new Error(
+      `${this.constructor.name} must implement sampleWorld(context)`,
+    );
+  }
+
+  emitStimuli(stimuli, meta = {}) {
+    if (!stimuli) {
+      return [];
+    }
+    const batch = Array.isArray(stimuli) ? stimuli : [stimuli];
+    if (batch.length === 0) {
+      return [];
+    }
+    const enriched = batch.map((stimulus) => {
+      const result = { ...stimulus };
+      if (!('timestamp' in result) && meta.time !== undefined) {
+        result.timestamp = meta.time;
+      }
+      result.sensorId = this.id;
+      result.sensorType = this.type;
+      return result;
+    });
+
+    for (const stimulus of enriched) {
+      this.onEmit?.(stimulus, meta);
+      this.emit('stimulus', stimulus, meta);
+    }
+
+    if (enriched.length > 0) {
+      this.emit('stimuli', enriched, meta);
+    }
+
+    return enriched;
+  }
+}
+
+export default MobSensor;

--- a/three-demo/src/entities/ai/sensors/ring-proximity-sensor.js
+++ b/three-demo/src/entities/ai/sensors/ring-proximity-sensor.js
@@ -1,0 +1,110 @@
+import { Vector3 } from 'three';
+import { MobSensor } from './mob-sensor.js';
+
+const tmpOrigin = new Vector3();
+const tmpOffset = new Vector3();
+
+const cloneVector3 = (value) => {
+  if (!value) {
+    return new Vector3();
+  }
+  if (value.isVector3) {
+    return value.clone();
+  }
+  return new Vector3(value.x ?? 0, value.y ?? 0, value.z ?? 0);
+};
+
+export class RingProximitySensor extends MobSensor {
+  constructor(options = {}) {
+    const {
+      id = 'ring-proximity',
+      interval = options.interval ?? 0,
+      innerRadius = options.innerRadius ?? 0,
+      outerRadius = options.outerRadius ?? 5,
+    } = options;
+    super({ id, type: 'proximity', label: options.label ?? 'Proximity', interval });
+
+    if (outerRadius <= 0) {
+      throw new Error('RingProximitySensor requires a positive outerRadius.');
+    }
+    if (innerRadius < 0) {
+      throw new Error('RingProximitySensor innerRadius cannot be negative.');
+    }
+    if (innerRadius > outerRadius) {
+      throw new Error('RingProximitySensor innerRadius must be <= outerRadius.');
+    }
+
+    this.innerRadius = innerRadius;
+    this.outerRadius = outerRadius;
+
+    this.queryTargets = options.queryTargets ?? (() => []);
+    this.getOrigin = options.getOrigin ?? ((entity) => entity?.position);
+    this.getTargetPosition =
+      options.getTargetPosition ?? ((target) => target?.position);
+    this.filterTarget = options.filterTarget ?? null;
+    this.decay =
+      options.decay ??
+      (({ distance, innerRadius, outerRadius }) => {
+        if (outerRadius === innerRadius) {
+          return 1;
+        }
+        const normalized = (distance - innerRadius) / (outerRadius - innerRadius);
+        return Math.max(0, 1 - normalized);
+      });
+  }
+
+  sampleWorld(context) {
+    const { world, entity, time, delta } = context;
+    if (!entity) {
+      return [];
+    }
+
+    const originSource = this.getOrigin(entity);
+    if (!originSource) {
+      return [];
+    }
+
+    tmpOrigin.copy(cloneVector3(originSource));
+    const contextInfo = { world, entity, time, delta };
+    const candidates = this.queryTargets(contextInfo) ?? [];
+    const detections = [];
+
+    for (const target of candidates) {
+      if (this.filterTarget && !this.filterTarget(target, contextInfo)) {
+        continue;
+      }
+      const positionSource = this.getTargetPosition(target, contextInfo);
+      if (!positionSource) {
+        continue;
+      }
+      const targetPosition = cloneVector3(positionSource);
+      tmpOffset.copy(targetPosition).sub(tmpOrigin);
+      const distance = tmpOffset.length();
+      if (distance < this.innerRadius || distance > this.outerRadius) {
+        continue;
+      }
+
+      const intensity = this.decay({
+        distance,
+        innerRadius: this.innerRadius,
+        outerRadius: this.outerRadius,
+        target,
+        entity,
+        world,
+        time,
+        delta,
+      });
+
+      detections.push({
+        target,
+        position: targetPosition.clone(),
+        distance,
+        intensity,
+      });
+    }
+
+    return detections;
+  }
+}
+
+export default RingProximitySensor;

--- a/three-demo/src/entities/ai/sensors/sensor-suite.js
+++ b/three-demo/src/entities/ai/sensors/sensor-suite.js
@@ -1,0 +1,114 @@
+import { EventEmitter } from 'node:events';
+import { MobSensor } from './mob-sensor.js';
+
+export class SensorSuite extends EventEmitter {
+  constructor(options = {}) {
+    super();
+    const { sensors = [], time = 0 } = options;
+
+    this.time = time;
+    this.entity = options.entity ?? null;
+    this.world = options.world ?? null;
+    this.aiCore = options.aiCore ?? null;
+
+    this.sensors = new Map();
+    sensors.forEach((sensor) => this.addSensor(sensor));
+  }
+
+  addSensor(sensor) {
+    if (!(sensor instanceof MobSensor)) {
+      throw new Error('SensorSuite expects sensors to extend MobSensor.');
+    }
+    if (this.sensors.has(sensor.id)) {
+      throw new Error(`Sensor with id "${sensor.id}" is already registered.`);
+    }
+    this.sensors.set(sensor.id, sensor);
+    if (this.entity || this.world) {
+      sensor.configure({ entity: this.entity, world: this.world });
+    }
+    return sensor;
+  }
+
+  removeSensor(id) {
+    const sensor = this.sensors.get(id);
+    if (sensor) {
+      this.sensors.delete(id);
+    }
+    return sensor;
+  }
+
+  configure(configuration = {}) {
+    const { entity, world, aiCore } = configuration;
+    if (entity !== undefined) {
+      this.entity = entity;
+    }
+    if (world !== undefined) {
+      this.world = world;
+    }
+    if (aiCore !== undefined) {
+      this.aiCore = aiCore;
+    }
+
+    for (const sensor of this.sensors.values()) {
+      sensor.configure({ entity: this.entity, world: this.world });
+    }
+
+    return this;
+  }
+
+  update(delta = 0, overrides = {}) {
+    if (overrides.entity !== undefined) {
+      this.entity = overrides.entity;
+    }
+    if (overrides.world !== undefined) {
+      this.world = overrides.world;
+    }
+    if (overrides.aiCore !== undefined) {
+      this.aiCore = overrides.aiCore;
+    }
+
+    this.time += delta;
+    const aggregated = [];
+    const meta = {
+      time: this.time,
+      delta,
+      entity: this.entity,
+      world: this.world,
+    };
+
+    const onEmit = (stimulus) => {
+      aggregated.push(stimulus);
+    };
+
+    for (const sensor of this.sensors.values()) {
+      sensor.configure({
+        entity: this.entity,
+        world: this.world,
+        onEmit,
+      });
+      sensor.update({
+        time: this.time,
+        delta,
+        world: this.world,
+      });
+    }
+
+    if (aggregated.length > 0) {
+      this.emit('stimuli', aggregated, meta);
+      for (const stimulus of aggregated) {
+        this.emit('stimulus', stimulus, meta);
+      }
+
+      if (this.aiCore?.emit) {
+        this.aiCore.emit('sensor:stimuli', aggregated, meta);
+        for (const stimulus of aggregated) {
+          this.aiCore.emit('sensor:stimulus', stimulus, meta);
+        }
+      }
+    }
+
+    return aggregated;
+  }
+}
+
+export default SensorSuite;

--- a/three-demo/src/entities/ai/sensors/threshold-sensor.js
+++ b/three-demo/src/entities/ai/sensors/threshold-sensor.js
@@ -1,0 +1,84 @@
+import { MobSensor } from './mob-sensor.js';
+
+export class ThresholdSensor extends MobSensor {
+  constructor(options = {}) {
+    const {
+      id = 'threshold',
+      interval = options.interval ?? 0,
+      threshold = options.threshold ?? 0,
+      onlyOnCrossing = options.onlyOnCrossing ?? true,
+    } = options;
+    super({ id, type: 'threshold', label: options.label ?? 'Threshold', interval });
+
+    this.threshold = threshold;
+    this.onlyOnCrossing = onlyOnCrossing;
+
+    this.getValue = options.getValue ?? (() => 0);
+    this.comparator =
+      options.comparator ?? ((value, limit) => value >= limit);
+    this.intensityMapper =
+      options.intensityMapper ??
+      (({ value, threshold: limit }) => Math.max(0, value - limit));
+
+    this._lastValue = null;
+    this._above = false;
+  }
+
+  sampleWorld(context) {
+    const { world, entity, time, delta } = context;
+    const previousValue = this._lastValue;
+    const value = this.getValue({
+      world,
+      entity,
+      time,
+      delta,
+      previous: previousValue,
+    });
+    this._lastValue = value;
+    const meets = this.comparator(value, this.threshold, {
+      world,
+      entity,
+      time,
+      delta,
+      previous: previousValue,
+    });
+
+    let emit = meets;
+    if (this.onlyOnCrossing) {
+      emit = meets && !this._above;
+    }
+
+    this._above = meets;
+
+    if (!emit) {
+      if (!meets) {
+        this._above = false;
+      }
+      return [];
+    }
+
+    const intensity = this.intensityMapper({
+      value,
+      threshold: this.threshold,
+      world,
+      entity,
+      time,
+      delta,
+      previous: previousValue,
+    });
+
+    const direction =
+      previousValue === null || value >= previousValue ? 'rising' : 'falling';
+
+    return [
+      {
+        value,
+        threshold: this.threshold,
+        intensity,
+        direction,
+      },
+    ];
+  }
+}
+
+export default ThresholdSensor;


### PR DESCRIPTION
## Summary
- add a MobSensor base contract plus cone vision, ring proximity, and threshold sensor implementations for AI entities
- build a SensorSuite manager that throttles sampling, aggregates stimuli, and forwards them to MobAICore event hooks
- update MobAICore to expose event emitter helpers and add focused tests covering cones, decay, throttling, and threshold crossings

## Testing
- node --test src/entities/ai/__tests__/sensor-suite.test.js
- npm test *(fails: existing crowned ghost runner animation expectation in src/entities/__tests__/crowned-ghost-runner.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dedde8de48832ab9c9039cde62c070