### PR TITLE
Add mob AI core documentation and sensor JSDoc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ The Vite demo is the recommended way to iterate on the experience:
 
 - Run `npm test` from the `three-demo/` workspace to execute the Node.js test runner (`node --test`). The suite exercises the AI modules under `three-demo/src/entities/ai/__tests__/`, including the new `mob-ai-core.transition-flow.test.js` and `spectral-runner.integration.test.js` coverage for behavior transitions, sensor fusion, and tactical point coordination.
 - The integration tests emit animation intents by sharing the `MobAICore` event bus with the `AIPresentationAdapter`. When adding additional cases that touch `THREE` APIs (e.g., the animation controller), provide lightweight mocks instead of the real library—for example, stub the required mixer methods or constants such as `LoopOnce`.
+- Read the [Mob AI Core Guide](three-demo/docs/mob-ai-core.md) for a deeper look at the ghost runner architecture, configuration schema, sensor presets, and extension workflows.
+
+### Ghost Runner AI Core quick start
+
+1. Ensure entity definitions are registered via `registerBuiltinEntities()` (the Vite bootstrap already calls this for you).
+2. Spawn the runner with the entity manager: `manager.spawnEntity('crowned_ghost_2', { position: { x: 12, y: 18, z: -6 } })`.
+3. Pass optional `behavior` overrides when spawning to tweak movement (for example, `{ walkSpeed: 1.1, walkDurationRange: [2, 5] }`).
+4. The entity wires its `MobAICore` automatically; consult the [guide](three-demo/docs/mob-ai-core.md#ghost-runner-quick-start) for diagrams, persona overrides, and presentation notes.
 
 ## World Configuration
 

--- a/WORLD_CONFIGURATION.md
+++ b/WORLD_CONFIGURATION.md
@@ -2,6 +2,22 @@
 
 This reference aggregates every tunable world-generation option exposed by the voxel sandbox. Labels, descriptions, defaults, and ranges originate from `three-demo/src/world/world-option-descriptors.js`, which the runtime also uses to clamp override values. Use these details when experimenting with terrain, biome, and environmental parameters.
 
+## Mob AI Core integration
+
+- The crowned ghost runner uses the shared AI systems documented in the [Mob AI Core Guide](three-demo/docs/mob-ai-core.md). Review that document for architecture diagrams, persona schemas, and extension workflows.
+- To see the AI in action within a configured world, register builtin entities and spawn the runner via the entity manager:
+  ```js
+  import { registerBuiltinEntities, createEntityManager } from './entities/index.js';
+
+  registerBuiltinEntities();
+  const manager = await createEntityManager({ /* world handles */ });
+  manager.spawnEntity('crowned_ghost_2', {
+    position: { x: 12, y: 18, z: -6 },
+    behavior: { walkSpeed: 1.05 },
+  });
+  ```
+- Behavior modifiers such as walk speed or idle durations can be overridden through the `behavior` object passed at spawn time—this approach keeps world option descriptors focused on terrain while still letting you tune the ghost runner per world preset.
+
 ## Option Reference
 
 ### Seed

--- a/three-demo/docs/mob-ai-core.md
+++ b/three-demo/docs/mob-ai-core.md
@@ -1,0 +1,184 @@
+# Mob AI Core Guide
+
+The crowned ghost runner uses a modular AI core that layers personas, traits, sensors, and behavior schedulers on top of the shared entity framework. This guide documents the modules that participate in that stack, the configuration schema each layer consumes, and the workflows for extending the system.
+
+## Architecture layers
+
+The runtime separates responsibilities into discrete layers so you can swap or augment pieces without rewriting the entire AI loop:
+
+1. **Resource & trait bootstrap** – `MobAICore` collects trait definitions (`three-demo/src/entities/ai/traits/`) and instantiates a `ResourcePool` for the persona's stamina, energy, and custom meters.
+2. **Perception** – `SensorSuite` aggregates individual `MobSensor` subclasses (vision cones, proximity rings, thresholds) and rebroadcasts stimuli on the AI event bus.
+3. **Context synthesis** – Persona definitions merge their sensor presets, resource defaults, and metadata into the AI context so downstream behaviors share a consistent snapshot.
+4. **Behavior scheduling** – The `BehaviorScheduler` orders behavior-tree loops created by the `BehaviorRegistry`, while the `AmbientTaskScheduler` queues low-priority tasks like patrol refreshes or coordination signals.
+5. **Presentation bridge** – Entities such as `CrownedGhostRunnerEntity` attach `AIPresentationAdapter` instances that translate scheduler state changes into animation intents.
+
+```mermaid
+flowchart LR
+  Entity -->|configure| SensorSuite
+  SensorSuite -->|stimuli| MobAICore
+  MobAICore -->|context| BehaviorScheduler
+  MobAICore -->|resources| ResourcePool
+  BehaviorScheduler -->|state changes| AmbientTaskScheduler
+  BehaviorScheduler -->|events| PresentationAdapter
+```
+
+## Module map
+
+| Concern | Module | Notes |
+| --- | --- | --- |
+| AI root | `three-demo/src/entities/ai/mob-ai-core.js` | Coordinates personas, behaviors, events, and resource state. |
+| Traits | `three-demo/src/entities/ai/traits/` | Trait definitions invoked when personas are activated. |
+| Personas | `three-demo/src/entities/ai/personas/` | Bundles traits, sensors, resources, behavior layers, and metadata. |
+| Sensors | `three-demo/src/entities/ai/sensors/` | Base `MobSensor` plus cone, ring, and threshold specializations. |
+| Resources | `three-demo/src/entities/ai/resources/resource-pool.js` | Emits change events as pools regen, deplete, or refill. |
+| Ambient tasks | `three-demo/src/entities/ai/environment/ambient-task-scheduler.js` | Handles staggered background jobs (e.g., scouting pings). |
+| Presentation | `three-demo/src/entities/ai/presentation/` | Maps behavior events to animation cues. |
+| Tests | `three-demo/src/entities/ai/__tests__/` | Integration and contract coverage for the full stack. |
+
+## Persona configuration schema
+
+Persona descriptors provide the glue between raw configuration data and runtime modules. The schema below matches `spectral-runner`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Unique identifier used when calling `usePersona`. |
+| `traits` | `Array<string | TraitRef>` | Each entry references a trait definition. Object entries accept `options`. |
+| `sensors` | `object` | Merged into the AI context (`presets`, `visionRange`, `hearingRange`, etc.). |
+| `resources` | `Record<string, ResourceConfig>` | Seed values for the `ResourcePool` (supports `max`, `initial/current`, `regen`, `metadata`). |
+| `behaviors` | `Array<BehaviorDescriptor>` | Behavior loop descriptors consumed by the `BehaviorRegistry`. |
+| `metadata` | `object` | Arbitrary values; ghost runner uses this for movement tuning and presentation defaults. |
+
+`BehaviorDescriptor` entries mirror the tests in `mob-ai-core.transition-flow.test.js`:
+
+```ts
+interface BehaviorDescriptor {
+  name?: string;        // Defaults to the loop name
+  loop: string;         // Name registered with BehaviorRegistry
+  priority?: number;    // Higher values run earlier each tick
+  duration?: { min: number; max: number; unit: 'seconds' | 'ticks' };
+  triggers?: Array<{ type: 'time' | 'percept' | string; [key: string]: unknown }>;
+  options?: Record<string, unknown>; // Forwarded to the loop factory
+  metadata?: Record<string, unknown>; // Stored on the behavior layer
+}
+```
+
+## Example personas and behaviors
+
+The ghost runner persona ships with high-agility defaults, but you can author variants by registering a new descriptor or by overriding fields when calling `usePersona`:
+
+```js
+import { MobAICore } from '../entities/ai/mob-ai-core.js';
+
+const ai = new MobAICore();
+ai.registerPersona('mist-sprinter', {
+  inherits: 'spectral-runner',
+  traits: [
+    { name: 'nocturnal', options: { lightThreshold: 0.6 } },
+    { name: 'packHunter', options: { minAllies: 2, formation: 'flank' } },
+  ],
+  sensors: { visionRange: 55, presets: ['spectral-vision', 'echo-location'] },
+  resources: {
+    stamina: { max: 150, regen: 8 },
+    ectoplasm: { max: 60, regen: 6 },
+  },
+  behaviors: [
+    { name: 'mist-scout', loop: 'idle', priority: 3, options: { wanderChance: 0.6 } },
+    { name: 'mist-chase', loop: 'chase', priority: 9, triggers: [{ type: 'percept', key: 'targetVisible', equals: true }] },
+  ],
+});
+
+const persona = ai.usePersona('mist-sprinter', {
+  sensors: { hearingRange: 140 },
+  metadata: { movement: { walkSpeed: 1.15, turnInPlaceDuration: 0.9 } },
+});
+```
+
+When the persona is installed the AI core automatically merges the sensor ranges, rehydrates resource pools, and installs the `BehaviorScheduler` layers.
+
+To attach a behavior loop without replacing the persona defaults:
+
+```js
+const patrolLoop = ai.useBehaviorLoop('idle', {
+  priority: 2,
+  wanderChance: 0.35,
+  idleChance: 0.15,
+});
+```
+
+## Perception cone reference
+
+The vision sensor performs a geometric test between the entity's forward vector and each candidate target. The diagram below illustrates the sample workflow.
+
+```mermaid
+flowchart TB
+  A[Entity origin] -->|forward vector| B((Cone axis))
+  subgraph Detection
+    B --> C{Angle <= halfAngle?}
+    C -- yes --> D[Distance <= range]
+    D --> E{Occluded?}
+    E -- no --> F[Emit stimulus]
+    E -- yes --> G[Discard target]
+  end
+```
+
+## Task scheduling timeline
+
+Ambient tasks and behavior loops share the same update cadence but run in priority order. Use this timeline when balancing new loops:
+
+```mermaid
+gantt
+  title Ghost Runner Scheduling
+  dateFormat  X
+  axisFormat  %L
+  section Tick 0
+  Ambient cooldown     :done, 0, 1
+  Vision sampling      :active, 0, 1
+  Behavior (idle loop) :done, 0, 1
+  section Tick 1
+  Ambient cooldown     :active, 1, 1
+  Task handoff         :done, 1, 1
+  Behavior (wander)    :active, 1, 1
+  section Tick 2
+  Ambient broadcast    :done, 2, 1
+  Task resolution      :done, 2, 1
+  Behavior (chase)     :active, 2, 1
+```
+
+## Extension workflows
+
+### Add a new sensor
+1. Subclass `MobSensor` in `three-demo/src/entities/ai/sensors/` and implement `sampleWorld(context)`.
+2. Register the sensor in a suite (e.g., from the entity's `onSpawn` hook) and optionally add a preset string so personas can pull it in automatically.
+3. Emit structured stimuli (`{ intensity, target, position, ... }`) so downstream behaviors can reason about the payload.
+
+### Add a new trait
+1. Create a trait definition in `three-demo/src/entities/ai/traits/` that exports `{ name, apply(core, options) }`.
+2. Register it via `MobAICore.registerTrait(name, trait)` or include it in `defaultTraits`.
+3. Reference the trait from persona descriptors or call `core._activateTrait` manually during bootstrap (tests cover this private helper).
+
+### Add a new behavior loop
+1. Extend `BehaviorRegistry` with `registerLoop(name, factory)` or reuse the helper loops already exported.
+2. Reference the loop from a persona `behaviors` entry or call `aiCore.useBehaviorLoop(name, options)` at runtime.
+3. Provide metadata for the presentation adapter if the loop maps to a new animation state.
+
+## Ghost runner quick start
+
+1. Ensure entities are registered (Vite bootstrapping already calls `registerBuiltinEntities()` inside `three-demo/src/entities/index.js`).
+2. Acquire the entity manager (for example from `initializeWorld` or the developer console) and spawn the runner:
+   ```js
+   import { registerBuiltinEntities, createEntityManager } from './entities/index.js';
+
+   registerBuiltinEntities();
+   const manager = await createEntityManager({ /* world references */ });
+   const ghost = manager.spawnEntity('crowned_ghost_2', {
+     position: { x: 12, y: 18, z: -6 },
+     behavior: { walkSpeed: 1.1, walkDurationRange: [2, 5] },
+   });
+   ```
+3. The `CrownedGhostRunnerEntity` constructor creates a `MobAICore`, applies the `spectral-runner` persona, and hooks the presentation adapter automatically. Overriding the `behavior` key lets you tweak movement defaults without editing the persona.
+4. Call `ghost.aiCore.update(deltaSeconds, { world: worldContext })` within your entity tick to keep the scheduler active. The entity class already does this during its update loop, so manual calls are only needed in bespoke simulations.
+
+## Additional references
+
+- Review `three-demo/src/entities/ai/__tests__/spectral-runner.integration.test.js` for an end-to-end example that exercises sensor fusion and resource spending.
+- `three-demo/src/entities/crowned-ghost-runner.js` demonstrates how to bridge AI output with movement controllers and animation playback.

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -138,7 +138,24 @@ class BehaviorScheduler {
   }
 }
 
+/**
+ * Coordinates persona traits, resource pools, sensor presets, and prioritized behavior loops
+ * for an AI-driven entity. The core exposes an event bus so presentation adapters, tests,
+ * and gameplay systems can observe lifecycle hooks without reaching into private state.
+ */
 export class MobAICore {
+  /**
+   * @param {Object} [options]
+   * @param {() => number} [options.random=Math.random] - RNG used for stochastic behaviors.
+   * @param {import('../../world/chunk-manager.js').ChunkManager|null} [options.chunkManager]
+   *   Optional chunk manager reference forwarded to personas and behavior loops.
+   * @param {Object|null} [options.audioManager] - Optional audio facade for traits that emit SFX.
+   * @param {BehaviorRegistry} [options.behaviorRegistry] - Registry that instantiates named behavior loops.
+   * @param {PersonaRegistry} [options.personaRegistry] - Registry of persona descriptors.
+   * @param {Array<Object>} [options.traitDefinitions=defaultTraits] - Traits installed during construction.
+   * @param {AmbientTaskScheduler|null} [options.ambientScheduler] - Scheduler for background AI jobs.
+   * @param {EventEmitter} [options.events] - Shared event emitter so callers can subscribe externally.
+   */
   constructor(options = {}) {
     const {
       random = Math.random,
@@ -179,6 +196,12 @@ export class MobAICore {
     });
   }
 
+  /**
+   * Registers a persona descriptor with the internal registry.
+   * @param {string|Object} name - Persona identifier or full descriptor object.
+   * @param {Object} [definition] - Descriptor body if `name` is provided separately.
+   * @returns {Object} The normalized persona definition registered with the registry.
+   */
   registerPersona(name, definition) {
     if (typeof name === 'object') {
       return this.personaRegistry.register(name);
@@ -189,6 +212,12 @@ export class MobAICore {
     return this.personaRegistry.register({ ...definition, name });
   }
 
+  /**
+   * Applies the requested persona and merges optional overrides before syncing the AI context.
+   * @param {string|Object} reference - Persona name or partial descriptor accepted by the registry.
+   * @param {Object} [overrides] - Optional overrides merged with the resolved persona definition.
+   * @returns {Object} The persona instance currently applied to the core.
+   */
   usePersona(reference, overrides = {}) {
     const persona = this.personaRegistry.create(reference, overrides);
     const previousPersona = this.currentPersona;
@@ -318,6 +347,11 @@ export class MobAICore {
     this.context.activeTraits = new Set(this.activeTraitHandles.keys());
   }
 
+  /**
+   * Adds a behavior node to the prioritized scheduler and initializes it when the core is ready.
+   * @param {{ name: string, node: Object, priority?: number }} options
+   * @returns {Object} The behavior node that was registered.
+   */
   addBehaviorLayer({ name, node, priority = 0 }) {
     this.scheduler.addLayer({ name, node, priority });
     if (this.initialized && this.context) {
@@ -329,12 +363,24 @@ export class MobAICore {
     return node;
   }
 
+  /**
+   * Instantiates a loop from the behavior registry and schedules it automatically.
+   * @param {string} loopName - Registered loop identifier.
+   * @param {Object} [options] - Options forwarded to the loop factory.
+   * @returns {Object} The behavior loop instance produced by the registry.
+   */
   useBehaviorLoop(loopName, options = {}) {
     const loop = this.behaviorRegistry.createLoop(loopName, options, this.dependencies);
     this.addBehaviorLayer({ name: loop.name, node: loop, priority: options.priority ?? 0 });
     return loop;
   }
 
+  /**
+   * Initializes the AI context, rehydrating persona resources and wiring schedulers.
+   * Subsequent calls merge new context data without resetting active traits.
+   * @param {Object} [initialContext]
+   * @returns {Object} The live AI context.
+   */
   initialize(initialContext = {}) {
     if (this.initialized) {
       Object.assign(this.context, initialContext);
@@ -374,6 +420,11 @@ export class MobAICore {
     return this.context;
   }
 
+  /**
+   * Associates an entity with the AI context and forwards the attachment to all behavior layers.
+   * @param {Object} entity - Entity facade exposing position, navigation, etc.
+   * @returns {Object} The entity provided for chaining.
+   */
   attachToEntity(entity) {
     if (!this.initialized) {
       this.initialize();
@@ -383,6 +434,11 @@ export class MobAICore {
     return entity;
   }
 
+  /**
+   * Advances the AI state machine by `delta` seconds, ticking ambient tasks and behavior layers.
+   * @param {number} delta - Time step in seconds.
+   * @param {Object} [contextUpdates] - Partial context overrides applied before evaluation.
+   */
   update(delta, contextUpdates = {}) {
     if (!this.initialized) {
       throw new Error('MobAICore must be initialized before update.');
@@ -397,21 +453,45 @@ export class MobAICore {
     this.emit('afterUpdate', this.context);
   }
 
+  /**
+   * Registers an event listener on the shared AI event bus.
+   * @param {string|symbol} eventName - Event identifier.
+   * @param {(...args: any[]) => void} listener - Callback invoked when the event fires.
+   * @returns {MobAICore} Fluent reference to the core.
+   */
   on(eventName, listener) {
     this.events.on(eventName, listener);
     return this;
   }
 
+  /**
+   * Registers a listener that is removed after its first invocation.
+   * @param {string|symbol} eventName - Event identifier.
+   * @param {(...args: any[]) => void} listener - Callback invoked once.
+   * @returns {MobAICore}
+   */
   once(eventName, listener) {
     this.events.once(eventName, listener);
     return this;
   }
 
+  /**
+   * Removes a previously registered listener from the event bus.
+   * @param {string|symbol} eventName - Event identifier.
+   * @param {(...args: any[]) => void} listener - Callback to remove.
+   * @returns {MobAICore}
+   */
   off(eventName, listener) {
     this.events.off(eventName, listener);
     return this;
   }
 
+  /**
+   * Emits an event to local listeners and any shared emitter the core was initialized with.
+   * @param {string|symbol} eventName - Event identifier.
+   * @param {...any} args - Payload forwarded to listeners.
+   * @returns {MobAICore}
+   */
   emit(eventName, ...args) {
     this.events.emit(eventName, ...args);
     return this;

--- a/three-demo/src/entities/ai/resources/resource-pool.js
+++ b/three-demo/src/entities/ai/resources/resource-pool.js
@@ -56,7 +56,15 @@ const normalizeResourceConfig = (name, config = {}) => {
   };
 };
 
+/**
+ * Tracks consumable and regenerating resources for AI personas while broadcasting
+ * change events so behaviors and traits can respond to depletion or restoration.
+ */
 export class ResourcePool {
+  /**
+   * @param {Record<string, number|Object>} [definitions] - Initial resource descriptors keyed by name.
+   * @param {{ events?: EventEmitter }} [options] - Optional shared event emitter.
+   */
   constructor(definitions = {}, { events } = {}) {
     this.resources = new Map();
     this.events = events ?? new EventEmitter();
@@ -66,6 +74,12 @@ export class ResourcePool {
     }
   }
 
+  /**
+   * Normalizes and stores a resource entry, emitting create/update events as needed.
+   * @param {string} name - Resource identifier.
+   * @param {number|Object} [config] - Max/current/regen metadata or shorthand numeric max.
+   * @returns {{ name: string, max?: number, current: number, regen: number, metadata: any }}
+   */
   defineResource(name, config = {}) {
     if (!name || typeof name !== 'string') {
       throw new Error('Resource names must be non-empty strings.');
@@ -91,18 +105,38 @@ export class ResourcePool {
     return entry;
   }
 
+  /**
+   * Checks whether the pool contains a resource with the provided name.
+   * @param {string} name
+   * @returns {boolean}
+   */
   has(name) {
     return this.resources.has(name);
   }
 
+  /**
+   * Retrieves the raw resource entry, or `null` when the entry is missing.
+   * @param {string} name
+   * @returns {{ name: string, max?: number, current: number, regen: number, metadata: any }|null}
+   */
   get(name) {
     return this.resources.get(name) ?? null;
   }
 
+  /**
+   * Convenience wrapper that returns only the current value.
+   * @param {string} name
+   * @returns {number|null}
+   */
   getCurrent(name) {
     return this.get(name)?.current ?? null;
   }
 
+  /**
+   * Advances regeneration for every resource that defines a non-zero `regen` rate.
+   * @param {number} deltaSeconds - Simulation delta in seconds.
+   * @param {{ reason?: string, context?: any }} [options] - Metadata broadcast with change events.
+   */
   tick(deltaSeconds, { reason = 'regen', context } = {}) {
     if (!isFiniteNumber(deltaSeconds) || deltaSeconds <= 0) {
       return;
@@ -131,6 +165,13 @@ export class ResourcePool {
     }
   }
 
+  /**
+   * Attempts to spend a resource amount, optionally allowing partial spends.
+   * @param {string} name - Resource identifier.
+   * @param {number} amount - Amount to consume.
+   * @param {{ allowPartial?: boolean, reason?: string, context?: any }} [options]
+   * @returns {number} Quantity successfully consumed.
+   */
   consume(name, amount, { allowPartial = false, reason = 'consume', context } = {}) {
     const entry = this.get(name);
     if (!entry) {
@@ -167,6 +208,13 @@ export class ResourcePool {
     return spent;
   }
 
+  /**
+   * Restores a resource by the provided amount, clamped by its max (if defined).
+   * @param {string} name - Resource identifier.
+   * @param {number} amount - Amount to restore.
+   * @param {{ reason?: string, context?: any }} [options]
+   * @returns {number} Net change applied to the resource.
+   */
   restore(name, amount, { reason = 'restore', context } = {}) {
     const entry = this.get(name);
     if (!entry) {
@@ -196,6 +244,13 @@ export class ResourcePool {
     return entry.current - previous;
   }
 
+  /**
+   * Assigns an explicit value to the resource, respecting its configured max/min bounds.
+   * @param {string} name - Resource identifier.
+   * @param {number} value - Target current value.
+   * @param {{ reason?: string, context?: any }} [options]
+   * @returns {number} The previous resource value.
+   */
   setCurrent(name, value, { reason = 'set', context } = {}) {
     const entry = this.get(name);
     if (!entry) {

--- a/three-demo/src/entities/ai/sensors/cone-vision-sensor.js
+++ b/three-demo/src/entities/ai/sensors/cone-vision-sensor.js
@@ -15,7 +15,27 @@ const cloneVector3 = (value) => {
   return new Vector3(value.x ?? 0, value.y ?? 0, value.z ?? 0);
 };
 
+/**
+ * Samples targets inside a configurable field-of-view cone and emits detections
+ * enriched with distance, direction, and angular offsets relative to the entity.
+ */
 export class ConeVisionSensor extends MobSensor {
+  /**
+   * @param {{
+   *   id?: string,
+   *   interval?: number,
+   *   range?: number,
+   *   angle?: number,
+   *   label?: string,
+   *   queryTargets?: Function,
+   *   getOrigin?: Function,
+   *   getForward?: Function,
+   *   getTargetPosition?: Function,
+   *   filterTarget?: Function|null,
+   *   isOccluded?: Function|null,
+   *   decay?: Function
+   * }} [options]
+   */
   constructor(options = {}) {
     const {
       id = 'cone-vision',
@@ -41,6 +61,10 @@ export class ConeVisionSensor extends MobSensor {
       (({ distance, range }) => Math.max(0, 1 - distance / Math.max(range, 1)));
   }
 
+  /**
+   * @param {{ world: any, entity: any, time: number, delta: number }} context
+   * @returns {Array<Object>} Stimuli representing visible targets.
+   */
   sampleWorld(context) {
     const { world, entity, time, delta } = context;
     if (!entity || !this.range || this.range <= 0) {

--- a/three-demo/src/entities/ai/sensors/mob-sensor.js
+++ b/three-demo/src/entities/ai/sensors/mob-sensor.js
@@ -1,6 +1,20 @@
 import { EventEmitter } from 'node:events';
 
+/**
+ * Base class for AI perception sensors. Subclasses emit structured stimuli by
+ * implementing `sampleWorld`, while the base class handles cadence, wiring, and
+ * metadata enrichment.
+ */
 export class MobSensor {
+  /**
+   * @param {{
+   *   id?: string,
+   *   type?: string,
+   *   label?: string,
+   *   interval?: number,
+   *   enabled?: boolean
+   * }} [options]
+   */
   constructor(options = {}) {
     const {
       id = null,
@@ -39,6 +53,11 @@ export class MobSensor {
     this._emitter.emit(eventName, ...args);
   }
 
+  /**
+   * Configures runtime references the sensor requires to function.
+   * @param {{ entity?: any, world?: any, onEmit?: Function }} [configuration]
+   * @returns {MobSensor}
+   */
   configure(configuration = {}) {
     const { entity, world, onEmit } = configuration;
     let reconfigured = false;
@@ -60,11 +79,21 @@ export class MobSensor {
     return this;
   }
 
+  /**
+   * Toggles whether the sensor should emit stimuli during updates.
+   * @param {boolean} enabled
+   * @returns {MobSensor}
+   */
   setEnabled(enabled) {
     this.enabled = Boolean(enabled);
     return this;
   }
 
+  /**
+   * Determines if the sensor should sample based on its interval and enabled state.
+   * @param {number} time - Current simulation timestamp.
+   * @returns {boolean}
+   */
   shouldSample(time) {
     if (!this.enabled) {
       return false;
@@ -75,6 +104,11 @@ export class MobSensor {
     return time - this._lastSampleTime >= this.interval;
   }
 
+  /**
+   * Runs the sampling pipeline and emits any detected stimuli.
+   * @param {{ time?: number, delta?: number, world?: any, entity?: any }} [context]
+   * @returns {Array<Object>} Stimuli emitted during the update.
+   */
   update(context = {}) {
     const { time = 0, delta = 0, world = this.world } = context;
     if (!this.shouldSample(time)) {
@@ -90,12 +124,22 @@ export class MobSensor {
     return this.emitStimuli(stimuli, { time, delta, world });
   }
 
+  /**
+   * Subclasses must implement this to return a stimulus or array of stimuli.
+   * @abstract
+   */
   sampleWorld() {
     throw new Error(
       `${this.constructor.name} must implement sampleWorld(context)`,
     );
   }
 
+  /**
+   * Normalizes raw stimuli and forwards them to listeners.
+   * @param {Object|Array<Object>} stimuli
+   * @param {{ time?: number, delta?: number, world?: any }} [meta]
+   * @returns {Array<Object>} Enriched stimuli payloads.
+   */
   emitStimuli(stimuli, meta = {}) {
     if (!stimuli) {
       return [];

--- a/three-demo/src/entities/ai/sensors/ring-proximity-sensor.js
+++ b/three-demo/src/entities/ai/sensors/ring-proximity-sensor.js
@@ -14,7 +14,24 @@ const cloneVector3 = (value) => {
   return new Vector3(value.x ?? 0, value.y ?? 0, value.z ?? 0);
 };
 
+/**
+ * Emits stimuli when targets fall within an annular detection region around the entity.
+ */
 export class RingProximitySensor extends MobSensor {
+  /**
+   * @param {{
+   *   id?: string,
+   *   interval?: number,
+   *   innerRadius?: number,
+   *   outerRadius?: number,
+   *   label?: string,
+   *   queryTargets?: Function,
+   *   getOrigin?: Function,
+   *   getTargetPosition?: Function,
+   *   filterTarget?: Function|null,
+   *   decay?: Function
+   * }} [options]
+   */
   constructor(options = {}) {
     const {
       id = 'ring-proximity',
@@ -53,6 +70,10 @@ export class RingProximitySensor extends MobSensor {
       });
   }
 
+  /**
+   * @param {{ world: any, entity: any, time: number, delta: number }} context
+   * @returns {Array<Object>} Stimuli representing nearby targets.
+   */
   sampleWorld(context) {
     const { world, entity, time, delta } = context;
     if (!entity) {

--- a/three-demo/src/entities/ai/sensors/sensor-suite.js
+++ b/three-demo/src/entities/ai/sensors/sensor-suite.js
@@ -1,7 +1,14 @@
 import { EventEmitter } from 'node:events';
 import { MobSensor } from './mob-sensor.js';
 
+/**
+ * Maintains a collection of sensors for a single entity and proxies emitted
+ * stimuli to both local listeners and the owning AI core.
+ */
 export class SensorSuite extends EventEmitter {
+  /**
+   * @param {{ sensors?: MobSensor[], entity?: any, world?: any, aiCore?: any, time?: number }} [options]
+   */
   constructor(options = {}) {
     super();
     const { sensors = [], time = 0 } = options;
@@ -15,6 +22,11 @@ export class SensorSuite extends EventEmitter {
     sensors.forEach((sensor) => this.addSensor(sensor));
   }
 
+  /**
+   * Registers a sensor instance and configures it if the suite is already bound.
+   * @param {MobSensor} sensor
+   * @returns {MobSensor}
+   */
   addSensor(sensor) {
     if (!(sensor instanceof MobSensor)) {
       throw new Error('SensorSuite expects sensors to extend MobSensor.');
@@ -29,6 +41,11 @@ export class SensorSuite extends EventEmitter {
     return sensor;
   }
 
+  /**
+   * Removes a sensor by id.
+   * @param {string} id
+   * @returns {MobSensor|null}
+   */
   removeSensor(id) {
     const sensor = this.sensors.get(id);
     if (sensor) {
@@ -37,6 +54,11 @@ export class SensorSuite extends EventEmitter {
     return sensor;
   }
 
+  /**
+   * Updates the shared entity/world references used by every sensor in the suite.
+   * @param {{ entity?: any, world?: any, aiCore?: any }} [configuration]
+   * @returns {SensorSuite}
+   */
   configure(configuration = {}) {
     const { entity, world, aiCore } = configuration;
     if (entity !== undefined) {
@@ -56,6 +78,12 @@ export class SensorSuite extends EventEmitter {
     return this;
   }
 
+  /**
+   * Advances all registered sensors and emits aggregated stimuli.
+   * @param {number} [delta=0]
+   * @param {{ entity?: any, world?: any, aiCore?: any }} [overrides]
+   * @returns {Array<Object>} Stimuli gathered during the update.
+   */
   update(delta = 0, overrides = {}) {
     if (overrides.entity !== undefined) {
       this.entity = overrides.entity;

--- a/three-demo/src/entities/ai/sensors/threshold-sensor.js
+++ b/three-demo/src/entities/ai/sensors/threshold-sensor.js
@@ -1,6 +1,21 @@
 import { MobSensor } from './mob-sensor.js';
 
+/**
+ * Emits a stimulus when a sampled scalar crosses a configured threshold.
+ */
 export class ThresholdSensor extends MobSensor {
+  /**
+   * @param {{
+   *   id?: string,
+   *   interval?: number,
+   *   threshold?: number,
+   *   onlyOnCrossing?: boolean,
+   *   label?: string,
+   *   getValue?: Function,
+   *   comparator?: Function,
+   *   intensityMapper?: Function
+   * }} [options]
+   */
   constructor(options = {}) {
     const {
       id = 'threshold',
@@ -24,6 +39,10 @@ export class ThresholdSensor extends MobSensor {
     this._above = false;
   }
 
+  /**
+   * @param {{ world: any, entity: any, time: number, delta: number }} context
+   * @returns {Array<Object>} Stimuli produced when the threshold condition is met.
+   */
   sampleWorld(context) {
     const { world, entity, time, delta } = context;
     const previousValue = this._lastValue;


### PR DESCRIPTION
## Summary
- add a detailed mob AI core guide covering architecture layers, configuration schemas, and ghost runner workflows
- reference the new guide from README and WORLD_CONFIGURATION, including quick-start steps for enabling the crowned ghost runner AI
- add JSDoc comments across MobAICore, sensors, and ResourcePool to improve IDE tooling hints

## Testing
- not run (documentation and typing updates only)


------
https://chatgpt.com/codex/tasks/task_e_68df4af0738c832abe97280772515aeb