### PR TITLE
Add persona registry and trait framework for mob AI

### DIFF
--- a/three-demo/src/entities/ai/__tests__/behavior-schema.test.js
+++ b/three-demo/src/entities/ai/__tests__/behavior-schema.test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateBehaviorDescriptor, TRIGGER_TYPES } from '../behavior-schema.js';
+
+describe('behavior-schema', () => {
+  it('normalizes durations, priorities, and triggers', () => {
+    const descriptor = validateBehaviorDescriptor({
+      name: 'test-loop',
+      loop: 'idle',
+      priority: '5',
+      duration: { min: 1, max: 3, unit: 'seconds' },
+      triggers: [
+        { type: 'time', after: '2' },
+        { type: 'flag', name: 'canBuild' },
+        { type: 'resource', resource: 'stamina', below: 20 },
+      ],
+      options: { wanderChance: 0.5 },
+    });
+
+    assert.strictEqual(descriptor.name, 'test-loop');
+    assert.strictEqual(descriptor.loop, 'idle');
+    assert.strictEqual(descriptor.priority, 5);
+    assert.deepStrictEqual(descriptor.duration, { min: 1, max: 3, unit: 'seconds' });
+    assert.strictEqual(descriptor.triggers.length, 3);
+    assert.ok(Array.from(TRIGGER_TYPES).includes('time'));
+  });
+
+  it('throws when trigger type is unsupported', () => {
+    assert.throws(() => {
+      validateBehaviorDescriptor({
+        name: 'bad-loop',
+        loop: 'idle',
+        triggers: [{ type: 'unknown' }],
+      });
+    });
+  });
+});

--- a/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
+++ b/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
@@ -105,4 +105,50 @@ describe('MobAICore', () => {
       },
     );
   });
+
+  it('loads registered personas and merges runtime overrides', () => {
+    const persona = core.usePersona('spectral-runner', {
+      resources: { stamina: { max: 150 } },
+      traits: [{ name: 'nocturnal', options: { lightThreshold: 0.6 } }],
+      behaviors: [
+        {
+          name: 'spectral-chase',
+          loop: 'chase',
+          priority: 10,
+          duration: { min: 2, max: 4 },
+        },
+        {
+          name: 'custom-wander',
+          loop: 'wander',
+          priority: 2,
+          triggers: [{ type: 'flag', name: 'nocturnalActive', state: true }],
+        },
+      ],
+    });
+
+    assert.strictEqual(persona.name, 'spectral-runner');
+    assert.strictEqual(persona.resources.stamina.max, 150);
+    assert.strictEqual(persona.behaviors.find((behavior) => behavior.name === 'spectral-chase').priority, 10);
+
+    core.initialize({ environment: { lightLevel: 0.3 }, percepts: { allyCount: 0 } });
+    core.attachToEntity({ id: 'entity-4' });
+
+    core.update(1, {
+      environment: { lightLevel: 0.2 },
+      percepts: { allyCount: 3, targetVisible: true },
+    });
+
+    assert.ok(core.context.activeTraits.has('nocturnal'));
+    assert.ok(core.context.activeTraits.has('packHunter'));
+    assert.strictEqual(core.context.resources.stamina.max, 150);
+    assert.ok(core.context.flags.nocturnalActive);
+    assert.ok(core.context.flags.packReady);
+
+    const layerNames = core.scheduler.layers.map((layer) => layer.name);
+    assert.ok(layerNames.includes('spectral-chase'));
+    assert.ok(layerNames.includes('custom-wander'));
+
+    const chaseLayer = core.scheduler.layers.find((layer) => layer.name === 'spectral-chase');
+    assert.strictEqual(chaseLayer.priority, 10);
+  });
 });

--- a/three-demo/src/entities/ai/behavior-schema.js
+++ b/three-demo/src/entities/ai/behavior-schema.js
@@ -1,0 +1,194 @@
+const TRIGGER_TYPES = new Set(['percept', 'time', 'flag', 'resource', 'manual']);
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const toNumber = (value, fallback = 0) => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Expected numeric value but received ${value}.`);
+  }
+  return parsed;
+};
+
+const normalizeDuration = (duration) => {
+  if (duration === undefined || duration === null) {
+    return null;
+  }
+
+  if (typeof duration === 'number') {
+    if (duration < 0) {
+      throw new Error('Behavior duration cannot be negative.');
+    }
+    return {
+      min: duration,
+      max: duration,
+      unit: 'seconds',
+    };
+  }
+
+  if (typeof duration !== 'object') {
+    throw new Error('Behavior duration must be a number or an object.');
+  }
+
+  const min = toNumber(duration.min ?? duration.max ?? 0, 0);
+  const max = toNumber(duration.max ?? duration.min ?? min, min);
+
+  if (min < 0 || max < 0) {
+    throw new Error('Behavior duration cannot include negative bounds.');
+  }
+  if (max < min) {
+    throw new Error('Behavior duration max must be greater than or equal to min.');
+  }
+
+  return {
+    min,
+    max,
+    unit: duration.unit ?? 'seconds',
+  };
+};
+
+const normalizeTrigger = (trigger) => {
+  if (!trigger || typeof trigger !== 'object') {
+    throw new Error('Behavior triggers must be objects.');
+  }
+
+  const type = trigger.type;
+  if (!type || typeof type !== 'string') {
+    throw new Error('Behavior trigger missing its type.');
+  }
+  if (!TRIGGER_TYPES.has(type)) {
+    throw new Error(`Unsupported behavior trigger type "${type}".`);
+  }
+
+  switch (type) {
+    case 'percept': {
+      const key = trigger.key;
+      if (!key || typeof key !== 'string') {
+        throw new Error('Percept triggers require a "key" field.');
+      }
+      return {
+        type,
+        key,
+        equals: trigger.equals,
+        exists: trigger.exists ?? trigger.equals === undefined,
+      };
+    }
+    case 'time': {
+      const after = toNumber(trigger.after ?? trigger.delay ?? 0, 0);
+      if (after < 0) {
+        throw new Error('Time trigger delays must be zero or positive.');
+      }
+      return {
+        type,
+        after,
+      };
+    }
+    case 'flag': {
+      const name = trigger.name ?? trigger.flag;
+      if (!name || typeof name !== 'string') {
+        throw new Error('Flag triggers require a "name" field.');
+      }
+      return {
+        type,
+        name,
+        state: trigger.state ?? true,
+      };
+    }
+    case 'resource': {
+      const resource = trigger.resource;
+      if (!resource || typeof resource !== 'string') {
+        throw new Error('Resource triggers require a "resource" field.');
+      }
+      const threshold = toNumber(trigger.threshold ?? trigger.below ?? trigger.above ?? 0, 0);
+      const comparator = trigger.comparator ?? (trigger.below !== undefined ? 'below' : 'above');
+      if (!['below', 'above'].includes(comparator)) {
+        throw new Error('Resource trigger comparator must be "below" or "above".');
+      }
+      return {
+        type,
+        resource,
+        threshold,
+        comparator,
+      };
+    }
+    case 'manual': {
+      return {
+        type,
+        event: trigger.event ?? null,
+      };
+    }
+    default: {
+      throw new Error(`Unhandled trigger type "${type}".`);
+    }
+  }
+};
+
+const normalizeTriggers = (triggers) => {
+  if (triggers === undefined || triggers === null) {
+    return [];
+  }
+  if (!Array.isArray(triggers)) {
+    throw new Error('Behavior triggers must be provided as an array.');
+  }
+  return triggers.map((trigger) => normalizeTrigger(trigger));
+};
+
+const normalizePriority = (priority) => {
+  if (priority === undefined || priority === null) {
+    return 0;
+  }
+  const value = Number(priority);
+  if (!Number.isFinite(value)) {
+    throw new Error('Behavior priority must be numeric.');
+  }
+  return clamp(value, -Infinity, Infinity);
+};
+
+const normalizeBehaviorDescriptor = (descriptor) => {
+  if (!descriptor || typeof descriptor !== 'object') {
+    throw new Error('Behavior descriptor must be an object.');
+  }
+
+  const loop = descriptor.loop;
+  if (!loop || typeof loop !== 'string') {
+    throw new Error('Behavior descriptor requires a "loop" field.');
+  }
+
+  const name = descriptor.name ?? descriptor.id ?? loop;
+  if (typeof name !== 'string' || name.trim() === '') {
+    throw new Error('Behavior descriptor requires a valid "name".');
+  }
+
+  const priority = normalizePriority(descriptor.priority);
+  const duration = normalizeDuration(descriptor.duration ?? descriptor.timebox);
+  const triggers = normalizeTriggers(descriptor.triggers);
+
+  const options = descriptor.options && typeof descriptor.options === 'object' ? descriptor.options : {};
+  const metadata = descriptor.metadata && typeof descriptor.metadata === 'object' ? descriptor.metadata : {};
+
+  return {
+    name,
+    loop,
+    priority,
+    duration,
+    triggers,
+    options,
+    metadata,
+    tags: Array.isArray(descriptor.tags) ? [...new Set(descriptor.tags.map(String))] : [],
+  };
+};
+
+export const validateBehaviorDescriptor = (descriptor) => normalizeBehaviorDescriptor(descriptor);
+
+export const validateBehaviorSet = (descriptors = []) => {
+  if (!Array.isArray(descriptors)) {
+    throw new Error('Behavior set must be an array of descriptors.');
+  }
+  return descriptors.map((descriptor) => validateBehaviorDescriptor(descriptor));
+};
+
+export { TRIGGER_TYPES };
+export default validateBehaviorDescriptor;

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -1,5 +1,70 @@
 import { EventEmitter } from 'node:events';
 import { BehaviorRegistry } from './behavior-nodes.js';
+import { PersonaRegistry } from './personas/persona-registry.js';
+import { defaultTraits } from './traits/index.js';
+
+const deepClone = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const normalizeTraitDefinition = (name, trait) => {
+  const definition =
+    trait && typeof trait === 'object'
+      ? trait
+      : {
+          name,
+          apply: typeof trait === 'function' ? trait : undefined,
+        };
+  if (!definition.name) {
+    definition.name = name;
+  }
+  if (!definition.name || typeof definition.name !== 'string') {
+    throw new Error('Trait definitions require a name.');
+  }
+  if (typeof definition.apply !== 'function') {
+    throw new Error(`Trait "${definition.name}" must define an apply(core, options) function.`);
+  }
+  return {
+    ...definition,
+  };
+};
+
+const createResourceState = (resources = {}) => {
+  const state = {};
+  for (const [name, config] of Object.entries(resources)) {
+    const hasMax = config.max !== undefined && config.max !== null;
+    const rawMax = hasMax ? Number(config.max) : Number(config.initial ?? 0);
+    const rawInitial = Number(config.initial ?? config.max ?? rawMax ?? 0);
+    const max = Number.isFinite(rawMax) && rawMax >= 0 ? rawMax : 0;
+    const initial = Number.isFinite(rawInitial) && rawInitial >= 0 ? rawInitial : 0;
+    const regen = Number(config.regen ?? 0);
+    const current = hasMax ? Math.min(initial, max) : initial;
+    const maxValue = hasMax ? max : Math.max(max, initial);
+    state[name] = {
+      max: maxValue,
+      current: current,
+      regen: Number.isFinite(regen) ? regen : 0,
+    };
+  }
+  return state;
+};
+
+const mergeSensorPresets = (current = {}, personaSensors = {}) => {
+  const existingPresets = new Set(current.presets ?? []);
+  for (const preset of personaSensors.presets ?? []) {
+    existingPresets.add(preset);
+  }
+  const { presets: _current, ...currentRest } = current;
+  const { presets: _persona, ...personaRest } = personaSensors;
+  return {
+    ...currentRest,
+    ...personaRest,
+    presets: [...existingPresets],
+  };
+};
 
 class BehaviorScheduler {
   constructor() {
@@ -32,6 +97,15 @@ class BehaviorScheduler {
       }
       return b.priority - a.priority;
     });
+  }
+
+  removeLayer(name) {
+    const index = this.layers.findIndex((layer) => layer.name === name);
+    if (index === -1) {
+      return null;
+    }
+    const [removed] = this.layers.splice(index, 1);
+    return removed;
   }
 
   initialize(context) {
@@ -70,6 +144,8 @@ export class MobAICore {
       chunkManager = null,
       audioManager = null,
       behaviorRegistry = new BehaviorRegistry(),
+      personaRegistry = new PersonaRegistry(),
+      traitDefinitions = defaultTraits,
       events,
     } = options;
 
@@ -81,51 +157,159 @@ export class MobAICore {
 
     this.scheduler = new BehaviorScheduler();
     this.behaviorRegistry = behaviorRegistry;
-    this.personas = new Map();
+    this.personaRegistry = personaRegistry;
     this.traits = new Map();
+    this.activeTraitHandles = new Map();
     this.context = null;
     this.currentPersona = null;
     this.initialized = false;
     this.events = events ?? new EventEmitter();
+
+    traitDefinitions.forEach((trait) => {
+      const definition = normalizeTraitDefinition(trait.name ?? trait, trait);
+      if (!this.traits.has(definition.name)) {
+        this.registerTrait(definition.name, definition);
+      }
+    });
   }
 
   registerPersona(name, definition) {
+    if (typeof name === 'object') {
+      return this.personaRegistry.register(name);
+    }
     if (!name) {
       throw new Error('Persona name is required.');
     }
-    this.personas.set(name, { ...definition });
-    return this;
+    return this.personaRegistry.register({ ...definition, name });
   }
 
-  usePersona(name) {
-    const persona = typeof name === 'string' ? this.personas.get(name) : name;
-    if (!persona) {
-      throw new Error(`Unknown persona "${name}".`);
-    }
+  usePersona(reference, overrides = {}) {
+    const persona = this.personaRegistry.create(reference, overrides);
+    const previousPersona = this.currentPersona;
     this.currentPersona = persona;
-    if (this.context) {
-      this.context.persona = persona;
-    }
+    this._applyPersona(persona, { resetResources: true });
+    this.emit('persona:applied', persona, { previous: previousPersona });
     return persona;
   }
 
   registerTrait(name, trait) {
-    if (!name) {
-      throw new Error('Trait name is required.');
-    }
-    this.traits.set(name, trait);
-    if (this.context) {
-      this.context.traits = this.traits;
-    }
+    const definition = normalizeTraitDefinition(name, trait);
+    this.traits.set(definition.name, definition);
+    this._updateTraitContext();
+    this.emit('trait:registered', definition);
     return this;
   }
 
   removeTrait(name) {
-    this.traits.delete(name);
-    if (this.context) {
-      this.context.traits = this.traits;
+    if (this.activeTraitHandles.has(name)) {
+      const handle = this.activeTraitHandles.get(name);
+      handle?.dispose?.();
+      this.activeTraitHandles.delete(name);
     }
+    this.traits.delete(name);
+    this._updateTraitContext();
     return this;
+  }
+
+  _disposeActiveTraits() {
+    for (const handle of this.activeTraitHandles.values()) {
+      handle?.dispose?.();
+    }
+    this.activeTraitHandles.clear();
+  }
+
+  _activateTrait(traitEntry) {
+    const name = typeof traitEntry === 'string' ? traitEntry : traitEntry?.name;
+    if (!name) {
+      throw new Error('Trait entry must include a name.');
+    }
+    const definition = this.traits.get(name);
+    if (!definition) {
+      throw new Error(`Persona requested unknown trait "${name}".`);
+    }
+    const options =
+      typeof traitEntry === 'object' && traitEntry !== null
+        ? deepClone(traitEntry.options ?? {})
+        : {};
+    const handle = definition.apply(this, options, this.currentPersona) ?? null;
+    this.activeTraitHandles.set(name, handle);
+  }
+
+  _applyPersona(persona, { resetResources = false } = {}) {
+    if (!persona) {
+      return;
+    }
+    this._disposeActiveTraits();
+    persona.traits?.forEach((trait) => this._activateTrait(trait));
+    this._updateTraitContext();
+    this._syncPersonaContext(persona, { resetResources });
+    this._installPersonaBehaviors(persona);
+  }
+
+  _syncPersonaContext(persona, { resetResources = false } = {}) {
+    if (!this.context) {
+      return;
+    }
+    this.context.persona = persona;
+    this.context.flags ??= {};
+    this.context.behaviorDescriptors = persona.behaviors
+      ? persona.behaviors.map((behavior) => deepClone(behavior))
+      : [];
+
+    if (!this.context.resources || resetResources) {
+      this.context.resources = createResourceState(persona.resources ?? {});
+    } else {
+      const personaResources = createResourceState(persona.resources ?? {});
+      this.context.resources ??= {};
+      for (const [name, config] of Object.entries(personaResources)) {
+        const existing = this.context.resources[name] ?? { current: config.current };
+        const current = resetResources ? config.current : Math.min(existing.current ?? config.current, config.max);
+        this.context.resources[name] = {
+          max: config.max,
+          regen: config.regen,
+          current,
+        };
+      }
+    }
+
+    this.context.sensors = mergeSensorPresets(this.context.sensors ?? {}, persona.sensors ?? {});
+  }
+
+  _installPersonaBehaviors(persona) {
+    if (!persona.behaviors || persona.behaviors.length === 0) {
+      return;
+    }
+    for (const descriptor of persona.behaviors) {
+      const layerName = descriptor.name ?? descriptor.loop;
+      if (!layerName) {
+        continue;
+      }
+      const existing = this.scheduler.layers.find((layer) => layer.name === layerName);
+      if (existing) {
+        const removed = this.scheduler.removeLayer(layerName);
+        removed?.node?.dispose?.();
+      }
+      const options = {
+        ...(descriptor.options ?? {}),
+        metadata: {
+          ...(descriptor.metadata ?? {}),
+          persona: persona.name,
+          duration: descriptor.duration ?? null,
+          triggers: descriptor.triggers ?? [],
+          tags: descriptor.tags ?? [],
+        },
+      };
+      const loop = this.behaviorRegistry.createLoop(descriptor.loop, options, this.dependencies);
+      this.addBehaviorLayer({ name: layerName, node: loop, priority: descriptor.priority ?? 0 });
+    }
+  }
+
+  _updateTraitContext() {
+    if (!this.context) {
+      return;
+    }
+    this.context.traits = this.traits;
+    this.context.activeTraits = new Set(this.activeTraitHandles.keys());
   }
 
   addBehaviorLayer({ name, node, priority = 0 }) {
@@ -147,14 +331,13 @@ export class MobAICore {
 
   initialize(initialContext = {}) {
     if (this.initialized) {
-      this.context = {
-        ...this.context,
-        ...initialContext,
-      };
+      Object.assign(this.context, initialContext);
       this.context.dependencies = this.dependencies;
-      this.context.traits = this.traits;
+      this.context.flags ??= {};
+      this.context.memory ??= new Map();
+      this._updateTraitContext();
       if (this.currentPersona) {
-        this.context.persona = this.currentPersona;
+        this._syncPersonaContext(this.currentPersona);
       }
       return this.context;
     }
@@ -164,11 +347,14 @@ export class MobAICore {
       delta: 0,
       entity: null,
       memory: new Map(),
+      flags: {},
       ...initialContext,
       dependencies: this.dependencies,
-      traits: this.traits,
-      persona: this.currentPersona,
     };
+    this._updateTraitContext();
+    if (this.currentPersona) {
+      this._syncPersonaContext(this.currentPersona, { resetResources: true });
+    }
     this.scheduler.initialize(this.context);
     this.initialized = true;
     return this.context;
@@ -191,7 +377,9 @@ export class MobAICore {
     Object.assign(this.context, contextUpdates);
     this.context.delta = delta;
     this.context.time += delta;
+    this.emit('beforeUpdate', this.context);
     this.scheduler.tick(delta, this.context);
+    this.emit('afterUpdate', this.context);
   }
 
   on(eventName, listener) {

--- a/three-demo/src/entities/ai/personas/persona-registry.js
+++ b/three-demo/src/entities/ai/personas/persona-registry.js
@@ -1,0 +1,330 @@
+import { validateBehaviorSet } from '../behavior-schema.js';
+import { spectralRunnerPersona } from './spectral-runner.js';
+
+const BUILT_IN_PERSONAS = [spectralRunnerPersona];
+
+const deepClone = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const normalizeTraitList = (traits = []) => {
+  if (!Array.isArray(traits)) {
+    throw new Error('Persona traits must be provided as an array.');
+  }
+
+  return traits.map((entry) => {
+    if (typeof entry === 'string') {
+      return { name: entry, options: {} };
+    }
+    if (!entry || typeof entry !== 'object' || typeof entry.name !== 'string') {
+      throw new Error('Trait entries must specify a "name".');
+    }
+    return {
+      name: entry.name,
+      options: entry.options && typeof entry.options === 'object' ? { ...entry.options } : {},
+    };
+  });
+};
+
+const normalizeSensors = (sensors = {}) => {
+  if (sensors === null) {
+    return { presets: [] };
+  }
+  if (typeof sensors !== 'object') {
+    throw new Error('Persona sensors must be described with an object.');
+  }
+  const presets = Array.isArray(sensors.presets) ? [...new Set(sensors.presets.map(String))] : [];
+  const { presets: _omitted, ...rest } = sensors;
+  return {
+    presets,
+    ...rest,
+  };
+};
+
+const normalizeResourceDefinition = (config) => {
+  if (config === null || config === undefined) {
+    return null;
+  }
+  if (typeof config === 'number') {
+    if (config < 0) {
+      throw new Error('Resource caps cannot be negative.');
+    }
+    return {
+      max: config,
+      initial: config,
+      regen: 0,
+    };
+  }
+  if (typeof config !== 'object') {
+    throw new Error('Resource configuration must be numeric or an object.');
+  }
+  const max = config.max !== undefined ? Number(config.max) : undefined;
+  const initial = config.initial ?? config.current ?? max ?? 0;
+  const regen = config.regen !== undefined ? Number(config.regen) : 0;
+  if (max !== undefined && (!Number.isFinite(max) || max < 0)) {
+    throw new Error('Resource max must be a non-negative finite number when provided.');
+  }
+  if (!Number.isFinite(initial) || initial < 0) {
+    throw new Error('Resource initial value must be a non-negative finite number.');
+  }
+  if (!Number.isFinite(regen)) {
+    throw new Error('Resource regeneration rate must be finite.');
+  }
+  const cappedInitial = max !== undefined ? Math.min(initial, max) : initial;
+  return {
+    max: max ?? cappedInitial,
+    initial: cappedInitial,
+    regen,
+  };
+};
+
+const normalizeResourcePatch = (config) => {
+  if (config === null || config === undefined) {
+    return {};
+  }
+  if (typeof config === 'number') {
+    if (config < 0) {
+      throw new Error('Resource caps cannot be negative.');
+    }
+    return { max: config };
+  }
+  if (typeof config !== 'object') {
+    throw new Error('Resource configuration must be numeric or an object.');
+  }
+  const patch = {};
+  if (config.max !== undefined) {
+    const max = Number(config.max);
+    if (!Number.isFinite(max) || max < 0) {
+      throw new Error('Resource max must be a non-negative finite number when provided.');
+    }
+    patch.max = max;
+  }
+  if (config.initial !== undefined || config.current !== undefined) {
+    const initial = Number(config.initial ?? config.current);
+    if (!Number.isFinite(initial) || initial < 0) {
+      throw new Error('Resource initial value must be a non-negative finite number.');
+    }
+    patch.initial = initial;
+  }
+  if (config.regen !== undefined) {
+    const regen = Number(config.regen);
+    if (!Number.isFinite(regen)) {
+      throw new Error('Resource regeneration rate must be finite.');
+    }
+    patch.regen = regen;
+  }
+  return patch;
+};
+
+const normalizeResources = (resources = {}, { partial = false } = {}) => {
+  if (resources === null) {
+    return {};
+  }
+  if (typeof resources !== 'object') {
+    throw new Error('Persona resources must be described with an object.');
+  }
+  const normalized = {};
+  for (const [name, config] of Object.entries(resources)) {
+    const entry = partial ? normalizeResourcePatch(config) : normalizeResourceDefinition(config);
+    if (entry) {
+      normalized[name] = entry;
+    }
+  }
+  return normalized;
+};
+
+const mergeTraitLists = (base = [], overrides = []) => {
+  const merged = new Map();
+  for (const trait of base) {
+    merged.set(trait.name, {
+      name: trait.name,
+      options: { ...trait.options },
+    });
+  }
+  for (const trait of overrides) {
+    const existing = merged.get(trait.name) ?? { name: trait.name, options: {} };
+    merged.set(trait.name, {
+      name: trait.name,
+      options: { ...existing.options, ...trait.options },
+    });
+  }
+  return Array.from(merged.values());
+};
+
+const mergeSensors = (base = {}, overrides = {}) => {
+  const basePresets = new Set(base.presets ?? []);
+  for (const preset of overrides.presets ?? []) {
+    basePresets.add(preset);
+  }
+  const { presets: _base, ...baseRest } = base;
+  const { presets: _override, ...overrideRest } = overrides;
+  return {
+    ...baseRest,
+    ...overrideRest,
+    presets: [...basePresets],
+  };
+};
+
+const mergeResources = (base = {}, overrides = {}) => {
+  const merged = {};
+  for (const [name, config] of Object.entries(base)) {
+    merged[name] = { ...config };
+  }
+  for (const [name, config] of Object.entries(overrides)) {
+    if (!config || Object.keys(config).length === 0) {
+      continue;
+    }
+    const target = merged[name] ?? { max: 0, initial: 0, regen: 0 };
+    const next = { ...target };
+    if (config.max !== undefined) {
+      next.max = config.max;
+    }
+    if (config.initial !== undefined) {
+      next.initial = config.initial;
+    }
+    if (config.regen !== undefined) {
+      next.regen = config.regen;
+    }
+    if (next.max !== undefined && next.initial !== undefined && next.max < next.initial) {
+      next.initial = next.max;
+    }
+    merged[name] = next;
+  }
+  return merged;
+};
+
+const mergeBehaviors = (base = [], overrides = []) => {
+  const merged = new Map();
+  for (const behavior of base) {
+    merged.set(behavior.name, deepClone(behavior));
+  }
+  for (const behavior of overrides) {
+    merged.set(behavior.name, deepClone(behavior));
+  }
+  return Array.from(merged.values());
+};
+
+const normalizePersona = (persona) => {
+  if (!persona || typeof persona !== 'object') {
+    throw new Error('Persona definition must be an object.');
+  }
+  if (!persona.name || typeof persona.name !== 'string') {
+    throw new Error('Persona definition requires a "name".');
+  }
+
+  const traits = persona.traits ? normalizeTraitList(persona.traits) : [];
+  const sensors = normalizeSensors(persona.sensors ?? {});
+  const resources = normalizeResources(persona.resources ?? {});
+  const behaviors = persona.behaviors ? validateBehaviorSet(persona.behaviors) : [];
+
+  return {
+    name: persona.name,
+    label: persona.label ?? persona.name,
+    description: persona.description ?? '',
+    traits,
+    sensors,
+    resources,
+    behaviors,
+    metadata: persona.metadata && typeof persona.metadata === 'object' ? { ...persona.metadata } : {},
+  };
+};
+
+const normalizePersonaOverrides = (overrides = {}) => {
+  const normalized = {};
+  if (overrides.name) {
+    normalized.name = overrides.name;
+  }
+  if (overrides.label !== undefined) {
+    normalized.label = overrides.label;
+  }
+  if (overrides.description !== undefined) {
+    normalized.description = overrides.description;
+  }
+  if (overrides.metadata !== undefined) {
+    normalized.metadata =
+      overrides.metadata && typeof overrides.metadata === 'object'
+        ? { ...overrides.metadata }
+        : {};
+  }
+  if (overrides.traits !== undefined) {
+    normalized.traits = normalizeTraitList(overrides.traits);
+  }
+  if (overrides.sensors !== undefined) {
+    normalized.sensors = normalizeSensors(overrides.sensors);
+  }
+  if (overrides.resources !== undefined) {
+    normalized.resources = normalizeResources(overrides.resources, { partial: true });
+  }
+  if (overrides.behaviors !== undefined) {
+    normalized.behaviors = validateBehaviorSet(overrides.behaviors);
+  }
+  return normalized;
+};
+
+const mergePersona = (base, overrides = {}) => {
+  const normalizedOverrides = normalizePersonaOverrides(overrides);
+  const traits = mergeTraitLists(base.traits, normalizedOverrides.traits ?? []);
+  const sensors = mergeSensors(base.sensors, normalizedOverrides.sensors ?? {});
+  const resources = mergeResources(base.resources, normalizedOverrides.resources ?? {});
+  const behaviors = mergeBehaviors(base.behaviors, normalizedOverrides.behaviors ?? []);
+
+  return {
+    name: normalizedOverrides.name ?? base.name,
+    label: normalizedOverrides.label ?? base.label,
+    description: normalizedOverrides.description ?? base.description,
+    metadata: normalizedOverrides.metadata ?? { ...base.metadata },
+    traits,
+    sensors,
+    resources,
+    behaviors,
+  };
+};
+
+export class PersonaRegistry {
+  constructor(initialPersonas = BUILT_IN_PERSONAS) {
+    this.personas = new Map();
+    initialPersonas.forEach((persona) => this.register(persona));
+  }
+
+  register(persona) {
+    const normalized = normalizePersona(persona);
+    this.personas.set(normalized.name, normalized);
+    return normalized;
+  }
+
+  has(name) {
+    return this.personas.has(name);
+  }
+
+  get(name) {
+    return this.personas.get(name);
+  }
+
+  list() {
+    return Array.from(this.personas.values(), (persona) => deepClone(persona));
+  }
+
+  create(reference, overrides = {}) {
+    if (typeof reference === 'string') {
+      const base = this.get(reference);
+      if (!base) {
+        throw new Error(`Unknown persona "${reference}".`);
+      }
+      return mergePersona(deepClone(base), overrides);
+    }
+
+    if (reference && typeof reference === 'object') {
+      if (reference.name && this.has(reference.name)) {
+        return mergePersona(deepClone(this.get(reference.name)), { ...reference, ...overrides });
+      }
+      return normalizePersona({ ...reference, ...overrides });
+    }
+
+    throw new Error('Persona reference must be a string name or object definition.');
+  }
+}
+
+export const defaultPersonas = BUILT_IN_PERSONAS.map((persona) => normalizePersona(persona));

--- a/three-demo/src/entities/ai/personas/spectral-runner.js
+++ b/three-demo/src/entities/ai/personas/spectral-runner.js
@@ -1,0 +1,54 @@
+export const spectralRunnerPersona = {
+  name: 'spectral-runner',
+  label: 'Spectral Runner',
+  description: 'An ethereal scout that thrives in low light and coordinates with its pack.',
+  traits: [
+    { name: 'nocturnal', options: { lightThreshold: 0.45 } },
+    { name: 'packHunter', options: { minAllies: 1, formation: 'pincer' } },
+    { name: 'builder', options: { resource: 'ectoplasm', reserve: 20 } },
+  ],
+  sensors: {
+    presets: ['spectral-vision', 'echo-location'],
+    visionRange: 75,
+    hearingRange: 110,
+  },
+  resources: {
+    stamina: { max: 120, regen: 6, initial: 120 },
+    ectoplasm: { max: 90, regen: 4, initial: 60 },
+  },
+  behaviors: [
+    {
+      name: 'spectral-scouting',
+      loop: 'idle',
+      priority: 4,
+      duration: { min: 3, max: 7, unit: 'seconds' },
+      triggers: [
+        { type: 'time', after: 1.5 },
+        { type: 'percept', key: 'threatLevel', equals: 'low' },
+      ],
+      options: {
+        wanderChance: 0.4,
+        idleChance: 0.1,
+      },
+      metadata: {
+        role: 'scout',
+      },
+    },
+    {
+      name: 'spectral-chase',
+      loop: 'chase',
+      priority: 8,
+      duration: { min: 5, max: 12, unit: 'seconds' },
+      triggers: [{ type: 'percept', key: 'targetVisible', equals: true }],
+      options: {
+        wanderChance: 0,
+        idleChance: 0.05,
+      },
+      metadata: {
+        role: 'hunter',
+      },
+    },
+  ],
+};
+
+export default spectralRunnerPersona;

--- a/three-demo/src/entities/ai/traits/builder.js
+++ b/three-demo/src/entities/ai/traits/builder.js
@@ -1,0 +1,33 @@
+export const builderTrait = {
+  name: 'builder',
+  description: 'Encourages structure crafting by monitoring resource reserves and setting build flags.',
+  apply(core, options = {}) {
+    const resourceName = options.resource ?? 'construction';
+    const reserve = Math.max(options.reserve ?? 0, 0);
+
+    const afterUpdate = (context) => {
+      context.resources ??= {};
+      const resource = context.resources[resourceName];
+      if (!resource) {
+        return;
+      }
+      const available = Number(resource.current ?? resource.initial ?? resource.max ?? 0);
+      const cap = Number(resource.max ?? available);
+      const ready = available > reserve && cap > 0;
+      context.flags ??= {};
+      context.flags.canBuild = ready;
+      context.flags.buildReserve = reserve;
+      context.flags.buildResource = resourceName;
+    };
+
+    core.on('afterUpdate', afterUpdate);
+
+    return {
+      dispose() {
+        core.off('afterUpdate', afterUpdate);
+      },
+    };
+  },
+};
+
+export default builderTrait;

--- a/three-demo/src/entities/ai/traits/index.js
+++ b/three-demo/src/entities/ai/traits/index.js
@@ -1,0 +1,11 @@
+import { nocturnalTrait } from './nocturnal.js';
+import { packHunterTrait } from './pack-hunter.js';
+import { builderTrait } from './builder.js';
+
+export const defaultTraits = [nocturnalTrait, packHunterTrait, builderTrait];
+
+export { nocturnalTrait };
+export { packHunterTrait };
+export { builderTrait };
+
+export default defaultTraits;

--- a/three-demo/src/entities/ai/traits/nocturnal.js
+++ b/three-demo/src/entities/ai/traits/nocturnal.js
@@ -1,0 +1,30 @@
+export const nocturnalTrait = {
+  name: 'nocturnal',
+  description: 'Boosts activity and perception while ambient light is low.',
+  apply(core, options = {}) {
+    const threshold = Math.min(Math.max(options.lightThreshold ?? 0.4, 0), 1);
+    const wanderBonus = options.wanderBonus ?? 0.2;
+
+    const beforeUpdate = (context) => {
+      const lightLevel = context.environment?.lightLevel ?? context.timeOfDay ?? 0.5;
+      const isNight = Number(lightLevel) <= threshold;
+      context.flags ??= {};
+      context.flags.nocturnalActive = isNight;
+      if (isNight) {
+        context.flags.wanderBias = (context.flags.wanderBias ?? 0) + wanderBonus;
+      } else {
+        context.flags.wanderBias = Math.max((context.flags.wanderBias ?? 0) - wanderBonus, 0);
+      }
+    };
+
+    core.on('beforeUpdate', beforeUpdate);
+
+    return {
+      dispose() {
+        core.off('beforeUpdate', beforeUpdate);
+      },
+    };
+  },
+};
+
+export default nocturnalTrait;

--- a/three-demo/src/entities/ai/traits/pack-hunter.js
+++ b/three-demo/src/entities/ai/traits/pack-hunter.js
@@ -1,0 +1,31 @@
+export const packHunterTrait = {
+  name: 'packHunter',
+  description: 'Coordinates tactics with nearby allies and boosts aggression when the pack is assembled.',
+  apply(core, options = {}) {
+    const minAllies = Math.max(options.minAllies ?? 2, 0);
+    const formation = options.formation ?? 'encircle';
+
+    const afterUpdate = (context) => {
+      const allies = Number(context.percepts?.allyCount ?? 0);
+      const hasPack = allies >= minAllies;
+      context.flags ??= {};
+      context.flags.packPresence = allies;
+      context.flags.packReady = hasPack;
+      if (hasPack) {
+        context.tactics ??= {};
+        context.tactics.formation = formation;
+        context.tactics.preferredTarget = context.percepts?.targetId ?? null;
+      }
+    };
+
+    core.on('afterUpdate', afterUpdate);
+
+    return {
+      dispose() {
+        core.off('afterUpdate', afterUpdate);
+      },
+    };
+  },
+};
+
+export default packHunterTrait;


### PR DESCRIPTION
## Summary
- add validation utilities for AI behavior descriptors and cover them with unit tests
- introduce a persona registry with a spectral-runner sample persona plus reusable trait modules
- wire MobAICore to load personas, activate traits, and merge overrides with accompanying tests

## Testing
- npm test *(fails: CrownedGhostRunnerEntity alternates between idle and walk states with animation swaps)*
- node --test three-demo/src/entities/ai/__tests__/mob-ai-core.test.js


------
https://chatgpt.com/codex/tasks/task_e_68dee8973e00832aaf06f7044b4eda58