### PR TITLE
Add spectral runner AI integration tests and document node test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The Vite demo is the recommended way to iterate on the experience:
    ```
 3. Open the provided local URL in a modern browser. The Vite entry point serves the modules from `three-demo/src/`, so changes are reflected instantly.
 
+## Testing AI Behaviors
+
+- Run `npm test` from the `three-demo/` workspace to execute the Node.js test runner (`node --test`). The suite exercises the AI modules under `three-demo/src/entities/ai/__tests__/`, including the new `mob-ai-core.transition-flow.test.js` and `spectral-runner.integration.test.js` coverage for behavior transitions, sensor fusion, and tactical point coordination.
+- The integration tests emit animation intents by sharing the `MobAICore` event bus with the `AIPresentationAdapter`. When adding additional cases that touch `THREE` APIs (e.g., the animation controller), provide lightweight mocks instead of the real library—for example, stub the required mixer methods or constants such as `LoopOnce`.
+
 ## World Configuration
 
 - Consult [WORLD_CONFIGURATION.md](WORLD_CONFIGURATION.md) for a complete breakdown of every configurable world option, including default ranges and the supported override workflow.

--- a/three-demo/src/entities/ai/__tests__/mob-ai-core.transition-flow.test.js
+++ b/three-demo/src/entities/ai/__tests__/mob-ai-core.transition-flow.test.js
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { MobAICore } from '../mob-ai-core.js';
+import { BehaviorRegistry } from '../behavior-nodes.js';
+import { spectralRunnerPersona } from '../personas/spectral-runner.js';
+import { SensorSuite } from '../sensors/sensor-suite.js';
+import { MobSensor } from '../sensors/mob-sensor.js';
+import { TacticalPointEngine } from '../combat/tactical-point-engine.js';
+
+class QueueSensor extends MobSensor {
+  constructor({ id, type = id, interval = 0, queue = [] } = {}) {
+    super({ id, type, interval });
+    this._queue = Array.isArray(queue) ? [...queue] : [queue];
+  }
+
+  enqueue(stimulus) {
+    this._queue.push(stimulus);
+  }
+
+  sampleWorld() {
+    if (this._queue.length === 0) {
+      return null;
+    }
+    return this._queue.shift();
+  }
+}
+
+describe('MobAICore transition flow', () => {
+  let core;
+
+  beforeEach(() => {
+    core = new MobAICore({
+      random: () => 0,
+      behaviorRegistry: new BehaviorRegistry(),
+    });
+    core.registerPersona(spectralRunnerPersona);
+    core.usePersona('spectral-runner');
+  });
+
+  it('applies the spectral runner persona and records loop transitions', () => {
+    const transitions = [];
+    core.useBehaviorLoop('idle', {
+      priority: 5,
+      onStateChange: ({ state, previousState, loop }) => {
+        if (previousState && previousState !== state) {
+          core.emit('behavior:stateExit', {
+            behavior: loop.name,
+            state: previousState,
+            nextState: state,
+          });
+        }
+        core.emit('behavior:stateEnter', {
+          behavior: loop.name,
+          state,
+          previousState,
+        });
+        transitions.push({ state, previousState });
+      },
+      shouldWander: (context) => Boolean(context.flags?.wander),
+      canSeeTarget: (context) => Boolean(context.percepts?.targetVisible),
+      lostTarget: (context) => !context.percepts?.targetVisible,
+    });
+
+    const context = core.initialize({
+      flags: { wander: false },
+      percepts: { targetVisible: false },
+      environment: { lightLevel: 0.6 },
+    });
+    core.attachToEntity({ id: 'entity-transition-test' });
+
+    assert.strictEqual(core.currentPersona.name, 'spectral-runner');
+    assert.strictEqual(context.resources.stamina.max, 120);
+    assert.strictEqual(context.resources.ectoplasm.current, 60);
+    assert.deepStrictEqual(
+      transitions.map((entry) => entry.state),
+      ['idle'],
+    );
+
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: false } });
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: true } });
+    core.update(1, { flags: { wander: false }, percepts: { targetVisible: false } });
+
+    assert.deepStrictEqual(
+      transitions.map((entry) => entry.state),
+      ['idle', 'wander', 'chase', 'idle'],
+    );
+    assert.strictEqual(context.behaviorState['mob-idle'], 'idle');
+  });
+
+  it('merges persona sensor presets and forwards fused stimuli', () => {
+    const context = core.initialize({
+      flags: {},
+      percepts: {},
+    });
+    core.attachToEntity({ id: 'entity-sensor-test' });
+
+    assert.ok(Array.isArray(context.sensors.presets));
+    assert.ok(context.sensors.presets.includes('spectral-vision'));
+    assert.ok(context.sensors.presets.includes('echo-location'));
+
+    const stimuliEvents = [];
+    core.events.on('sensor:stimuli', (stimuli, meta) => {
+      stimuliEvents.push({ stimuli, meta });
+    });
+
+    const vision = new QueueSensor({
+      id: 'vision',
+      type: 'vision',
+      queue: [{ type: 'target', id: 'hero', confidence: 0.9 }],
+    });
+    const hearing = new QueueSensor({
+      id: 'hearing',
+      type: 'hearing',
+      queue: [{ type: 'sound', id: 'footstep', volume: 0.6 }],
+    });
+
+    const suite = new SensorSuite({
+      sensors: [vision, hearing],
+      aiCore: core,
+      entity: { id: 'entity-sensor-test' },
+      world: { threats: [] },
+    });
+
+    const aggregated = suite.update(0.5, {
+      world: { threats: ['hero'] },
+      aiCore: core,
+    });
+
+    assert.strictEqual(aggregated.length, 2);
+    assert.strictEqual(aggregated[0].sensorId, 'vision');
+    assert.strictEqual(aggregated[1].sensorId, 'hearing');
+    assert.strictEqual(stimuliEvents.length, 1);
+    assert.strictEqual(stimuliEvents[0].stimuli.length, 2);
+    assert.strictEqual(stimuliEvents[0].meta.entity.id, 'entity-sensor-test');
+  });
+
+  it('relays tactical point ability usage through shared events', () => {
+    core.initialize();
+    core.attachToEntity({ id: 'entity-tactical-test' });
+
+    const abilityEvents = [];
+    core.events.on('ability:spent', (payload) => abilityEvents.push(payload));
+
+    const engine = new TacticalPointEngine({
+      initialPoints: 10,
+      events: core.events,
+    });
+    engine.registerAbility('howl', { cost: 4 });
+
+    assert.strictEqual(engine.points, 10);
+    assert.strictEqual(engine.spendForAbility('howl', { context: { entityId: 'entity-tactical-test' } }), true);
+    assert.strictEqual(engine.points, 6);
+    assert.strictEqual(abilityEvents.length, 1);
+    assert.strictEqual(abilityEvents[0].ability.name, 'howl');
+    assert.strictEqual(abilityEvents[0].context.entityId, 'entity-tactical-test');
+  });
+});

--- a/three-demo/src/entities/ai/__tests__/spectral-runner.integration.test.js
+++ b/three-demo/src/entities/ai/__tests__/spectral-runner.integration.test.js
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { MobAICore } from '../mob-ai-core.js';
+import { BehaviorRegistry } from '../behavior-nodes.js';
+import { spectralRunnerPersona } from '../personas/spectral-runner.js';
+import { AIPresentationAdapter } from '../presentation/presentation-adapter.js';
+import { TacticalPointEngine } from '../combat/tactical-point-engine.js';
+
+describe('Spectral Runner integration', () => {
+  it('emits animation intents across a chase sequence', () => {
+    const core = new MobAICore({
+      random: () => 0,
+      behaviorRegistry: new BehaviorRegistry(),
+    });
+    core.registerPersona(spectralRunnerPersona);
+    core.usePersona('spectral-runner');
+
+    const animationCalls = [];
+    const animationController = {
+      playVariant(variant, options = {}) {
+        animationCalls.push({ variant, options });
+      },
+      stop() {},
+    };
+
+    const adapter = new AIPresentationAdapter({
+      ai: core.events,
+      animationController,
+      personaConfig: spectralRunnerPersona.metadata.presentation,
+    });
+
+    const transitions = [];
+    core.useBehaviorLoop('idle', {
+      priority: 5,
+      onStateChange: ({ state, previousState, loop }) => {
+        if (previousState && previousState !== state) {
+          core.emit('behavior:stateExit', {
+            behavior: loop.name,
+            state: previousState,
+            nextState: state,
+          });
+        }
+        core.emit('behavior:stateEnter', {
+          behavior: loop.name,
+          state,
+          previousState,
+        });
+        transitions.push(state);
+      },
+      shouldWander: (context) => Boolean(context.flags?.wander),
+      canSeeTarget: (context) => Boolean(context.percepts?.targetVisible),
+      lostTarget: (context) => !context.percepts?.targetVisible,
+    });
+
+    core.initialize({
+      flags: { wander: false },
+      percepts: { targetVisible: false },
+      environment: { lightLevel: 0.55 },
+    });
+    core.attachToEntity({ id: 'spectral-runner-entity' });
+
+    assert.deepStrictEqual(transitions, ['idle']);
+    assert.strictEqual(animationCalls.length, 1);
+    assert.strictEqual(animationCalls[0].variant, 'idle');
+    assert.strictEqual(animationCalls[0].options.fadeDuration, 0.35);
+
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: false } });
+    core.update(1, { flags: { wander: true }, percepts: { targetVisible: true } });
+    core.update(1, { flags: { wander: false }, percepts: { targetVisible: false } });
+
+    assert.deepStrictEqual(transitions, ['idle', 'wander', 'chase', 'idle']);
+    assert.deepStrictEqual(
+      animationCalls.map((entry) => entry.variant),
+      ['idle', 'runner', 'runner', 'idle'],
+    );
+    assert.deepStrictEqual(
+      animationCalls.slice(0, 4).map((entry) => Number(entry.options.fadeDuration.toFixed(2))),
+      [0.35, 0.2, 0.15, 0.35],
+    );
+
+    const engine = new TacticalPointEngine({
+      initialPoints: 10,
+      events: core.events,
+    });
+    engine.registerAbility('howl', { cost: 4 });
+
+    assert.strictEqual(engine.spendForAbility('howl', { context: { entityId: 'spectral-runner-entity' } }), true);
+    const lastCall = animationCalls.at(-1);
+    assert.strictEqual(lastCall.variant, 'howl');
+    assert.strictEqual(lastCall.options.fadeDuration, 0);
+
+    adapter.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- add a MobAICore transition flow suite that exercises persona loading, sensor fusion, and tactical point events
- add a spectral runner integration test that drives behavior ticks and verifies emitted animation intents
- document how to run the new node test suites and mock THREE dependencies in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df49054ff4832a89e7652d11a825d1