### PR TITLE
Replace Node EventEmitter usage with browser-safe utility

### DIFF
--- a/three-demo/src/entities/ai/__tests__/presentation-adapter.test.js
+++ b/three-demo/src/entities/ai/__tests__/presentation-adapter.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 import {
   AIPresentationAdapter,
   DEFAULT_PRESENTATION_MAPPING,

--- a/three-demo/src/entities/ai/combat/tactical-point-engine.js
+++ b/three-demo/src/entities/ai/combat/tactical-point-engine.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 
 const isFiniteNumber = (value) => Number.isFinite(value);
 

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../utils/event-emitter.js';
 import { BehaviorRegistry } from './behavior-nodes.js';
 import { PersonaRegistry } from './personas/persona-registry.js';
 import { defaultTraits } from './traits/index.js';

--- a/three-demo/src/entities/ai/presentation/presentation-adapter.js
+++ b/three-demo/src/entities/ai/presentation/presentation-adapter.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 
 const EMPTY_CONFIG = Object.freeze({ states: {}, abilities: {} });
 

--- a/three-demo/src/entities/ai/resources/resource-pool.js
+++ b/three-demo/src/entities/ai/resources/resource-pool.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 
 const clamp = (value, min, max = Number.POSITIVE_INFINITY) => {
   if (Number.isFinite(max)) {

--- a/three-demo/src/entities/ai/resources/status-effect-manager.js
+++ b/three-demo/src/entities/ai/resources/status-effect-manager.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 
 const STACKING_BEHAVIORS = new Set(['refresh', 'replace', 'stack', 'ignore']);
 

--- a/three-demo/src/entities/ai/sensors/mob-sensor.js
+++ b/three-demo/src/entities/ai/sensors/mob-sensor.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 
 /**
  * Base class for AI perception sensors. Subclasses emit structured stimuli by

--- a/three-demo/src/entities/ai/sensors/sensor-suite.js
+++ b/three-demo/src/entities/ai/sensors/sensor-suite.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from '../../../utils/event-emitter.js';
 import { MobSensor } from './mob-sensor.js';
 
 /**

--- a/three-demo/src/utils/event-emitter.js
+++ b/three-demo/src/utils/event-emitter.js
@@ -1,0 +1,80 @@
+/**
+ * Minimal event emitter compatible with the subset of the Node.js EventEmitter API
+ * used across the AI systems. The implementation avoids Node-specific imports so
+ * it can be safely bundled for the browser.
+ */
+export class EventEmitter {
+  constructor() {
+    this._listeners = new Map();
+    this._onceWrappers = new Map();
+    this._onceReverse = new Map();
+  }
+
+  on(eventName, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('EventEmitter.on requires a listener function');
+    }
+    const bucket = this._listeners.get(eventName);
+    if (bucket) {
+      bucket.push(listener);
+    } else {
+      this._listeners.set(eventName, [listener]);
+    }
+    return this;
+  }
+
+  off(eventName, listener) {
+    const bucket = this._listeners.get(eventName);
+    if (!bucket) {
+      return this;
+    }
+
+    let target = listener;
+    if (this._onceWrappers.has(listener)) {
+      target = this._onceWrappers.get(listener);
+      this._onceWrappers.delete(listener);
+      this._onceReverse.delete(target);
+    } else if (this._onceReverse.has(listener)) {
+      const original = this._onceReverse.get(listener);
+      this._onceWrappers.delete(original);
+      this._onceReverse.delete(listener);
+    }
+
+    const index = bucket.indexOf(target);
+    if (index !== -1) {
+      bucket.splice(index, 1);
+    }
+    if (bucket.length === 0) {
+      this._listeners.delete(eventName);
+    }
+    return this;
+  }
+
+  once(eventName, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('EventEmitter.once requires a listener function');
+    }
+    const wrapped = (...args) => {
+      this.off(eventName, wrapped);
+      listener.apply(this, args);
+    };
+    this._onceWrappers.set(listener, wrapped);
+    this._onceReverse.set(wrapped, listener);
+    this.on(eventName, wrapped);
+    return this;
+  }
+
+  emit(eventName, ...args) {
+    const bucket = this._listeners.get(eventName);
+    if (!bucket || bucket.length === 0) {
+      return false;
+    }
+    const listeners = bucket.slice();
+    for (const listener of listeners) {
+      listener.apply(this, args);
+    }
+    return true;
+  }
+}
+
+export const createEventEmitter = () => new EventEmitter();


### PR DESCRIPTION
## Summary
- add a browser-safe EventEmitter utility that matches the on/off/once/emit API we use
- refactor AI runtime modules and presentation tests to import the shared emitter helper
- ensure both Node-based tests and the browser bundle rely on the same event emitter implementation

## Testing
- npm run build
- npm run dev -- --host 0.0.0.0 --port 4173 --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68dfe7152884832aadd8579762bd360d