### PR TITLE
Add AI resource and tactical systems with supporting tests

### DIFF
--- a/three-demo/src/entities/ai/__tests__/resource-pool.test.js
+++ b/three-demo/src/entities/ai/__tests__/resource-pool.test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ResourcePool } from '../resources/resource-pool.js';
+
+describe('ResourcePool', () => {
+  it('regenerates resources and enforces caps', () => {
+    const pool = new ResourcePool({
+      stamina: { max: 10, current: 4, regen: 5 },
+    });
+
+    pool.tick(1);
+    assert.strictEqual(pool.getCurrent('stamina'), 9);
+    pool.tick(1);
+    assert.strictEqual(pool.getCurrent('stamina'), 10);
+
+    // Should not exceed cap even if regen would push beyond max.
+    pool.tick(10);
+    assert.strictEqual(pool.getCurrent('stamina'), 10);
+  });
+
+  it('supports consumption, partial spending, and depletion events', () => {
+    const pool = new ResourcePool({ mana: { max: 12, current: 12, regen: 0 } });
+    let depleted = 0;
+    let changeEvents = 0;
+    pool.events.on('resource:depleted', (entry) => {
+      if (entry.name === 'mana') {
+        depleted += 1;
+      }
+    });
+    pool.events.on('resource:changed', (entry) => {
+      if (entry.name === 'mana') {
+        changeEvents += 1;
+      }
+    });
+
+    const firstSpend = pool.consume('mana', 3);
+    assert.strictEqual(firstSpend, 3);
+    assert.strictEqual(pool.getCurrent('mana'), 9);
+
+    const secondSpend = pool.consume('mana', 20, { allowPartial: true });
+    assert.strictEqual(secondSpend, 9);
+    assert.strictEqual(pool.getCurrent('mana'), 0);
+    assert.strictEqual(depleted, 1);
+    assert.ok(changeEvents >= 2);
+  });
+});

--- a/three-demo/src/entities/ai/__tests__/status-effect-manager.test.js
+++ b/three-demo/src/entities/ai/__tests__/status-effect-manager.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { StatusEffectManager } from '../resources/status-effect-manager.js';
+
+describe('StatusEffectManager', () => {
+  it('expires timed effects and fires callbacks', () => {
+    const manager = new StatusEffectManager();
+    let expiredCount = 0;
+    manager.events.on('effect:expired', (effect, detail) => {
+      if (effect.id === 'burn') {
+        expiredCount += 1;
+        assert.strictEqual(detail.reason, 'expired');
+      }
+    });
+
+    let applied = false;
+    manager.apply({
+      id: 'burn',
+      duration: 3,
+      onApply: () => {
+        applied = true;
+      },
+    });
+    assert.ok(manager.has('burn'));
+    assert.ok(applied);
+
+    manager.update(1);
+    manager.update(1);
+    assert.ok(manager.has('burn'));
+    const expired = manager.update(1);
+    assert.deepStrictEqual(expired, ['burn']);
+    assert.strictEqual(manager.has('burn'), false);
+    assert.strictEqual(expiredCount, 1);
+  });
+
+  it('stacks effects respecting caps and refresh rules', () => {
+    const manager = new StatusEffectManager();
+    let stackEvents = 0;
+    manager.events.on('effect:stacked', () => {
+      stackEvents += 1;
+    });
+
+    manager.apply({ id: 'fury', duration: 5, stacking: 'stack', maxStacks: 2 });
+    const afterFirst = manager.get('fury');
+    assert.strictEqual(afterFirst.stacks, 1);
+    assert.strictEqual(afterFirst.remaining, 5);
+
+    manager.update(2);
+    manager.apply({ id: 'fury', duration: 5, stacking: 'stack', maxStacks: 2 });
+    const afterSecond = manager.get('fury');
+    assert.strictEqual(afterSecond.stacks, 2);
+    assert.ok(afterSecond.remaining <= 5 && afterSecond.remaining > 0);
+    assert.ok(stackEvents >= 1);
+  });
+});

--- a/three-demo/src/entities/ai/__tests__/tactical-point-engine.test.js
+++ b/three-demo/src/entities/ai/__tests__/tactical-point-engine.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { TacticalPointEngine } from '../combat/tactical-point-engine.js';
+
+describe('TacticalPointEngine', () => {
+  it('validates ability costs and spending', () => {
+    const engine = new TacticalPointEngine({ maxPoints: 20, initialPoints: 10 });
+    engine.registerAbility('dash', { cost: 8 });
+    engine.registerAbility('blink', { cost: 5 });
+
+    assert.ok(engine.canUseAbility('dash'));
+    let spentEvent = null;
+    engine.events.on('ability:spent', (payload) => {
+      spentEvent = payload;
+    });
+
+    assert.strictEqual(engine.spendForAbility('dash'), true);
+    assert.strictEqual(engine.points, 2);
+    assert.ok(spentEvent);
+    assert.strictEqual(spentEvent.ability.name, 'dash');
+
+    assert.strictEqual(engine.spendForAbility('dash'), false);
+    assert.strictEqual(engine.points, 2);
+
+    assert.throws(() => engine.registerAbility('bad', { cost: -1 }));
+  });
+
+  it('accrues points over time and triggers behaviors', () => {
+    const engine = new TacticalPointEngine({
+      maxPoints: 30,
+      initialPoints: 2,
+      accrualRules: [{ id: 'passive', rate: 2 }],
+    });
+    engine.registerAbility('strike', 6);
+
+    let triggered = 0;
+    engine.addTrigger(
+      'threshold-10',
+      ({ current, previous }) => previous < 10 && current >= 10,
+      {
+        once: true,
+        callback: () => {
+          triggered += 1;
+        },
+      },
+    );
+    engine.events.on('trigger:threshold-10', () => {
+      triggered += 1;
+    });
+
+    engine.update(4); // +8 points -> 10 total
+    assert.strictEqual(engine.points, 10);
+    assert.ok(triggered >= 1);
+    assert.ok(engine.canUseAbility('strike'));
+
+    const spent = engine.spendForAbility('strike');
+    assert.ok(spent);
+    assert.strictEqual(engine.points, 4);
+  });
+});

--- a/three-demo/src/entities/ai/combat/tactical-point-engine.js
+++ b/three-demo/src/entities/ai/combat/tactical-point-engine.js
@@ -1,0 +1,236 @@
+import { EventEmitter } from 'node:events';
+
+const isFiniteNumber = (value) => Number.isFinite(value);
+
+const clamp = (value, min, max = Infinity) => {
+  if (max === Infinity) {
+    return Math.max(value, min);
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const normalizeAccrualRule = (rule) => {
+  if (!rule || typeof rule !== 'object') {
+    throw new Error('Accrual rules must be objects.');
+  }
+  const id = rule.id ?? `rule-${Math.random().toString(36).slice(2)}`;
+  const rate = Number(rule.rate ?? rule.amountPerSecond ?? 0);
+  if (!Number.isFinite(rate)) {
+    throw new Error('Accrual rule rate must be a finite number.');
+  }
+  const limit = rule.limit ?? rule.cap ?? Infinity;
+  const normalizedLimit = limit === Infinity ? Infinity : Number(limit);
+  if (normalizedLimit !== Infinity && (!Number.isFinite(normalizedLimit) || normalizedLimit < 0)) {
+    throw new Error('Accrual rule limit must be a non-negative finite number or Infinity.');
+  }
+  return {
+    id,
+    rate,
+    limit: normalizedLimit,
+    condition: typeof rule.condition === 'function' ? rule.condition : null,
+    payload: rule,
+  };
+};
+
+const normalizeAbilityConfig = (name, config) => {
+  const definition = typeof config === 'number' ? { cost: config } : config ?? {};
+  const cost = Number(definition.cost ?? definition.points ?? 0);
+  if (!isFiniteNumber(cost) || cost < 0) {
+    throw new Error(`Ability "${name}" cost must be a non-negative finite number.`);
+  }
+  return {
+    name,
+    cost,
+    min: Number.isFinite(definition.min) ? Math.max(0, Number(definition.min)) : cost,
+    onSpend: typeof definition.onSpend === 'function' ? definition.onSpend : undefined,
+    metadata: definition.metadata,
+  };
+};
+
+export class TacticalPointEngine {
+  constructor(options = {}) {
+    const {
+      maxPoints = Infinity,
+      initialPoints = 0,
+      accrualRules = [],
+      events,
+    } = options;
+
+    const normalizedMax = maxPoints === Infinity ? Infinity : Number(maxPoints);
+    if (normalizedMax !== Infinity && (!Number.isFinite(normalizedMax) || normalizedMax < 0)) {
+      throw new Error('Tactical point maximum must be a non-negative finite number or Infinity.');
+    }
+
+    const initial = Number(initialPoints);
+    if (!isFiniteNumber(initial) || initial < 0) {
+      throw new Error('Initial tactical points must be a non-negative finite number.');
+    }
+
+    this.maxPoints = normalizedMax;
+    this.points = clamp(initial, 0, this.maxPoints);
+    this.events = events ?? new EventEmitter();
+    this.accrualRules = new Map();
+    this.abilities = new Map();
+    this.triggers = new Map();
+
+    accrualRules.forEach((rule) => {
+      const normalized = normalizeAccrualRule(rule);
+      this.accrualRules.set(normalized.id, normalized);
+    });
+  }
+
+  addAccrualRule(rule) {
+    const normalized = normalizeAccrualRule(rule);
+    this.accrualRules.set(normalized.id, normalized);
+    this.events.emit('accrual:added', normalized);
+    return normalized.id;
+  }
+
+  removeAccrualRule(id) {
+    if (!this.accrualRules.has(id)) {
+      return false;
+    }
+    const rule = this.accrualRules.get(id);
+    this.accrualRules.delete(id);
+    this.events.emit('accrual:removed', rule);
+    return true;
+  }
+
+  registerAbility(name, config) {
+    if (!name || typeof name !== 'string') {
+      throw new Error('Ability names must be non-empty strings.');
+    }
+    const definition = normalizeAbilityConfig(name, config);
+    this.abilities.set(name, definition);
+    this.events.emit('ability:registered', definition);
+    return definition;
+  }
+
+  unregisterAbility(name) {
+    if (!this.abilities.has(name)) {
+      return false;
+    }
+    const ability = this.abilities.get(name);
+    this.abilities.delete(name);
+    this.events.emit('ability:unregistered', ability);
+    return true;
+  }
+
+  canUseAbility(name) {
+    const ability = this.abilities.get(name);
+    if (!ability) {
+      throw new Error(`Ability "${name}" is not registered.`);
+    }
+    return this.points >= ability.cost && this.points >= ability.min;
+  }
+
+  spendForAbility(name, { context } = {}) {
+    const ability = this.abilities.get(name);
+    if (!ability) {
+      throw new Error(`Ability "${name}" is not registered.`);
+    }
+    if (!this.canUseAbility(name)) {
+      return false;
+    }
+    const previous = this.points;
+    this.points = clamp(this.points - ability.cost, 0, this.maxPoints);
+    ability.onSpend?.({ ability, engine: this, context });
+    this.events.emit('ability:spent', { ability, cost: ability.cost, previous, current: this.points, context });
+    this.events.emit('points:changed', { previous, current: this.points, reason: 'ability', context });
+    this._evaluateTriggers(previous, context);
+    return true;
+  }
+
+  addPoints(amount, { reason = 'gain', context } = {}) {
+    const normalized = Number(amount);
+    if (!isFiniteNumber(normalized)) {
+      throw new Error('Point adjustments must be finite numbers.');
+    }
+    if (normalized === 0) {
+      return this.points;
+    }
+    const previous = this.points;
+    this.points = clamp(this.points + normalized, 0, this.maxPoints);
+    this.events.emit('points:changed', { previous, current: this.points, reason, context, delta: this.points - previous });
+    this._evaluateTriggers(previous, context);
+    return this.points;
+  }
+
+  setPoints(value, { reason = 'set', context } = {}) {
+    const normalized = Number(value);
+    if (!isFiniteNumber(normalized) || normalized < 0) {
+      throw new Error('Tactical points must be a non-negative finite number.');
+    }
+    const previous = this.points;
+    this.points = clamp(normalized, 0, this.maxPoints);
+    this.events.emit('points:changed', { previous, current: this.points, reason, context, delta: this.points - previous });
+    this._evaluateTriggers(previous, context);
+    return this.points;
+  }
+
+  update(deltaSeconds, { context } = {}) {
+    if (!isFiniteNumber(deltaSeconds) || deltaSeconds <= 0) {
+      return this.points;
+    }
+    let totalDelta = 0;
+    for (const rule of this.accrualRules.values()) {
+      if (rule.condition && !rule.condition({ engine: this, context, delta: deltaSeconds, rule })) {
+        continue;
+      }
+      const proposed = rule.rate * deltaSeconds;
+      if (proposed === 0) {
+        continue;
+      }
+      if (rule.rate > 0 && this.points >= rule.limit && rule.limit !== Infinity) {
+        continue;
+      }
+      totalDelta += proposed;
+    }
+    if (totalDelta !== 0) {
+      this.addPoints(totalDelta, { reason: 'accrual', context });
+    }
+    return this.points;
+  }
+
+  addTrigger(name, condition, { once = false, callback } = {}) {
+    if (!name || typeof name !== 'string') {
+      throw new Error('Trigger names must be non-empty strings.');
+    }
+    if (typeof condition !== 'function') {
+      throw new Error('Trigger conditions must be functions.');
+    }
+    this.triggers.set(name, { name, condition, once, callback, fired: false });
+    return name;
+  }
+
+  removeTrigger(name) {
+    return this.triggers.delete(name);
+  }
+
+  _evaluateTriggers(previous, context) {
+    for (const trigger of this.triggers.values()) {
+      if (trigger.once && trigger.fired) {
+        continue;
+      }
+      const shouldFire = trigger.condition({
+        current: this.points,
+        previous,
+        context,
+        engine: this,
+      });
+      if (!shouldFire) {
+        continue;
+      }
+      trigger.fired = true;
+      trigger.callback?.({ engine: this, current: this.points, previous, context });
+      this.events.emit(`trigger:${trigger.name}`, {
+        name: trigger.name,
+        current: this.points,
+        previous,
+        context,
+      });
+    }
+  }
+}
+
+export default TacticalPointEngine;

--- a/three-demo/src/entities/ai/resources/resource-pool.js
+++ b/three-demo/src/entities/ai/resources/resource-pool.js
@@ -1,0 +1,254 @@
+import { EventEmitter } from 'node:events';
+
+const clamp = (value, min, max = Number.POSITIVE_INFINITY) => {
+  if (Number.isFinite(max)) {
+    return Math.min(Math.max(value, min), max);
+  }
+  return Math.max(value, min);
+};
+
+const isFiniteNumber = (value) => Number.isFinite(value);
+
+const normalizeResourceConfig = (name, config = {}) => {
+  if (typeof config === 'number') {
+    if (!Number.isFinite(config) || config < 0) {
+      throw new Error(`Resource "${name}" numeric configuration must be a non-negative finite number.`);
+    }
+    return {
+      name,
+      max: config,
+      current: config,
+      regen: 0,
+      metadata: undefined,
+    };
+  }
+
+  const { max, current, initial, regen, metadata } = config;
+
+  const hasExplicitMax = max !== undefined && max !== null;
+  const normalizedMax = hasExplicitMax ? Number(max) : undefined;
+  if (hasExplicitMax && (!Number.isFinite(normalizedMax) || normalizedMax < 0)) {
+    throw new Error(`Resource "${name}" max must be a non-negative finite number when provided.`);
+  }
+
+  const sourceInitial = current ?? initial ?? normalizedMax ?? 0;
+  const normalizedInitial = Number(sourceInitial);
+  if (!Number.isFinite(normalizedInitial) || normalizedInitial < 0) {
+    throw new Error(`Resource "${name}" initial value must be a non-negative finite number.`);
+  }
+
+  const normalizedRegen = Number(regen ?? 0);
+  if (!Number.isFinite(normalizedRegen)) {
+    throw new Error(`Resource "${name}" regeneration rate must be a finite number.`);
+  }
+
+  const entryMax = hasExplicitMax ? normalizedMax : undefined;
+  const entryCurrent = hasExplicitMax
+    ? clamp(normalizedInitial, 0, entryMax)
+    : Math.max(normalizedInitial, 0);
+
+  return {
+    name,
+    max: entryMax,
+    current: entryCurrent,
+    regen: normalizedRegen,
+    metadata,
+  };
+};
+
+export class ResourcePool {
+  constructor(definitions = {}, { events } = {}) {
+    this.resources = new Map();
+    this.events = events ?? new EventEmitter();
+
+    for (const [name, config] of Object.entries(definitions)) {
+      this.defineResource(name, config);
+    }
+  }
+
+  defineResource(name, config = {}) {
+    if (!name || typeof name !== 'string') {
+      throw new Error('Resource names must be non-empty strings.');
+    }
+
+    const normalized = normalizeResourceConfig(name, config);
+    const previous = this.resources.get(name);
+    const entry = {
+      name,
+      max: normalized.max,
+      current: normalized.current,
+      regen: normalized.regen,
+      metadata: normalized.metadata,
+    };
+    this.resources.set(name, entry);
+
+    if (previous) {
+      this.events.emit('resource:updated', entry, { previous });
+    } else {
+      this.events.emit('resource:created', entry);
+    }
+
+    return entry;
+  }
+
+  has(name) {
+    return this.resources.has(name);
+  }
+
+  get(name) {
+    return this.resources.get(name) ?? null;
+  }
+
+  getCurrent(name) {
+    return this.get(name)?.current ?? null;
+  }
+
+  tick(deltaSeconds, { reason = 'regen', context } = {}) {
+    if (!isFiniteNumber(deltaSeconds) || deltaSeconds <= 0) {
+      return;
+    }
+
+    for (const entry of this.resources.values()) {
+      if (!entry || entry.regen === 0) {
+        continue;
+      }
+      if (entry.max !== undefined && entry.current >= entry.max && entry.regen > 0) {
+        continue;
+      }
+      const previous = entry.current;
+      const delta = entry.regen * deltaSeconds;
+      const next = entry.max !== undefined ? clamp(previous + delta, 0, entry.max) : Math.max(previous + delta, 0);
+      if (next === previous) {
+        continue;
+      }
+      entry.current = next;
+      this.events.emit('resource:changed', entry, {
+        previous,
+        delta: next - previous,
+        reason,
+        context,
+      });
+    }
+  }
+
+  consume(name, amount, { allowPartial = false, reason = 'consume', context } = {}) {
+    const entry = this.get(name);
+    if (!entry) {
+      throw new Error(`Resource "${name}" is not defined.`);
+    }
+    const normalizedAmount = Number(amount);
+    if (!isFiniteNumber(normalizedAmount) || normalizedAmount <= 0) {
+      throw new Error('Resource consumption amount must be a positive, finite number.');
+    }
+
+    const available = entry.current;
+    if (!allowPartial && available < normalizedAmount) {
+      return 0;
+    }
+
+    const spent = allowPartial ? Math.min(available, normalizedAmount) : normalizedAmount;
+    if (spent === 0) {
+      return 0;
+    }
+
+    const previous = entry.current;
+    entry.current = Math.max(entry.current - spent, 0);
+    this.events.emit('resource:changed', entry, {
+      previous,
+      delta: entry.current - previous,
+      reason,
+      context,
+    });
+
+    if (entry.current === 0 && previous > 0) {
+      this.events.emit('resource:depleted', entry, { spent, reason, context });
+    }
+
+    return spent;
+  }
+
+  restore(name, amount, { reason = 'restore', context } = {}) {
+    const entry = this.get(name);
+    if (!entry) {
+      throw new Error(`Resource "${name}" is not defined.`);
+    }
+
+    const normalizedAmount = Number(amount);
+    if (!isFiniteNumber(normalizedAmount) || normalizedAmount <= 0) {
+      throw new Error('Resource restoration amount must be a positive, finite number.');
+    }
+
+    const previous = entry.current;
+    const max = entry.max;
+    const next = max !== undefined ? clamp(previous + normalizedAmount, 0, max) : Math.max(previous + normalizedAmount, 0);
+    if (next === previous) {
+      return 0;
+    }
+
+    entry.current = next;
+    this.events.emit('resource:changed', entry, {
+      previous,
+      delta: entry.current - previous,
+      reason,
+      context,
+    });
+
+    return entry.current - previous;
+  }
+
+  setCurrent(name, value, { reason = 'set', context } = {}) {
+    const entry = this.get(name);
+    if (!entry) {
+      throw new Error(`Resource "${name}" is not defined.`);
+    }
+    const normalizedValue = Number(value);
+    if (!isFiniteNumber(normalizedValue) || normalizedValue < 0) {
+      throw new Error('Resource value must be a non-negative finite number.');
+    }
+
+    const previous = entry.current;
+    const next = entry.max !== undefined ? clamp(normalizedValue, 0, entry.max) : normalizedValue;
+    if (next === previous) {
+      return entry.current;
+    }
+
+    entry.current = next;
+    this.events.emit('resource:changed', entry, {
+      previous,
+      delta: entry.current - previous,
+      reason,
+      context,
+    });
+
+    if (entry.current === 0 && previous > 0) {
+      this.events.emit('resource:depleted', entry, { reason, context });
+    }
+
+    return entry.current;
+  }
+
+  remove(name) {
+    const entry = this.get(name);
+    if (!entry) {
+      return false;
+    }
+    this.resources.delete(name);
+    this.events.emit('resource:removed', entry);
+    return true;
+  }
+
+  snapshot() {
+    const result = {};
+    for (const [name, entry] of this.resources.entries()) {
+      result[name] = {
+        max: entry.max,
+        current: entry.current,
+        regen: entry.regen,
+        metadata: entry.metadata,
+      };
+    }
+    return result;
+  }
+}
+
+export default ResourcePool;

--- a/three-demo/src/entities/ai/resources/status-effect-manager.js
+++ b/three-demo/src/entities/ai/resources/status-effect-manager.js
@@ -1,0 +1,184 @@
+import { EventEmitter } from 'node:events';
+
+const STACKING_BEHAVIORS = new Set(['refresh', 'replace', 'stack', 'ignore']);
+
+const normalizeEffectConfig = (effect) => {
+  if (!effect || typeof effect !== 'object') {
+    throw new Error('Status effects must be provided as objects.');
+  }
+
+  const id = effect.id ?? effect.name;
+  if (!id || typeof id !== 'string') {
+    throw new Error('Status effects require a string "id" or "name".');
+  }
+
+  const rawDuration = effect.duration ?? effect.time ?? 0;
+  const duration = rawDuration === Infinity ? Infinity : Number(rawDuration);
+  if (duration !== Infinity && (!Number.isFinite(duration) || duration < 0)) {
+    throw new Error(`Status effect "${id}" duration must be a non-negative finite number or Infinity.`);
+  }
+
+  const stacking = effect.stacking ?? effect.stackingBehavior ?? 'refresh';
+  if (!STACKING_BEHAVIORS.has(stacking)) {
+    throw new Error(
+      `Status effect "${id}" has unsupported stacking behavior "${stacking}". Supported behaviors: ${[...STACKING_BEHAVIORS].join(', ')}.`,
+    );
+  }
+
+  const stacks = Number(effect.stacks ?? effect.stackCount ?? 1);
+  if (!Number.isFinite(stacks) || stacks <= 0) {
+    throw new Error(`Status effect "${id}" stack count must be a positive finite number.`);
+  }
+
+  const maxStacksRaw = effect.maxStacks ?? effect.stackLimit ?? Infinity;
+  const maxStacks = maxStacksRaw === Infinity ? Infinity : Number(maxStacksRaw);
+  if (maxStacks !== Infinity && (!Number.isFinite(maxStacks) || maxStacks <= 0)) {
+    throw new Error(`Status effect "${id}" max stacks must be a positive finite number or Infinity.`);
+  }
+
+  return {
+    id,
+    label: effect.label ?? effect.title ?? id,
+    duration,
+    remaining: duration,
+    stacking,
+    stacks,
+    maxStacks,
+    refreshOnStack: effect.refreshOnStack ?? true,
+    data: effect.data ?? {},
+    source: effect.source,
+    onApply: typeof effect.onApply === 'function' ? effect.onApply : undefined,
+    onExpire: typeof effect.onExpire === 'function' ? effect.onExpire : undefined,
+    onStack: typeof effect.onStack === 'function' ? effect.onStack : undefined,
+    onUpdate: typeof effect.onUpdate === 'function' ? effect.onUpdate : undefined,
+  };
+};
+
+export class StatusEffectManager {
+  constructor({ events } = {}) {
+    this.events = events ?? new EventEmitter();
+    this.effects = new Map();
+  }
+
+  apply(effectConfig, { context } = {}) {
+    const effect = normalizeEffectConfig(effectConfig);
+    const existing = this.effects.get(effect.id);
+
+    if (!existing) {
+      this.effects.set(effect.id, effect);
+      effect.onApply?.(effect, { context, manager: this });
+      this.events.emit('effect:applied', effect, { context });
+      return effect;
+    }
+
+    switch (effect.stacking) {
+      case 'ignore':
+        return existing;
+      case 'replace': {
+        this._expireEffect(existing, { reason: 'replaced', context, replacement: effect });
+        this.effects.set(effect.id, effect);
+        effect.onApply?.(effect, { context, manager: this });
+        this.events.emit('effect:applied', effect, { context, replaced: existing });
+        return effect;
+      }
+      case 'refresh': {
+        existing.remaining = effect.duration;
+        existing.data = { ...existing.data, ...effect.data };
+        existing.source = effect.source ?? existing.source;
+        existing.onUpdate = effect.onUpdate ?? existing.onUpdate;
+        existing.onExpire = effect.onExpire ?? existing.onExpire;
+        existing.onApply = effect.onApply ?? existing.onApply;
+        existing.onStack = effect.onStack ?? existing.onStack;
+        this.events.emit('effect:refreshed', existing, { context });
+        return existing;
+      }
+      case 'stack': {
+        const previousStacks = existing.stacks;
+        const total = Math.min(existing.stacks + effect.stacks, existing.maxStacks);
+        existing.stacks = total;
+        if (effect.refreshOnStack !== false && effect.duration !== Infinity) {
+          existing.remaining = effect.duration;
+        }
+        existing.data = { ...existing.data, ...effect.data };
+        existing.source = effect.source ?? existing.source;
+        if (total !== previousStacks) {
+          existing.onStack?.(existing, { previous: previousStacks, context, manager: this });
+          this.events.emit('effect:stacked', existing, { previous: previousStacks, context });
+        } else {
+          this.events.emit('effect:stacked', existing, { previous: previousStacks, context, capped: true });
+        }
+        return existing;
+      }
+      default:
+        return existing;
+    }
+  }
+
+  has(id) {
+    return this.effects.has(id);
+  }
+
+  get(id) {
+    return this.effects.get(id) ?? null;
+  }
+
+  remove(id, { reason = 'removed', context } = {}) {
+    const effect = this.effects.get(id);
+    if (!effect) {
+      return false;
+    }
+    this._expireEffect(effect, { reason, context });
+    return true;
+  }
+
+  update(deltaSeconds, { context } = {}) {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+      return [];
+    }
+
+    const expired = [];
+    for (const effect of [...this.effects.values()]) {
+      if (effect.duration === Infinity) {
+        effect.onUpdate?.(effect, { delta: deltaSeconds, context, manager: this });
+        continue;
+      }
+      effect.remaining = Math.max(effect.remaining - deltaSeconds, 0);
+      effect.onUpdate?.(effect, { delta: deltaSeconds, context, manager: this });
+      if (effect.remaining === 0) {
+        expired.push(effect.id);
+        this._expireEffect(effect, { reason: 'expired', context });
+      }
+    }
+    return expired;
+  }
+
+  clear({ reason = 'cleared', context } = {}) {
+    for (const effect of [...this.effects.values()]) {
+      this._expireEffect(effect, { reason, context });
+    }
+  }
+
+  list() {
+    return [...this.effects.values()].map((effect) => ({
+      id: effect.id,
+      label: effect.label,
+      duration: effect.duration,
+      remaining: effect.remaining,
+      stacks: effect.stacks,
+      maxStacks: effect.maxStacks,
+      data: effect.data,
+      source: effect.source,
+    }));
+  }
+
+  _expireEffect(effect, { reason, context, replacement } = {}) {
+    if (!this.effects.has(effect.id)) {
+      return;
+    }
+    this.effects.delete(effect.id);
+    effect.onExpire?.(effect, { reason, context, manager: this, replacement });
+    this.events.emit('effect:expired', effect, { reason, context, replacement });
+  }
+}
+
+export default StatusEffectManager;


### PR DESCRIPTION
## Summary
- implement a reusable ResourcePool for AI resources with regeneration, consumption, and lifecycle events
- add a StatusEffectManager to coordinate timed effects, stacking behaviors, and behavior callbacks
- introduce a TacticalPointEngine with accrual rules, ability cost validation, and automated triggers plus focused unit tests

## Testing
- npm test *(fails: CrownedGhostRunnerEntity alternates between idle and walk states with animation swaps)*

------
https://chatgpt.com/codex/tasks/task_e_68def235c74c832ab97e0a490d7bbba8