### PR TITLE
Add environment flower POIs to CrownedGhostRunner context

### DIFF
--- a/three-demo/src/entities/ai/__tests__/environment-index.test.js
+++ b/three-demo/src/entities/ai/__tests__/environment-index.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collectNearbyFlowerPOIs } from '../environment/environment-index.js';
+
+describe('environment-index helpers', () => {
+  it('collects flower decorations as points of interest within radius', () => {
+    const flowerEntries = [
+      { id: 'flower-alpha', position: { x: 2, y: 0, z: 3 }, type: 'flowers' },
+      { id: 'flower-beta', position: { x: 48, y: 0, z: 0 }, type: 'flowers' },
+    ];
+    const flowerGroup = {
+      key: 'flowers-1',
+      type: 'flowers',
+      instanceIndices: [0, 1],
+      entries: flowerEntries,
+    };
+    const chunkManager = {
+      decorationTypeIndex: new Map([[
+        'flowers',
+        new Set([flowerGroup]),
+      ]]),
+    };
+
+    const origin = { x: 0, y: 0, z: 0 };
+    const results = collectNearbyFlowerPOIs({ chunkManager, origin, radius: 12 });
+
+    assert.ok(Array.isArray(results), 'expected helper to return an array of POIs');
+    assert.strictEqual(results.length, 1, 'expected only the nearby flower to be included');
+    const [first] = results;
+    assert.deepStrictEqual(first.position, flowerEntries[0].position);
+    assert.strictEqual(first.id, 'flower-alpha');
+    assert.strictEqual(first.type, 'flowers');
+  });
+});

--- a/three-demo/src/entities/ai/environment/environment-index.js
+++ b/three-demo/src/entities/ai/environment/environment-index.js
@@ -1,0 +1,247 @@
+import { Matrix4, Vector3 } from 'three';
+
+const SCRATCH_MATRIX = new Matrix4();
+const SCRATCH_POSITION = new Vector3();
+
+const DEFAULT_FLOWER_RADIUS = 36;
+const DEFAULT_FLOWER_LIMIT = 24;
+
+function toNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function resolveVector(input, fallback = null) {
+  if (!input) {
+    return fallback;
+  }
+  if (input.isVector3) {
+    return { x: toNumber(input.x), y: toNumber(input.y), z: toNumber(input.z) };
+  }
+  if (Array.isArray(input)) {
+    const [x = 0, y = 0, z = 0] = input;
+    return { x: toNumber(x), y: toNumber(y), z: toNumber(z) };
+  }
+  if (typeof input === 'object') {
+    if ('x' in input || 'y' in input || 'z' in input) {
+      return {
+        x: toNumber(input.x),
+        y: toNumber(input.y),
+        z: toNumber(input.z),
+      };
+    }
+    if (input.position) {
+      return resolveVector(input.position, fallback);
+    }
+  }
+  return fallback;
+}
+
+function distanceSquared(a, b) {
+  if (!a || !b) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const dx = toNumber(a.x) - toNumber(b.x);
+  const dy = toNumber(a.y) - toNumber(b.y);
+  const dz = toNumber(a.z) - toNumber(b.z);
+  return dx * dx + dy * dy + dz * dz;
+}
+
+function normalizeCollection(collection) {
+  if (!collection) {
+    return [];
+  }
+  if (collection instanceof Set) {
+    return Array.from(collection.values());
+  }
+  if (Array.isArray(collection)) {
+    return collection.slice();
+  }
+  if (collection instanceof Map) {
+    return Array.from(collection.values());
+  }
+  if (typeof collection === 'object') {
+    return Object.values(collection);
+  }
+  return [];
+}
+
+function normalizeInstanceIndices(group, fallbackCount = 0) {
+  if (Array.isArray(group?.instanceIndices) && group.instanceIndices.length > 0) {
+    return group.instanceIndices.filter((index) => Number.isInteger(index) && index >= 0);
+  }
+  const count = Number.isInteger(fallbackCount) && fallbackCount > 0 ? fallbackCount : 0;
+  return Array.from({ length: count }, (_, index) => index);
+}
+
+function readEntryFromCollection(group, entry, index) {
+  if (!entry) {
+    return null;
+  }
+  const position = resolveVector(entry.position, null);
+  if (!position) {
+    return null;
+  }
+  const type = entry.type ?? group?.type ?? 'decoration';
+  const id = entry.id ?? entry.key ?? `${group?.key ?? type}:${index}`;
+  return { position, type, id };
+}
+
+function readEntryFromMesh(group, mesh, index) {
+  if (!mesh?.isInstancedMesh || typeof mesh.getMatrixAt !== 'function') {
+    return null;
+  }
+  const count = Number.isInteger(mesh.count) ? mesh.count : 0;
+  if (index < 0 || index >= count) {
+    return null;
+  }
+
+  mesh.getMatrixAt(index, SCRATCH_MATRIX);
+  SCRATCH_POSITION.setFromMatrixPosition(SCRATCH_MATRIX);
+  if (mesh.matrixWorld?.isMatrix4) {
+    SCRATCH_POSITION.applyMatrix4(mesh.matrixWorld);
+  } else if (mesh.parent?.matrixWorld?.isMatrix4) {
+    SCRATCH_POSITION.applyMatrix4(mesh.parent.matrixWorld);
+  }
+
+  return {
+    position: {
+      x: SCRATCH_POSITION.x,
+      y: SCRATCH_POSITION.y,
+      z: SCRATCH_POSITION.z,
+    },
+    type: group?.type ?? mesh.userData?.type ?? 'decoration',
+    id: `${group?.key ?? mesh.uuid}:${index}`,
+  };
+}
+
+function collectGroupEntries(group) {
+  if (!group) {
+    return [];
+  }
+  const directEntries = Array.isArray(group.entries)
+    ? group.entries
+    : Array.isArray(group.instances)
+      ? group.instances
+      : null;
+
+  if (directEntries) {
+    const results = [];
+    const indices = normalizeInstanceIndices(group, directEntries.length);
+    indices.forEach((index) => {
+      const entry = directEntries[index];
+      const normalized = readEntryFromCollection(group, entry, index);
+      if (normalized) {
+        results.push(normalized);
+      }
+    });
+    if (results.length > 0) {
+      return results;
+    }
+  }
+
+  const mesh = group.mesh ?? null;
+  if (!mesh) {
+    return [];
+  }
+  if (typeof mesh.count !== 'number' || mesh.count <= 0) {
+    return [];
+  }
+
+  const indices = normalizeInstanceIndices(group, mesh.count);
+  const results = [];
+  indices.forEach((index) => {
+    const entry = readEntryFromMesh(group, mesh, index);
+    if (entry) {
+      results.push(entry);
+    }
+  });
+  return results;
+}
+
+function collectDecorationGroups(chunkManager, type) {
+  if (!chunkManager) {
+    return [];
+  }
+  const groups = new Set();
+  const typeIndex = chunkManager.decorationTypeIndex ?? null;
+  if (typeIndex instanceof Map) {
+    const bucket = typeIndex.get(type);
+    normalizeCollection(bucket).forEach((group) => groups.add(group));
+  } else if (Array.isArray(typeIndex)) {
+    typeIndex
+      .filter((entry) => entry?.type === type)
+      .forEach((entry) => groups.add(entry));
+  } else if (typeof typeIndex === 'object' && typeIndex !== null) {
+    const bucket = typeIndex[type];
+    normalizeCollection(bucket).forEach((group) => groups.add(group));
+  }
+
+  if (groups.size === 0 && chunkManager.decorationGroups) {
+    normalizeCollection(chunkManager.decorationGroups)
+      .filter((group) => group?.type === type)
+      .forEach((group) => groups.add(group));
+  }
+
+  return Array.from(groups.values());
+}
+
+export function collectNearbyFlowerPOIs({
+  chunkManager,
+  origin = null,
+  radius = DEFAULT_FLOWER_RADIUS,
+  maxResults = DEFAULT_FLOWER_LIMIT,
+} = {}) {
+  if (!chunkManager) {
+    return [];
+  }
+
+  const groups = collectDecorationGroups(chunkManager, 'flowers');
+  if (groups.length === 0) {
+    return [];
+  }
+
+  const originVector = resolveVector(origin, null);
+  const radiusSq = Number.isFinite(radius) && radius > 0 ? radius * radius : null;
+
+  const candidates = [];
+  groups.forEach((group) => {
+    const entries = collectGroupEntries(group);
+    entries.forEach((entry) => {
+      if (!entry?.position) {
+        return;
+      }
+      const distanceSq = originVector ? distanceSquared(entry.position, originVector) : 0;
+      if (radiusSq !== null && distanceSq > radiusSq) {
+        return;
+      }
+      candidates.push({ ...entry, distanceSq });
+    });
+  });
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  candidates.sort((a, b) => a.distanceSq - b.distanceSq);
+  const limit = Number.isFinite(maxResults) && maxResults > 0 ? maxResults : candidates.length;
+  return candidates.slice(0, limit).map(({ distanceSq: _distanceSq, ...entry }) => entry);
+}
+
+export function buildEnvironmentSnapshot({
+  chunkManager,
+  origin = null,
+  radius = DEFAULT_FLOWER_RADIUS,
+  maxResults = DEFAULT_FLOWER_LIMIT,
+} = {}) {
+  const pointsOfInterest = collectNearbyFlowerPOIs({
+    chunkManager,
+    origin,
+    radius,
+    maxResults,
+  });
+  return {
+    pointsOfInterest,
+    resourceNodes: [],
+  };
+}

--- a/three-demo/src/entities/crowned-ghost-runner.js
+++ b/three-demo/src/entities/crowned-ghost-runner.js
@@ -1,6 +1,7 @@
 import { CrownedGhostEntity } from './crowned-ghost.js';
 import { MobAICore } from './ai/mob-ai-core.js';
 import { AIPresentationAdapter } from './ai/presentation/presentation-adapter.js';
+import { buildEnvironmentSnapshot } from './ai/environment/environment-index.js';
 
 const RUNNER_MODEL_CONFIG = {
   baseUrl: new URL(
@@ -22,6 +23,8 @@ const WALK_STATE = 'walk';
 const IDLE_STATE = 'idle';
 const TURN_STATE = 'turn';
 const PRESENTATION_BEHAVIOR_ID = 'crowned-ghost-runner';
+const FLOWER_SAMPLE_RADIUS = 36;
+const FLOWER_SAMPLE_LIMIT = 24;
 
 const BASE_PRESENTATION_CONFIG = {
   states: {
@@ -201,10 +204,12 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
   onSpawn(spawnContext, options = {}) {
     super.onSpawn(spawnContext, options);
     this.aiCore.dependencies.chunkManager = this.chunkManager ?? null;
+    const world = this.getWorldContext();
+    const sensors = this.getSensorContext(world.environment);
     const initialContext = {
       entity: this,
-      world: this.getWorldContext(),
-      sensors: this.getSensorContext(),
+      world,
+      sensors,
       elapsedTime: Number.isFinite(options?.elapsedTime) ? options.elapsedTime : 0,
     };
     this.aiCore.initialize(initialContext);
@@ -212,19 +217,34 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
     this.ensurePresentationAdapter();
   }
 
+  buildEnvironmentContext() {
+    if (!this.chunkManager || !this.root?.position) {
+      return { pointsOfInterest: [], resourceNodes: [] };
+    }
+    return buildEnvironmentSnapshot({
+      chunkManager: this.chunkManager,
+      origin: this.root.position,
+      radius: FLOWER_SAMPLE_RADIUS,
+      maxResults: FLOWER_SAMPLE_LIMIT,
+    });
+  }
+
   getWorldContext() {
+    const environment = this.buildEnvironmentContext();
     return {
       chunkManager: this.chunkManager ?? null,
       terrainHeight: this.terrainHeight ?? null,
       scene: this.scene ?? null,
+      environment,
     };
   }
 
-  getSensorContext() {
+  getSensorContext(environment = null) {
     return {
       chunkManager: this.chunkManager ?? null,
       terrainHeight: this.terrainHeight ?? null,
       forward: this.forward ?? null,
+      environment,
     };
   }
 
@@ -656,10 +676,13 @@ export class CrownedGhostRunnerEntity extends CrownedGhostEntity {
 
     this.decayBlockedHeadings(delta);
 
+    const world = this.getWorldContext();
+    const sensors = this.getSensorContext(world.environment);
+
     this.aiCore.update(delta, {
       entity: this,
-      world: this.getWorldContext(),
-      sensors: this.getSensorContext(),
+      world,
+      sensors,
       elapsedTime,
     });
 


### PR DESCRIPTION
## Summary
- add an environment-index helper that translates flower decoration metadata into POI records
- surface the helper inside CrownedGhostRunner world and sensor contexts so AI updates receive flower POIs
- cover the helper with a focused unit test using a stubbed chunk manager

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e02da5fe30832aa9990918f7852e94