### PR TITLE
Align crowned ghost forward basis with model yaw

### DIFF
--- a/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
+++ b/three-demo/src/entities/__tests__/crowned-ghost-runner.test.js
@@ -174,6 +174,19 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
     'runner variant should originate from the runner asset animations',
   );
 
+  const initialForward = entity.forward.clone();
+  const initialBasis = entity.getVisualForwardBasis(new THREE.Vector3());
+  assert.ok(
+    initialForward.angleTo(initialBasis) < 1e-6,
+    'entity.forward should match the mesh basis before updates',
+  );
+  const sensorContext = entity.getSensorContext();
+  assert.equal(
+    sensorContext.forward,
+    entity.forward,
+    'sensor context should surface the shared forward vector reference',
+  );
+
   assert.equal(StubAnimationController.instances.length, 1, 'should create one animation controller');
   const controller = StubAnimationController.instances[0];
 
@@ -223,6 +236,44 @@ test('CrownedGhostRunnerEntity alternates between idle and walk states with anim
   assert.ok(
     entity.root.position.distanceTo(walkStart) > 0.01,
     'walk update should move the entity forward with acceleration applied',
+  );
+  const worldForward = entity.getVisualForwardBasis(new THREE.Vector3());
+  assert.ok(
+    worldForward.angleTo(entity.forward) < 1e-6,
+    'entity.forward should stay aligned with the mesh orientation in world space',
+  );
+  const walkIntent = entity.buildMovementIntent('walk', {});
+  assert.ok(walkIntent.movement.vector.isVector3, 'walk intent should include a movement vector');
+  assert.ok(
+    walkIntent.movement.vector.angleTo(worldForward) < 1e-6,
+    'movement vector should align with the mesh-oriented forward basis',
+  );
+  assert.ok(
+    walkIntent.movement.forward?.isVector3,
+    'movement intent should expose a forward basis vector',
+  );
+  assert.ok(
+    walkIntent.movement.forward.angleTo(worldForward) < 1e-6,
+    'movement intent forward basis should match the mesh orientation',
+  );
+  assert.ok(
+    walkIntent.forward?.isVector3,
+    'top-level intent should share the entity forward vector',
+  );
+  assert.ok(
+    walkIntent.forward.angleTo(worldForward) < 1e-6,
+    'intent forward vector should align with the entity forward basis',
+  );
+  const expectedYaw = entity.normalizeAngle(entity.visualYawOffset + entity.getModelForwardYaw());
+  const idleIntent = entity.buildMovementIntent('idle', {});
+  assert.ok(
+    Math.abs(idleIntent.visualYawOffset - expectedYaw) < 1e-6,
+    'idle intent yaw offset should include the model forward yaw',
+  );
+  const turnIntent = entity.buildMovementIntent('turn', {});
+  assert.ok(
+    Math.abs(turnIntent.movement.visualYawOffset - expectedYaw) < 1e-6,
+    'turn intent yaw offset should include the model forward yaw',
   );
   const rootHeading = entity.root.rotation.y;
   const combinedVisualYaw = rootHeading + entity.visualRoot.rotation.y;

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -7,6 +7,8 @@ const RUNNER_MODEL_CONFIG = {
     '../models/entity_ghost_guy_1/entity_ghost_guy_1_runner.glb',
     import.meta.url,
   ).href,
+  // Aligns the GLB forward axis with the gameplay +Z basis unless overridden by a persona.
+  forwardYaw: Math.PI,
   animationMap: {
     runner: {
       Ghost_Guy_Runner_Idle: 'idle',
@@ -138,6 +140,9 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       ? movement.headingTurnSpeed
       : 6;
 
+    this.forward = new this.THREE.Vector3(0, 0, 1);
+    this.getVisualForwardBasis(this.forward);
+
     this.visualYawOffset = 0;
 
     this.idleBaseYaw = 0;
@@ -158,6 +163,8 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     ];
     this._scratchHeadingDirection = new this.THREE.Vector3();
     this._scratchHeadingSample = new this.THREE.Vector3();
+    this._scratchHeadingQuaternion = new this.THREE.Quaternion();
+    this._worldUp = new this.THREE.Vector3(0, 1, 0);
 
     this.behaviorTimer = {
       state: IDLE_STATE,
@@ -217,6 +224,7 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     return {
       chunkManager: this.chunkManager ?? null,
       terrainHeight: this.terrainHeight ?? null,
+      forward: this.forward ?? null,
     };
   }
 
@@ -300,24 +308,36 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
       return payload;
     }
 
+    const forwardYaw = this.getModelForwardYaw();
+
     if (state === WALK_STATE || state === TURN_STATE) {
       const targetAngle = Number.isFinite(this.targetHeadingAngle)
         ? this.targetHeadingAngle
         : this.headingAngle;
       const vector = this.buildHeadingVector(targetAngle);
+      const forwardVector = this.forward?.isVector3
+        ? this.forward.clone()
+        : vector.clone();
       payload.movement = {
         ...(payload.movement ?? {}),
         vector,
+        forward: forwardVector,
       };
       if (state === TURN_STATE) {
         if (!('visualYawOffset' in payload.movement)) {
-          payload.movement.visualYawOffset = this.visualYawOffset;
+          const offset = Number.isFinite(this.visualYawOffset) ? this.visualYawOffset : 0;
+          payload.movement.visualYawOffset = this.normalizeAngle(offset + forwardYaw);
         }
       }
     } else if (state === IDLE_STATE) {
       if (!('visualYawOffset' in payload)) {
-        payload.visualYawOffset = this.visualYawOffset;
+        const offset = Number.isFinite(this.visualYawOffset) ? this.visualYawOffset : 0;
+        payload.visualYawOffset = this.normalizeAngle(offset + forwardYaw);
       }
+    }
+
+    if (!('forward' in payload) && this.forward?.isVector3) {
+      payload.forward = this.forward.clone();
     }
 
     return payload;
@@ -325,7 +345,13 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
 
   buildHeadingVector(angle) {
     const resolved = Number.isFinite(angle) ? angle : 0;
-    const vector = new this.THREE.Vector3(Math.sin(resolved), 0, Math.cos(resolved));
+    const vector = new this.THREE.Vector3(0, 0, 1);
+    vector.applyQuaternion(this.getModelForwardQuaternion());
+    const headingQuaternion = this._scratchHeadingQuaternion.setFromAxisAngle(
+      this._worldUp,
+      resolved,
+    );
+    vector.applyQuaternion(headingQuaternion);
     return vector.normalize();
   }
 
@@ -565,6 +591,10 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.headingAngle = normalized;
     this.heading.set(Math.sin(normalized), 0, Math.cos(normalized)).normalize();
     this.root.rotation.y = normalized;
+    if (!this.forward) {
+      this.forward = new this.THREE.Vector3(0, 0, 1);
+    }
+    this.getVisualForwardBasis(this.forward);
     if (changed) {
       this.markBoundsDirty();
     }

--- a/three-demo/src/entities/crowned-ghost.js
+++ b/three-demo/src/entities/crowned-ghost.js
@@ -7,6 +7,12 @@ const MODEL_CONFIG = {
     '../models/entity_ghost_guy_1/entity_ghost_guy_1_base.glb',
     import.meta.url,
   ).href,
+  /**
+   * Optional yaw offset (in radians) used to align the GLB's forward axis with
+   * the engine's +Z basis. Config authors can override this when a persona's
+   * mesh faces a different direction.
+   */
+  forwardYaw: Math.PI,
   variantUrls: {
     runner: new URL(
       '../models/entity_ghost_guy_1/entity_ghost_guy_1_runner.glb',
@@ -76,6 +82,13 @@ export class CrownedGhostEntity extends BaseEntity {
     this.visualRoot = new this.THREE.Group();
     this.visualRoot.name = 'CrownedGhost.VisualRoot';
     this.root.add(this.visualRoot);
+
+    this._forwardYawAxis = new this.THREE.Vector3(0, 1, 0);
+    this._modelForwardQuaternion = new this.THREE.Quaternion();
+    const initialForwardYaw = Number.isFinite(this.modelConfig?.forwardYaw)
+      ? this.modelConfig.forwardYaw
+      : Math.PI;
+    this.setModelForwardYaw(initialForwardYaw);
 
     this.animationController = null;
     this.variantClipMap = new Map();
@@ -168,7 +181,38 @@ export class CrownedGhostEntity extends BaseEntity {
     scaledBox.getCenter(center);
     scene.position.sub(center);
     scene.position.y -= scaledBox.min.y;
-    scene.rotation.y = Math.PI;
+    const forwardYaw = Number.isFinite(this.modelConfig?.forwardYaw)
+      ? this.modelConfig.forwardYaw
+      : this.modelForwardYaw ?? Math.PI;
+    scene.rotation.y = forwardYaw;
+    this.setModelForwardYaw(forwardYaw);
+  }
+
+  setModelForwardYaw(yaw) {
+    const next = Number.isFinite(yaw) ? yaw : Math.PI;
+    if (this.modelForwardYaw === next) {
+      return this.modelForwardYaw;
+    }
+    this.modelForwardYaw = next;
+    this._modelForwardQuaternion.setFromAxisAngle(this._forwardYawAxis, this.modelForwardYaw);
+    return this.modelForwardYaw;
+  }
+
+  getModelForwardYaw() {
+    return Number.isFinite(this.modelForwardYaw) ? this.modelForwardYaw : Math.PI;
+  }
+
+  getModelForwardQuaternion() {
+    return this._modelForwardQuaternion;
+  }
+
+  getVisualForwardBasis(target) {
+    const result = target instanceof this.THREE.Vector3 ? target : new this.THREE.Vector3();
+    result.set(0, 0, 1).applyQuaternion(this._modelForwardQuaternion);
+    if (this.root?.quaternion) {
+      result.applyQuaternion(this.root.quaternion);
+    }
+    return result.normalize();
   }
 
   enableShadows(scene) {


### PR DESCRIPTION
## Summary
- capture the crowned ghost model's forward yaw during normalization and expose a helper for computing the world forward basis
- rotate runner heading vectors, intents, and yaw offsets by the model forward yaw while publishing the entity forward vector to sensors
- extend the crowned ghost runner test suite to validate forward alignment and yaw rotation metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffdd77e44832aa6b7e3c3c9298aae