### PR TITLE
Add ambient AI scheduler with environment queries

### DIFF
--- a/three-demo/src/entities/ai/__tests__/ambient-task-scheduler.test.js
+++ b/three-demo/src/entities/ai/__tests__/ambient-task-scheduler.test.js
@@ -1,0 +1,134 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AmbientTaskScheduler } from '../environment/ambient-task-scheduler.js';
+import {
+  createSeekSunlightBehavior,
+  createGatherResourcesBehavior,
+  createIdleChatterBehavior,
+} from '../environment/ambient-behaviors.js';
+
+const createStepRng = (values) => {
+  let index = 0;
+  const pool = values.length > 0 ? values : [0.5];
+  return () => {
+    const value = pool[index % pool.length];
+    index += 1;
+    return value;
+  };
+};
+
+const createContext = () => ({
+  time: 0,
+  flags: { allowWander: true },
+  entity: {
+    id: 'ghost-alpha',
+    faction: 'covenant',
+    position: { x: 0, y: 12, z: 0 },
+  },
+  environment: {
+    lightLevel: 0.3,
+    pointsOfInterest: [{ x: 22, y: 11, z: -6 }],
+    resourceNodes: [
+      { id: 'ecto-1', type: 'ectoplasm', amount: 3, position: { x: 12, y: 10, z: -4 } },
+    ],
+    nearbyEntities: [
+      { id: 'ghost-beta', faction: 'covenant', position: { x: 3, y: 12, z: 4 } },
+    ],
+  },
+  percepts: {
+    threatLevel: 'low',
+    nearbyEntities: [
+      { id: 'ghost-beta', faction: 'covenant', position: { x: 3, y: 12, z: 4 } },
+    ],
+  },
+  terrainHeight: (x, z) => 10 + Math.sin((x + z) * 0.2),
+  timeOfDay: { normalized: 0.2 },
+  memory: new Map(),
+});
+
+describe('AmbientTaskScheduler', () => {
+  let scheduler;
+  let context;
+
+  beforeEach(() => {
+    scheduler = new AmbientTaskScheduler({ random: createStepRng([0.1, 0.6, 0.8]) });
+    context = createContext();
+  });
+
+  it('prioritizes ambient tasks with cooldown-aware scheduling', () => {
+    scheduler.tick(0, context);
+
+    const first = scheduler.requestTask(context);
+    assert.ok(first, 'expected an ambient task to be scheduled');
+    assert.strictEqual(first.name, 'explore');
+    const firstResult = first.execute(context);
+    assert.strictEqual(firstResult.style, 'explore');
+    first.succeed(firstResult);
+
+    const second = scheduler.requestTask(context);
+    assert.ok(second, 'expected a follow-up ambient task');
+    assert.strictEqual(second.name, 'socialize');
+    const secondResult = second.execute(context);
+    assert.strictEqual(secondResult.style, 'chat');
+    second.succeed(secondResult);
+
+    const third = scheduler.requestTask(context);
+    assert.ok(third, 'expected wander task after socializing');
+    assert.strictEqual(third.name, 'wander');
+    const thirdResult = third.execute(context);
+    assert.strictEqual(thirdResult.style, 'wander');
+    third.succeed(thirdResult);
+
+    const state = scheduler.getTaskState('explore');
+    assert.ok(state.cooldownUntil > scheduler.time, 'explore should be on cooldown after execution');
+  });
+
+  it('recovers from failures and requeues high priority tasks after cooldown', () => {
+    scheduler.tick(0, context);
+
+    const exploreHandle = scheduler.requestTask(context, { include: ['explore'] });
+    assert.ok(exploreHandle, 'expected explore task to be available initially');
+    exploreHandle.execute(context);
+    exploreHandle.fail('blocked path');
+
+    const failedState = scheduler.getTaskState('explore');
+    assert.strictEqual(failedState.failures, 1);
+    assert.ok(failedState.cooldownUntil > scheduler.time, 'failure should apply cooldown');
+
+    const fallback = scheduler.requestTask(context);
+    assert.ok(fallback, 'expected fallback task while explore cools down');
+    assert.notStrictEqual(fallback.name, 'explore');
+    fallback.succeed(fallback.execute(context));
+
+    scheduler.tick(6, context);
+    const retried = scheduler.requestTask(context, { include: ['explore'] });
+    assert.ok(retried, 'explore should reschedule after failure cooldown elapses');
+  });
+
+  it('drives ambient behaviors via scheduler hooks', () => {
+    scheduler.tick(0, context);
+
+    const seekSunlight = createSeekSunlightBehavior(scheduler, { lightThreshold: 0.8 });
+    const gatherResources = createGatherResourcesBehavior(scheduler, { radius: 32 });
+    const idleChatter = createIdleChatterBehavior(scheduler, { radius: 12 });
+
+    seekSunlight.initialize?.(context);
+    gatherResources.initialize?.(context);
+    idleChatter.initialize?.(context);
+
+    const sunlightResult = seekSunlight.update(1, context);
+    assert.strictEqual(sunlightResult.status, 'seeking');
+    assert.strictEqual(context.memory.get('ambient:lastSeekSunlightResult').success, true);
+
+    const gatherResult = gatherResources.update(1, context);
+    assert.strictEqual(gatherResult.status, 'gathering');
+    const recordedGather = context.memory.get('ambient:lastGatherResult');
+    assert.strictEqual(recordedGather.status, 'gathering');
+
+    const chatterResult = idleChatter.update(1, context);
+    assert.strictEqual(chatterResult.status, 'chatting');
+    const recordedChatter = context.memory.get('ambient:lastChatterResult');
+    assert.strictEqual(recordedChatter.status, 'chatting');
+  });
+});

--- a/three-demo/src/entities/ai/environment/ambient-behaviors.js
+++ b/three-demo/src/entities/ai/environment/ambient-behaviors.js
@@ -1,0 +1,218 @@
+import { ActionNode } from '../behavior-nodes.js';
+import {
+  getLightLevel,
+  getTerrainHeight,
+  findNearbyEntities,
+  findResourceNodes,
+} from './environment-query.js';
+
+const resolveContextPosition = (context) => {
+  if (!context) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  if (context.entity?.root?.position) {
+    const { x = 0, y = 0, z = 0 } = context.entity.root.position;
+    return { x, y, z };
+  }
+  if (context.entity?.position) {
+    const { x = 0, y = 0, z = 0 } = context.entity.position;
+    return { x, y, z };
+  }
+  if (context.position) {
+    const { x = 0, y = 0, z = 0 } = context.position;
+    return { x, y, z };
+  }
+  return { x: 0, y: 0, z: 0 };
+};
+
+const recordOutcome = (context, key, value) => {
+  if (!context) {
+    return;
+  }
+  if (context.memory instanceof Map) {
+    context.memory.set(key, value);
+    return;
+  }
+  context.memory ??= {};
+  context.memory[key] = value;
+};
+
+export function createSeekSunlightBehavior(scheduler, options = {}) {
+  if (!scheduler) {
+    throw new Error('createSeekSunlightBehavior requires an AmbientTaskScheduler instance.');
+  }
+  const lightThreshold = Number.isFinite(options.lightThreshold)
+    ? Number(options.lightThreshold)
+    : 0.65;
+
+  return new ActionNode('ambient-seek-sunlight', {
+    onUpdate: (_delta, context) => {
+      const lightLevel = getLightLevel(context);
+      recordOutcome(context, 'ambient:lastLightLevel', lightLevel);
+      if (lightLevel >= lightThreshold) {
+        return { status: 'satisfied', light: lightLevel };
+      }
+
+      const handle = scheduler.requestTask(context, { include: ['explore', 'wander'] });
+      if (!handle) {
+        return { status: 'waiting', reason: 'no-task', light: lightLevel };
+      }
+
+      const result = handle.execute?.(context) ?? {};
+      if (result?.success === false) {
+        handle.fail(result.reason ?? 'blocked');
+        recordOutcome(context, 'ambient:lastSeekSunlightResult', {
+          success: false,
+          reason: result.reason ?? 'blocked',
+          light: lightLevel,
+        });
+        return { status: 'blocked', reason: result.reason ?? 'blocked', light: lightLevel };
+      }
+
+      handle.succeed(result);
+      recordOutcome(context, 'ambient:lastSeekSunlightResult', {
+        success: true,
+        task: handle.name,
+        light: lightLevel,
+      });
+      return { status: 'seeking', task: handle.name, light: lightLevel };
+    },
+  });
+}
+
+export function createGatherResourcesBehavior(scheduler, options = {}) {
+  if (!scheduler) {
+    throw new Error('createGatherResourcesBehavior requires an AmbientTaskScheduler instance.');
+  }
+  const radius = Number.isFinite(options.radius) ? Math.max(1, Number(options.radius)) : 48;
+  const types = options.types ?? null;
+
+  return new ActionNode('ambient-gather-resources', {
+    onUpdate: (_delta, context) => {
+      const origin = resolveContextPosition(context);
+      const nodes = findResourceNodes(context, origin, { radius, types, limit: 5 });
+      if (nodes.length === 0) {
+        recordOutcome(context, 'ambient:lastGatherResult', {
+          status: 'idle',
+          reason: 'no-resources',
+        });
+        return { status: 'idle', reason: 'no-resources' };
+      }
+
+      const targetNode = nodes[0];
+      const targetSurface = getTerrainHeight(context, targetNode.position);
+      const normalizedResource = {
+        ...targetNode,
+        position: {
+          ...targetNode.position,
+          ...(Number.isFinite(targetSurface) ? { y: targetSurface } : {}),
+        },
+      };
+      const handle = scheduler.requestTask(context, { include: ['wander', 'explore'] });
+      if (!handle) {
+        recordOutcome(context, 'ambient:lastGatherResult', {
+          status: 'waiting',
+          resource: normalizedResource,
+        });
+        return { status: 'waiting', resource: normalizedResource };
+      }
+
+      const augmentedContext = {
+        ...context,
+        targetResource: normalizedResource,
+      };
+      const result = handle.execute?.(augmentedContext) ?? {};
+      if (result?.success === false) {
+        handle.fail(result.reason ?? 'unreachable');
+        recordOutcome(context, 'ambient:lastGatherResult', {
+          status: 'failed',
+          resource: normalizedResource,
+          reason: result.reason ?? 'unreachable',
+        });
+        return {
+          status: 'failed',
+          resource: normalizedResource,
+          reason: result.reason ?? 'unreachable',
+        };
+      }
+
+      handle.succeed({ ...result, resource: normalizedResource });
+      recordOutcome(context, 'ambient:lastGatherResult', {
+        status: 'gathering',
+        task: handle.name,
+        resource: normalizedResource,
+      });
+      return { status: 'gathering', task: handle.name, resource: normalizedResource };
+    },
+  });
+}
+
+export function createIdleChatterBehavior(scheduler, options = {}) {
+  if (!scheduler) {
+    throw new Error('createIdleChatterBehavior requires an AmbientTaskScheduler instance.');
+  }
+  const radius = Number.isFinite(options.radius) ? Math.max(1, Number(options.radius)) : 18;
+
+  return new ActionNode('ambient-idle-chatter', {
+    onUpdate: (_delta, context) => {
+      const origin = resolveContextPosition(context);
+      const allies = findNearbyEntities(context, origin, {
+        radius,
+        limit: 5,
+        filter: options.filter,
+      });
+      if (allies.length === 0) {
+        recordOutcome(context, 'ambient:lastChatterResult', { status: 'quiet' });
+        return { status: 'quiet' };
+      }
+
+      const partner = allies[0].entity ?? allies[0];
+      const handle = scheduler.requestTask(context, { include: ['socialize'] });
+      if (!handle) {
+        recordOutcome(context, 'ambient:lastChatterResult', {
+          status: 'ready',
+          partner,
+        });
+        return { status: 'ready', partner };
+      }
+
+      const augmentedContext = {
+        ...context,
+        socialPartner: partner,
+      };
+      const result = handle.execute?.(augmentedContext) ?? {};
+      if (result?.success === false) {
+        handle.fail(result.reason ?? 'rejected');
+        recordOutcome(context, 'ambient:lastChatterResult', {
+          status: 'rejected',
+          partner,
+          reason: result.reason ?? 'rejected',
+        });
+        return { status: 'rejected', partner, reason: result.reason ?? 'rejected' };
+      }
+
+      handle.succeed({ ...result, partner });
+      recordOutcome(context, 'ambient:lastChatterResult', {
+        status: 'chatting',
+        task: handle.name,
+        partner,
+      });
+      return { status: 'chatting', task: handle.name, partner };
+    },
+  });
+}
+
+export function createAmbientBehaviorSuite(scheduler, options = {}) {
+  return {
+    seekSunlight: createSeekSunlightBehavior(scheduler, options.seekSunlight),
+    gatherResources: createGatherResourcesBehavior(scheduler, options.gatherResources),
+    idleChatter: createIdleChatterBehavior(scheduler, options.idleChatter),
+  };
+}
+
+export default {
+  createSeekSunlightBehavior,
+  createGatherResourcesBehavior,
+  createIdleChatterBehavior,
+  createAmbientBehaviorSuite,
+};

--- a/three-demo/src/entities/ai/environment/ambient-task-scheduler.js
+++ b/three-demo/src/entities/ai/environment/ambient-task-scheduler.js
@@ -1,0 +1,648 @@
+import {
+  getTerrainHeight,
+  getLightLevel,
+  findNearbyEntities,
+  findResourceNodes,
+} from './environment-query.js';
+
+const toNumber = (value, fallback = 0) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const resolveVector = (input) => {
+  if (!input) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  if (input.isVector3) {
+    return { x: toNumber(input.x), y: toNumber(input.y), z: toNumber(input.z) };
+  }
+  if (Array.isArray(input)) {
+    const [x = 0, y = 0, z = 0] = input;
+    return { x: toNumber(x), y: toNumber(y), z: toNumber(z) };
+  }
+  if (typeof input === 'object') {
+    if ('x' in input || 'z' in input || 'y' in input) {
+      return {
+        x: toNumber(input.x),
+        y: toNumber(input.y),
+        z: toNumber(input.z),
+      };
+    }
+    if (input.position) {
+      return resolveVector(input.position);
+    }
+    if (input.entity?.position) {
+      return resolveVector(input.entity.position);
+    }
+    if (input.entity?.root?.position) {
+      return resolveVector(input.entity.root.position);
+    }
+    if (input.root?.position) {
+      return resolveVector(input.root.position);
+    }
+  }
+  return { x: 0, y: 0, z: 0 };
+};
+
+const resolveContextPosition = (context, fallback = null) => {
+  if (!context) {
+    return fallback ?? { x: 0, y: 0, z: 0 };
+  }
+  if (context.entity?.root?.position) {
+    return resolveVector(context.entity.root.position);
+  }
+  if (context.entity?.position) {
+    return resolveVector(context.entity.position);
+  }
+  if (context.position) {
+    return resolveVector(context.position);
+  }
+  if (context.environment?.position) {
+    return resolveVector(context.environment.position);
+  }
+  return fallback ?? { x: 0, y: 0, z: 0 };
+};
+
+const clampNumber = (value, min, max) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, numeric));
+};
+
+const DEFAULT_TASKS = ['wander', 'explore', 'socialize'];
+
+const ensureFilterArray = (filters) => {
+  if (!filters) {
+    return [];
+  }
+  if (Array.isArray(filters)) {
+    return filters.filter((filter) => typeof filter === 'function');
+  }
+  if (typeof filters === 'function') {
+    return [filters];
+  }
+  return [];
+};
+
+const ensureTagSet = (value) => {
+  if (!value) {
+    return new Set();
+  }
+  if (value instanceof Set) {
+    return new Set(value);
+  }
+  if (Array.isArray(value)) {
+    return new Set(value.filter((item) => typeof item === 'string').map((item) => item));
+  }
+  if (typeof value === 'string') {
+    return new Set([value]);
+  }
+  return new Set();
+};
+
+const normalizeDefinition = (definition = {}) => {
+  if (!definition.name || typeof definition.name !== 'string') {
+    throw new Error('Ambient tasks require a string name.');
+  }
+  const cooldown = Number.isFinite(definition.cooldown)
+    ? Math.max(0, Number(definition.cooldown))
+    : 8;
+  const failureCooldown = Number.isFinite(definition.failureCooldown)
+    ? Math.max(0.5, Number(definition.failureCooldown))
+    : Math.max(2, cooldown * 0.6);
+  return {
+    name: definition.name,
+    label: definition.label ?? definition.name,
+    priority: Number.isFinite(definition.priority) ? Number(definition.priority) : 0,
+    weight: Number.isFinite(definition.weight) ? Math.max(0, Number(definition.weight)) : 1,
+    cooldown,
+    failureCooldown,
+    maxFailures: Number.isFinite(definition.maxFailures)
+      ? Math.max(1, Math.floor(definition.maxFailures))
+      : 3,
+    failureBackoffMultiplier: Number.isFinite(definition.failureBackoffMultiplier)
+      ? Math.max(1, Number(definition.failureBackoffMultiplier))
+      : 1,
+    filters: ensureFilterArray(definition.filters),
+    execute: typeof definition.execute === 'function' ? definition.execute : () => ({ success: true }),
+    onFailure: typeof definition.onFailure === 'function' ? definition.onFailure : null,
+    onSuccess: typeof definition.onSuccess === 'function' ? definition.onSuccess : null,
+    metadata: definition.metadata ?? null,
+    tags: Array.from(ensureTagSet(definition.tags)),
+  };
+};
+
+const toNameSet = (value) => {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Set) {
+    return value.size > 0 ? new Set(value) : null;
+  }
+  if (Array.isArray(value)) {
+    const set = new Set(value.map((entry) => `${entry}`));
+    return set.size > 0 ? set : null;
+  }
+  if (typeof value === 'string') {
+    return new Set([value]);
+  }
+  return null;
+};
+
+const randomInRange = (rng, min, max) => {
+  const t = rng();
+  return min + (max - min) * t;
+};
+
+const chooseRandom = (rng, list) => {
+  if (!Array.isArray(list) || list.length === 0) {
+    return null;
+  }
+  const index = Math.floor(rng() * list.length);
+  return list[clampNumber(index, 0, list.length - 1)];
+};
+
+const createWanderInstruction = (context, scheduler) => {
+  const origin = resolveContextPosition(context);
+  const radius = randomInRange(scheduler.random, 4, 10);
+  const angle = scheduler.random() * Math.PI * 2;
+  const target = {
+    x: origin.x + Math.cos(angle) * radius,
+    z: origin.z + Math.sin(angle) * radius,
+    y: origin.y,
+  };
+  const terrainHeight = getTerrainHeight(context, target);
+  if (Number.isFinite(terrainHeight)) {
+    target.y = terrainHeight;
+  }
+  return {
+    success: true,
+    type: 'movement',
+    style: 'wander',
+    target,
+  };
+};
+
+const createExploreInstruction = (context, scheduler) => {
+  const origin = resolveContextPosition(context);
+  const resourceNodes = findResourceNodes(context, origin, { radius: 80, limit: 4 });
+  const pointsOfInterest = Array.isArray(context?.environment?.pointsOfInterest)
+    ? context.environment.pointsOfInterest.map((entry) => resolveVector(entry))
+    : [];
+  let target = null;
+  let intent = 'survey';
+  if (resourceNodes.length > 0) {
+    const chosen = resourceNodes[0];
+    target = { ...chosen.position };
+    intent = 'resource';
+  } else if (pointsOfInterest.length > 0) {
+    target = { ...chooseRandom(scheduler.random, pointsOfInterest) };
+    intent = 'poi';
+  } else {
+    const radius = randomInRange(scheduler.random, 12, 24);
+    const angle = scheduler.random() * Math.PI * 2;
+    target = {
+      x: origin.x + Math.cos(angle) * radius,
+      z: origin.z + Math.sin(angle) * radius,
+      y: origin.y,
+    };
+  }
+  const terrainHeight = getTerrainHeight(context, target);
+  if (Number.isFinite(terrainHeight)) {
+    target.y = terrainHeight;
+  }
+  return {
+    success: true,
+    type: 'movement',
+    style: 'explore',
+    intent,
+    target,
+  };
+};
+
+const createSocializeInstruction = (context, scheduler) => {
+  const origin = resolveContextPosition(context);
+  const allies = findNearbyEntities(context, origin, {
+    radius: 24,
+    limit: 4,
+    filter: (entity) => {
+      const id = entity?.id ?? entity?.entity?.id;
+      if (context?.entity?.id && id === context.entity.id) {
+        return false;
+      }
+      if (entity?.entity?.faction && context?.entity?.faction) {
+        return entity.entity.faction === context.entity.faction;
+      }
+      if (entity?.faction && context?.entity?.faction) {
+        return entity.faction === context.entity.faction;
+      }
+      return true;
+    },
+  });
+  const partner = allies[0]?.entity ?? allies[0] ?? null;
+  if (!partner) {
+    return { success: false, reason: 'no-partner' };
+  }
+  return {
+    success: true,
+    type: 'social',
+    style: 'chat',
+    partner,
+    message: chooseRandom(scheduler.random, [
+      'shares a rumor about hidden ruins',
+      'recounts the last hunt',
+      'hums a spectral melody',
+    ]),
+  };
+};
+
+class TaskRecord {
+  constructor(definition) {
+    this.definition = definition;
+    this.state = {
+      lastRun: -Infinity,
+      cooldownUntil: 0,
+      failures: 0,
+      pendingHandle: null,
+      pendingContext: null,
+    };
+    this.stats = {
+      runs: 0,
+      failures: 0,
+    };
+  }
+}
+
+export class AmbientTaskScheduler {
+  constructor(options = {}) {
+    const { random = Math.random, tasks = [] } = options;
+    this.random = typeof random === 'function' ? random : Math.random;
+    this.time = 0;
+    this.tasks = new Map();
+    this.queue = [];
+    this._queueDirty = false;
+    this._handleId = 1;
+    DEFAULT_TASKS.forEach((name) => {
+      if (!options.skipDefaults) {
+        this._registerDefaultTask(name);
+      }
+    });
+    tasks.forEach((task) => this.registerTask(task));
+  }
+
+  _registerDefaultTask(name) {
+    if (this.tasks.has(name)) {
+      return;
+    }
+    switch (name) {
+      case 'wander': {
+        this.registerTask({
+          name: 'wander',
+          label: 'Ambient Wander',
+          priority: 1,
+          cooldown: 6,
+          failureCooldown: 3,
+          tags: ['movement', 'ambient'],
+          filters: [
+            (context) => (context?.flags?.allowWander ?? true) !== false,
+            (context) => (context?.percepts?.threatLevel ?? 'low') === 'low',
+          ],
+          execute: (context) => createWanderInstruction(context, this),
+        });
+        break;
+      }
+      case 'explore': {
+        this.registerTask({
+          name: 'explore',
+          label: 'Ambient Exploration',
+          priority: 3,
+          cooldown: 12,
+          failureCooldown: 6,
+          tags: ['movement', 'exploration'],
+          filters: [
+            (context) => (context?.percepts?.threatLevel ?? 'low') === 'low',
+            (context) => {
+              const light = getLightLevel(context);
+              if (light < 0.65) {
+                return { allow: true, priority: 3.5 };
+              }
+              const points = Array.isArray(context?.environment?.pointsOfInterest)
+                ? context.environment.pointsOfInterest.length
+                : 0;
+              const nodes = findResourceNodes(context, resolveContextPosition(context), {
+                radius: 64,
+                limit: 1,
+              });
+              if (points > 0 || nodes.length > 0) {
+                return { allow: true, priority: 3 };
+              }
+              return false;
+            },
+          ],
+          execute: (context) => createExploreInstruction(context, this),
+        });
+        break;
+      }
+      case 'socialize': {
+        this.registerTask({
+          name: 'socialize',
+          label: 'Ambient Socialize',
+          priority: 2,
+          cooldown: 15,
+          failureCooldown: 8,
+          tags: ['social', 'ambient'],
+          filters: [
+            (context) =>
+              findNearbyEntities(context, resolveContextPosition(context), {
+                radius: 20,
+                limit: 1,
+                filter: (entity) => {
+                  const id = entity?.id ?? entity?.entity?.id;
+                  if (context?.entity?.id && id === context.entity.id) {
+                    return false;
+                  }
+                  if (entity?.entity?.faction && context?.entity?.faction) {
+                    return entity.entity.faction === context.entity.faction;
+                  }
+                  if (entity?.faction && context?.entity?.faction) {
+                    return entity.faction === context.entity.faction;
+                  }
+                  return true;
+                },
+              }).length > 0,
+          ],
+          execute: (context) => createSocializeInstruction(context, this),
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  registerTask(definition) {
+    const normalized = normalizeDefinition(definition);
+    const record = new TaskRecord(normalized);
+    this.tasks.set(normalized.name, record);
+    return record;
+  }
+
+  tick(delta = 0, context = {}) {
+    const numericDelta = Number(delta);
+    if (Number.isFinite(numericDelta)) {
+      this.time += numericDelta;
+    }
+    this._enqueueEligibleTasks(context);
+  }
+
+  _enqueueEligibleTasks(context) {
+    for (const [name, record] of this.tasks.entries()) {
+      if (record.state.pendingHandle) {
+        continue;
+      }
+      if (this._isQueued(name)) {
+        continue;
+      }
+      if (this.time < record.state.cooldownUntil) {
+        continue;
+      }
+      const filters = this._evaluateFilters(record.definition, context);
+      if (!filters.allow) {
+        continue;
+      }
+      this._enqueueRecord(record, filters.priority, filters.weight);
+    }
+  }
+
+  _isQueued(name) {
+    return this.queue.some((entry) => entry.name === name);
+  }
+
+  _evaluateFilters(definition, context) {
+    let priority = definition.priority;
+    let weight = definition.weight;
+    for (const filter of definition.filters) {
+      let result = null;
+      try {
+        result = filter(context, { scheduler: this, definition });
+      } catch (error) {
+        console.warn(`Ambient task filter failed for "${definition.name}":`, error);
+        return { allow: false, priority, weight };
+      }
+      if (result === false) {
+        return { allow: false, priority, weight };
+      }
+      if (typeof result === 'object' && result !== null) {
+        if ('allow' in result && result.allow === false) {
+          return { allow: false, priority, weight };
+        }
+        if (Number.isFinite(result.priority)) {
+          priority = Number(result.priority);
+        }
+        if (Number.isFinite(result.weight)) {
+          weight = Math.max(0, Number(result.weight));
+        }
+      }
+    }
+    return { allow: true, priority, weight };
+  }
+
+  _enqueueRecord(record, priorityOverride, weightOverride) {
+    const priority = Number.isFinite(priorityOverride)
+      ? Number(priorityOverride)
+      : record.definition.priority;
+    const weight = Number.isFinite(weightOverride)
+      ? Math.max(0, Number(weightOverride))
+      : record.definition.weight;
+    const bias = this.random() * (weight > 0 ? weight : 1);
+    this.queue.push({
+      name: record.definition.name,
+      priority,
+      weight,
+      bias,
+      enqueuedAt: this.time,
+    });
+    this._queueDirty = true;
+  }
+
+  _sortQueue() {
+    if (!this._queueDirty) {
+      return;
+    }
+    this.queue.sort((a, b) => {
+      if (b.priority === a.priority) {
+        if (b.bias === a.bias) {
+          return a.enqueuedAt - b.enqueuedAt;
+        }
+        return b.bias - a.bias;
+      }
+      return b.priority - a.priority;
+    });
+    this._queueDirty = false;
+  }
+
+  requestTask(context = {}, options = {}) {
+    this._enqueueEligibleTasks(context);
+    this._sortQueue();
+
+    if (this.queue.length === 0) {
+      return null;
+    }
+
+    const include = toNameSet(options.include);
+    const exclude = toNameSet(options.exclude);
+    const tags = toNameSet(options.tags);
+    const predicate = typeof options.predicate === 'function' ? options.predicate : null;
+
+    let candidateIndex = -1;
+    for (let i = 0; i < this.queue.length; i += 1) {
+      const entry = this.queue[i];
+      const record = this.tasks.get(entry.name);
+      if (!record) {
+        continue;
+      }
+      if (include && !include.has(entry.name)) {
+        continue;
+      }
+      if (exclude && exclude.has(entry.name)) {
+        continue;
+      }
+      if (tags) {
+        const taskTags = record.definition.tags;
+        if (!taskTags.some((tag) => tags.has(tag))) {
+          continue;
+        }
+      }
+      if (predicate && predicate(record.definition, { context, scheduler: this }) === false) {
+        continue;
+      }
+      candidateIndex = i;
+      break;
+    }
+
+    if (candidateIndex === -1) {
+      return null;
+    }
+
+    const [entry] = this.queue.splice(candidateIndex, 1);
+    const record = this.tasks.get(entry.name);
+    if (!record) {
+      return null;
+    }
+
+    const handleId = this._handleId++;
+    record.state.pendingHandle = { id: handleId, priority: entry.priority };
+    record.state.pendingContext = context;
+
+    return {
+      name: record.definition.name,
+      priority: entry.priority,
+      metadata: record.definition.metadata,
+      execute: (runContext = context) => record.definition.execute(runContext, this),
+      succeed: (result = null) =>
+        this._completeTask(record, handleId, { success: true, result }),
+      fail: (reason = null, optionsOverride = {}) =>
+        this._completeTask(record, handleId, {
+          success: false,
+          reason,
+          failureCooldown: optionsOverride.failureCooldown,
+        }),
+      complete: (options = {}) => this._completeTask(record, handleId, options),
+      cancel: (cancelOptions = {}) => this._cancelPending(record, handleId, cancelOptions),
+    };
+  }
+
+  _completeTask(record, handleId, options = {}) {
+    if (!record.state.pendingHandle || record.state.pendingHandle.id !== handleId) {
+      return null;
+    }
+    const success = options.success !== false;
+    const now = this.time;
+    record.state.lastRun = now;
+    const cooldownOverride = Number.isFinite(options.cooldown)
+      ? Math.max(0, Number(options.cooldown))
+      : null;
+    const failureCooldownOverride = Number.isFinite(options.failureCooldown)
+      ? Math.max(0, Number(options.failureCooldown))
+      : null;
+
+    if (success) {
+      record.state.failures = 0;
+      record.stats.runs += 1;
+      record.state.cooldownUntil = now + (cooldownOverride ?? record.definition.cooldown);
+      if (record.definition.onSuccess) {
+        record.definition.onSuccess({
+          scheduler: this,
+          context: record.state.pendingContext,
+          result: options.result ?? null,
+        });
+      }
+    } else {
+      record.state.failures += 1;
+      record.stats.failures += 1;
+      const failureCount = Math.min(record.state.failures, record.definition.maxFailures);
+      const multiplier =
+        record.definition.failureBackoffMultiplier + (failureCount - 1) * 0.25;
+      const delay =
+        (failureCooldownOverride ?? record.definition.failureCooldown) * Math.max(1, multiplier);
+      record.state.cooldownUntil = now + delay;
+      if (record.definition.onFailure) {
+        record.definition.onFailure({
+          scheduler: this,
+          context: record.state.pendingContext,
+          reason: options.reason ?? null,
+          failures: record.state.failures,
+        });
+      }
+    }
+
+    record.state.pendingHandle = null;
+    record.state.pendingContext = null;
+
+    if (options.requeue === true) {
+      this._enqueueRecord(record, options.priority, options.weight);
+    }
+    return success;
+  }
+
+  _cancelPending(record, handleId, options = {}) {
+    if (!record.state.pendingHandle || record.state.pendingHandle.id !== handleId) {
+      return false;
+    }
+    record.state.pendingHandle = null;
+    const requeue = options.requeue !== false;
+    if (requeue) {
+      this._enqueueRecord(record, options.priority, options.weight);
+    }
+    record.state.pendingContext = null;
+    return true;
+  }
+
+  getTaskState(name) {
+    const record = this.tasks.get(name);
+    if (!record) {
+      return null;
+    }
+    return {
+      name: record.definition.name,
+      priority: record.definition.priority,
+      weight: record.definition.weight,
+      cooldown: record.definition.cooldown,
+      failureCooldown: record.definition.failureCooldown,
+      lastRun: record.state.lastRun,
+      cooldownUntil: record.state.cooldownUntil,
+      failures: record.state.failures,
+      pending: Boolean(record.state.pendingHandle),
+      stats: { ...record.stats },
+    };
+  }
+
+  clearQueue() {
+    this.queue.length = 0;
+  }
+}
+
+export default AmbientTaskScheduler;

--- a/three-demo/src/entities/ai/environment/environment-query.js
+++ b/three-demo/src/entities/ai/environment/environment-query.js
@@ -1,0 +1,347 @@
+const clamp01 = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, numeric));
+};
+
+const toNumber = (value, fallback = 0) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const resolveVector = (input) => {
+  if (!input) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  if (input.isVector3) {
+    return { x: toNumber(input.x), y: toNumber(input.y), z: toNumber(input.z) };
+  }
+  if (Array.isArray(input)) {
+    const [x = 0, y = 0, z = 0] = input;
+    return { x: toNumber(x), y: toNumber(y), z: toNumber(z) };
+  }
+  if (typeof input === 'object') {
+    if ('x' in input || 'y' in input || 'z' in input) {
+      return {
+        x: toNumber(input.x),
+        y: toNumber(input.y),
+        z: toNumber(input.z),
+      };
+    }
+    if (input.position) {
+      return resolveVector(input.position);
+    }
+    if (input.entity && input.entity.position) {
+      return resolveVector(input.entity.position);
+    }
+    if (input.entity && input.entity.root && input.entity.root.position) {
+      return resolveVector(input.entity.root.position);
+    }
+    if (input.root && input.root.position) {
+      return resolveVector(input.root.position);
+    }
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return { x: input, y: 0, z: 0 };
+  }
+  return { x: 0, y: 0, z: 0 };
+};
+
+const distance2D = (a, b) => {
+  const ax = toNumber(a?.x);
+  const az = toNumber(a?.z);
+  const bx = toNumber(b?.x);
+  const bz = toNumber(b?.z);
+  return Math.hypot(ax - bx, az - bz);
+};
+
+const resolvePositionFromSource = (source) => {
+  if (!source) {
+    return null;
+  }
+  if (source.position) {
+    return resolveVector(source.position);
+  }
+  if (source.entity?.root?.position) {
+    return resolveVector(source.entity.root.position);
+  }
+  if (source.entity?.position) {
+    return resolveVector(source.entity.position);
+  }
+  if (source.root?.position) {
+    return resolveVector(source.root.position);
+  }
+  if (Array.isArray(source)) {
+    return resolveVector(source);
+  }
+  if (typeof source === 'object' && ('x' in source || 'z' in source)) {
+    return resolveVector(source);
+  }
+  return null;
+};
+
+export function getTerrainHeight(context, position, options = {}) {
+  const { x, z } = resolveVector(position ?? context?.entity?.root?.position ?? null);
+  const explicit = options.terrainHeight ?? context?.terrainHeight;
+  if (typeof explicit === 'function') {
+    const value = explicit(x, z);
+    return Number.isFinite(value) ? value : null;
+  }
+  const dependencies = context?.dependencies ?? {};
+  if (typeof dependencies.terrainHeight === 'function') {
+    const value = dependencies.terrainHeight(x, z);
+    if (Number.isFinite(value)) {
+      return value;
+    }
+  }
+  const chunkManager = options.chunkManager ?? dependencies.chunkManager;
+  if (chunkManager) {
+    if (typeof chunkManager.sampleColumnHeight === 'function') {
+      const value = chunkManager.sampleColumnHeight(x, z);
+      if (Number.isFinite(value)) {
+        return value;
+      }
+    }
+    if (typeof chunkManager.getColumnHeight === 'function') {
+      const value = chunkManager.getColumnHeight(x, z);
+      if (Number.isFinite(value)) {
+        return value;
+      }
+    }
+  }
+  if (typeof options.fallback === 'number') {
+    return options.fallback;
+  }
+  return null;
+}
+
+export function getLightLevel(context, position, options = {}) {
+  const environment = context?.environment ?? {};
+  const sampleFunctions = [
+    environment.sampleLightAt,
+    environment.lightProbe?.sample,
+    context?.percepts?.sampleLightAt,
+    options.sampleLightAt,
+  ].filter((fn) => typeof fn === 'function');
+
+  const targetPosition = position ?? context?.entity?.root?.position ?? null;
+  for (const sampler of sampleFunctions) {
+    try {
+      const sample = sampler(targetPosition, context, options);
+      if (Number.isFinite(sample)) {
+        return clamp01(sample);
+      }
+    } catch (error) {
+      console.warn('environment-query: light sampler failed', error);
+    }
+  }
+
+  const lightSources = [
+    environment.lightLevel,
+    context?.percepts?.lightLevel,
+    context?.timeOfDay?.lightLevel,
+    context?.timeOfDay?.normalized,
+  ];
+  for (const value of lightSources) {
+    if (Number.isFinite(value)) {
+      return clamp01(value);
+    }
+  }
+
+  if (context?.timeOfDay?.normalized !== undefined) {
+    const normalized = clamp01(context.timeOfDay.normalized);
+    const daylight = normalized <= 0.5 ? normalized * 2 : (1 - normalized) * 2;
+    return clamp01(daylight);
+  }
+
+  if (Number.isFinite(options.fallback)) {
+    return clamp01(options.fallback);
+  }
+
+  return 0.5;
+}
+
+const collectEntitiesFromContext = (context, options = {}) => {
+  const sources = [];
+  if (Array.isArray(options.entities)) {
+    sources.push(...options.entities);
+  }
+  if (Array.isArray(context?.percepts?.nearbyEntities)) {
+    sources.push(...context.percepts.nearbyEntities);
+  }
+  if (Array.isArray(context?.environment?.nearbyEntities)) {
+    sources.push(...context.environment.nearbyEntities);
+  }
+  const manager = context?.dependencies?.entityManager ?? options.entityManager;
+  if (manager?.getEntities) {
+    try {
+      sources.push(...(manager.getEntities() ?? []));
+    } catch (error) {
+      console.warn('environment-query: entityManager.getEntities failed', error);
+    }
+  }
+  return sources;
+};
+
+const normalizeEntityRecord = (source) => {
+  if (!source) {
+    return null;
+  }
+  if (source.entity) {
+    const position = resolvePositionFromSource(source);
+    return position
+      ? {
+          id: source.id ?? source.entity?.id ?? source.entity?.name ?? null,
+          position,
+          data: source.entity,
+        }
+      : null;
+  }
+  const position = resolvePositionFromSource(source);
+  if (!position) {
+    return null;
+  }
+  return {
+    id: source.id ?? source.name ?? null,
+    position,
+    data: source,
+  };
+};
+
+export function findNearbyEntities(context, position, options = {}) {
+  const origin = resolveVector(position ?? context?.entity?.root?.position ?? context?.entity?.position ?? null);
+  const radius = Number.isFinite(options.radius) ? Math.max(0, options.radius) : 10;
+  const limit = Number.isFinite(options.limit) ? Math.max(1, Math.floor(options.limit)) : null;
+  const filter = typeof options.filter === 'function' ? options.filter : null;
+
+  const rawEntities = collectEntitiesFromContext(context, options);
+  const results = [];
+  const seen = new Set();
+
+  rawEntities.forEach((candidate) => {
+    const normalized = normalizeEntityRecord(candidate);
+    if (!normalized) {
+      return;
+    }
+    const { id, position: candidatePosition } = normalized;
+    if (id && seen.has(id)) {
+      return;
+    }
+    const distance = distance2D(origin, candidatePosition);
+    if (Number.isFinite(radius) && distance > radius) {
+      return;
+    }
+    if (filter && filter(normalized.data ?? candidate, { distance, origin }) === false) {
+      return;
+    }
+    if (id) {
+      seen.add(id);
+    }
+    results.push({
+      id: normalized.id,
+      position: candidatePosition,
+      entity: normalized.data ?? candidate,
+      distance,
+    });
+  });
+
+  results.sort((a, b) => a.distance - b.distance);
+
+  if (limit && results.length > limit) {
+    return results.slice(0, limit);
+  }
+
+  return results;
+}
+
+const collectResourceNodes = (context, options = {}) => {
+  const nodes = [];
+  if (Array.isArray(options.nodes)) {
+    nodes.push(...options.nodes);
+  }
+  if (Array.isArray(context?.environment?.resourceNodes)) {
+    nodes.push(...context.environment.resourceNodes);
+  }
+  if (Array.isArray(context?.percepts?.resourceNodes)) {
+    nodes.push(...context.percepts.resourceNodes);
+  }
+  const locator = context?.dependencies?.resourceLocator ?? options.resourceLocator;
+  if (locator?.findNodes) {
+    try {
+      nodes.push(...(locator.findNodes(options) ?? []));
+    } catch (error) {
+      console.warn('environment-query: resourceLocator.findNodes failed', error);
+    }
+  }
+  return nodes;
+};
+
+const normalizeResourceNode = (node) => {
+  if (!node) {
+    return null;
+  }
+  const position = resolvePositionFromSource(node);
+  if (!position) {
+    return null;
+  }
+  return {
+    id: node.id ?? node.key ?? null,
+    type: node.type ?? node.resource ?? null,
+    amount: node.amount ?? node.quantity ?? null,
+    position,
+    data: node,
+  };
+};
+
+export function findResourceNodes(context, position, options = {}) {
+  const origin = resolveVector(position ?? context?.entity?.root?.position ?? context?.entity?.position ?? null);
+  const radius = Number.isFinite(options.radius) ? Math.max(0, options.radius) : 32;
+  const allowedTypes = Array.isArray(options.types)
+    ? new Set(options.types.map((type) => `${type}`))
+    : options.types instanceof Set
+    ? options.types
+    : null;
+  const limit = Number.isFinite(options.limit) ? Math.max(1, Math.floor(options.limit)) : null;
+
+  const nodes = collectResourceNodes(context, options);
+  const results = [];
+
+  nodes.forEach((node) => {
+    const normalized = normalizeResourceNode(node);
+    if (!normalized) {
+      return;
+    }
+    if (allowedTypes && normalized.type && !allowedTypes.has(normalized.type)) {
+      return;
+    }
+    const distance = distance2D(origin, normalized.position);
+    if (Number.isFinite(radius) && distance > radius) {
+      return;
+    }
+    results.push({
+      id: normalized.id,
+      type: normalized.type,
+      amount: normalized.amount,
+      position: normalized.position,
+      node: normalized.data,
+      distance,
+    });
+  });
+
+  results.sort((a, b) => a.distance - b.distance);
+
+  if (limit && results.length > limit) {
+    return results.slice(0, limit);
+  }
+
+  return results;
+}
+
+export default {
+  getTerrainHeight,
+  getLightLevel,
+  findNearbyEntities,
+  findResourceNodes,
+};

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import { BehaviorRegistry } from './behavior-nodes.js';
 import { PersonaRegistry } from './personas/persona-registry.js';
 import { defaultTraits } from './traits/index.js';
+import { AmbientTaskScheduler } from './environment/ambient-task-scheduler.js';
 
 const deepClone = (value) => {
   if (typeof structuredClone === 'function') {
@@ -146,6 +147,7 @@ export class MobAICore {
       behaviorRegistry = new BehaviorRegistry(),
       personaRegistry = new PersonaRegistry(),
       traitDefinitions = defaultTraits,
+      ambientScheduler = null,
       events,
     } = options;
 
@@ -156,6 +158,10 @@ export class MobAICore {
     };
 
     this.scheduler = new BehaviorScheduler();
+    this.ambientScheduler =
+      ambientScheduler instanceof AmbientTaskScheduler
+        ? ambientScheduler
+        : new AmbientTaskScheduler({ random });
     this.behaviorRegistry = behaviorRegistry;
     this.personaRegistry = personaRegistry;
     this.traits = new Map();
@@ -335,10 +341,14 @@ export class MobAICore {
       this.context.dependencies = this.dependencies;
       this.context.flags ??= {};
       this.context.memory ??= new Map();
+      this.context.ambientScheduler = this.ambientScheduler;
+      this.context.ambient ??= {};
+      this.context.ambient.scheduler = this.ambientScheduler;
       this._updateTraitContext();
       if (this.currentPersona) {
         this._syncPersonaContext(this.currentPersona);
       }
+      this.ambientScheduler.tick(0, this.context);
       return this.context;
     }
 
@@ -352,10 +362,14 @@ export class MobAICore {
       dependencies: this.dependencies,
     };
     this._updateTraitContext();
+    this.context.ambientScheduler = this.ambientScheduler;
+    this.context.ambient ??= {};
+    this.context.ambient.scheduler = this.ambientScheduler;
     if (this.currentPersona) {
       this._syncPersonaContext(this.currentPersona, { resetResources: true });
     }
     this.scheduler.initialize(this.context);
+    this.ambientScheduler.tick(0, this.context);
     this.initialized = true;
     return this.context;
   }
@@ -378,6 +392,7 @@ export class MobAICore {
     this.context.delta = delta;
     this.context.time += delta;
     this.emit('beforeUpdate', this.context);
+    this.ambientScheduler.tick(delta, this.context);
     this.scheduler.tick(delta, this.context);
     this.emit('afterUpdate', this.context);
   }

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -7,8 +7,9 @@ const RUNNER_MODEL_CONFIG = {
   ).href,
   animationMap: {
     runner: {
+      Ghost_Guy_Runner_Idle: 'idle',
+      Ghost_Guy_Runner: 'runner',
       NlaTrack: 'runner',
-      '*': 'runner',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add environment-query utilities for terrain, light, nearby entities, and resource nodes to support ambient AI
- implement an ambient task scheduler with wander/explore/socialize tasks plus behavior nodes, and integrate it into the MobAICore lifecycle
- adjust the crowned ghost runner animation map to preserve idle/runner clips and add integration tests for the scheduler

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def9ee5860832a9c183dee42f5cfd5