### PR TITLE
Add ambient AI layer with scheduler-driven intents

### DIFF
--- a/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
+++ b/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
@@ -3,6 +3,28 @@ import assert from 'node:assert/strict';
 import { MobAICore } from '../mob-ai-core.js';
 import { ActionNode } from '../behavior-nodes.js';
 
+const createAmbientContext = () => ({
+  time: 0,
+  flags: { allowWander: false },
+  entity: {
+    id: 'ghost-alpha',
+    faction: 'covenant',
+    position: { x: 0, y: 10, z: 0 },
+  },
+  environment: {
+    lightLevel: 0.35,
+    pointsOfInterest: [{ x: 12, y: 9, z: -6 }],
+    resourceNodes: [],
+    nearbyEntities: [],
+  },
+  percepts: {
+    threatLevel: 'low',
+    nearbyEntities: [],
+  },
+  terrainHeight: () => 10,
+  memory: new Map(),
+});
+
 const createLoggingNode = (name, logs) =>
   new ActionNode(name, {
     onInitialize: () => logs.push(`${name}:initialize`),
@@ -150,5 +172,71 @@ describe('MobAICore', () => {
 
     const chaseLayer = core.scheduler.layers.find((layer) => layer.name === 'spectral-chase');
     assert.strictEqual(chaseLayer.priority, 10);
+  });
+
+  it('installs ambient behavior layer and emits intents from scheduler tasks', () => {
+    core.usePersona('spectral-runner');
+    const initialContext = createAmbientContext();
+    const intentEvents = [];
+    core.on('ambient:intent', (intent, meta) =>
+      intentEvents.push({ intent, time: meta?.context?.time ?? core.context.time }),
+    );
+
+    core.initialize(initialContext);
+    core.attachToEntity({ id: 'entity-ambient' });
+
+    const scheduler = core.ambientScheduler;
+    const originalRequestTask = scheduler.requestTask.bind(scheduler);
+    let requestCount = 0;
+    scheduler.requestTask = (...args) => {
+      requestCount += 1;
+      return originalRequestTask(...args);
+    };
+
+    const ambientLayerEntry = core.scheduler.layers.find((layer) => layer.name === 'ambient-behaviors');
+    assert.ok(ambientLayerEntry, 'expected ambient behavior layer to be registered');
+
+    const environment = { ...initialContext.environment };
+    const percepts = { ...initialContext.percepts };
+    const flags = { ...initialContext.flags };
+
+    const steps = [1, 1, 1, 12, 1];
+    for (const step of steps) {
+      core.update(step, { environment, percepts, flags });
+    }
+
+    assert.ok(requestCount >= steps.length, 'expected ambient layer to request scheduler tasks');
+
+    const inspectEvents = intentEvents.filter((event) => event.intent.type === 'inspect-poi');
+    const recordedTypes = intentEvents.map((event) => event.intent.type);
+    assert.ok(
+      inspectEvents.length >= 1,
+      `expected at least one inspect intent to fire when POIs exist (saw: ${recordedTypes.join(', ')})`,
+    );
+    assert.ok(inspectEvents[0].intent.target, 'inspect intent should include a target payload');
+
+    assert.ok(
+      inspectEvents.length >= 2,
+      'expected a follow-up inspect intent once scheduler cooldown elapsed',
+    );
+    const inspectTimes = inspectEvents.map((event) => event.time);
+    const cooldownDelta = inspectTimes.at(-1) - inspectTimes[0];
+    assert.ok(
+      cooldownDelta >= 12,
+      `expected inspect intents to respect scheduler cooldown, got delta=${cooldownDelta} (times: ${inspectTimes.join(', ')})`,
+    );
+
+    scheduler.requestTask = originalRequestTask;
+  });
+
+  it('honors persona ambient overrides for behavior selection', () => {
+    core.usePersona('spectral-runner', { ambient: { behaviors: { gatherResources: false } } });
+    core.initialize({ environment: { pointsOfInterest: [] } });
+
+    const ambientLayerEntry = core.scheduler.layers.find((layer) => layer.name === 'ambient-behaviors');
+    assert.ok(ambientLayerEntry, 'ambient layer should be installed');
+    const enabled = ambientLayerEntry.node.enabledBehaviors;
+    assert.ok(enabled.includes('seekSunlight'));
+    assert.ok(!enabled.includes('gatherResources'), 'gatherResources should be disabled via override');
   });
 });

--- a/three-demo/src/entities/ai/environment/ambient-behavior-layer.js
+++ b/three-demo/src/entities/ai/environment/ambient-behavior-layer.js
@@ -1,0 +1,264 @@
+import { BehaviorNode } from '../behavior-nodes.js';
+import { createAmbientBehaviorSuite } from './ambient-behaviors.js';
+
+const DEFAULT_BEHAVIOR_ORDER = ['seekSunlight', 'gatherResources', 'idleChatter'];
+const MAX_INTENT_HISTORY = 8;
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const cloneValue = (value) => {
+  if (!isPlainObject(value)) {
+    if (Array.isArray(value)) {
+      return value.map((entry) => cloneValue(entry));
+    }
+    return value;
+  }
+  const result = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = cloneValue(entry);
+  }
+  return result;
+};
+
+const normalizeBehaviorEntry = (entry) => {
+  if (entry === false) {
+    return { enabled: false, options: null };
+  }
+  if (entry === true || entry === undefined) {
+    return { enabled: true, options: {} };
+  }
+  if (!isPlainObject(entry)) {
+    return { enabled: entry !== false, options: {} };
+  }
+  const { enabled, options, ...rest } = entry;
+  if (enabled === false) {
+    return { enabled: false, options: null };
+  }
+  if (options && isPlainObject(options)) {
+    return { enabled: true, options: cloneValue(options) };
+  }
+  return { enabled: enabled !== false, options: cloneValue(rest) };
+};
+
+const trimIntentHistory = (list) => {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  if (list.length <= MAX_INTENT_HISTORY) {
+    return list;
+  }
+  return list.slice(list.length - MAX_INTENT_HISTORY);
+};
+
+export class AmbientBehaviorLayer extends BehaviorNode {
+  constructor(options = {}) {
+    super(options.name ?? 'ambient-behaviors');
+    this.scheduler = options.scheduler ?? null;
+    this.behaviorConfig = isPlainObject(options.behaviors) ? cloneValue(options.behaviors) : {};
+    this.taskRequestOptions = isPlainObject(options.taskRequest)
+      ? { ...options.taskRequest }
+      : null;
+    this.behaviorOrder = Array.isArray(options.order)
+      ? options.order.filter((name) => typeof name === 'string')
+      : null;
+    this.behaviorSuite = null;
+    this.enabledBehaviors = [];
+    this.context = null;
+  }
+
+  configure(options = {}) {
+    if (Object.prototype.hasOwnProperty.call(options, 'scheduler')) {
+      this.scheduler = options.scheduler ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'behaviors')) {
+      this.behaviorConfig = isPlainObject(options.behaviors) ? cloneValue(options.behaviors) : {};
+      this.behaviorSuite = null;
+      this.enabledBehaviors = [];
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'taskRequest')) {
+      this.taskRequestOptions = isPlainObject(options.taskRequest)
+        ? { ...options.taskRequest }
+        : null;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'order')) {
+      this.behaviorOrder = Array.isArray(options.order)
+        ? options.order.filter((name) => typeof name === 'string')
+        : null;
+    }
+    if (this.context) {
+      this._initializeSuite(this.context, { force: true });
+    }
+  }
+
+  initialize(context) {
+    this.context = context;
+    this._initializeSuite(context, { force: true });
+  }
+
+  attachToEntity(entity, context) {
+    this.context = context;
+    this._initializeSuite(context);
+    for (const name of this.enabledBehaviors) {
+      this.behaviorSuite?.[name]?.attachToEntity?.(entity, context);
+    }
+  }
+
+  update(delta, context) {
+    this.context = context;
+    this._initializeSuite(context);
+    this._executeAmbientTask(context);
+    this._updateBehaviors(delta, context);
+  }
+
+  dispose() {
+    if (this.behaviorSuite) {
+      for (const name of this.enabledBehaviors) {
+        this.behaviorSuite[name]?.dispose?.();
+      }
+    }
+    this.behaviorSuite = null;
+    this.enabledBehaviors = [];
+    this.context = null;
+  }
+
+  _resolveScheduler(context) {
+    if (this.scheduler) {
+      return this.scheduler;
+    }
+    return context?.ambient?.scheduler ?? context?.ambientScheduler ?? null;
+  }
+
+  _initializeSuite(context, { force = false } = {}) {
+    const scheduler = this._resolveScheduler(context);
+    if (!scheduler) {
+      return;
+    }
+    if (!force && this.behaviorSuite) {
+      return;
+    }
+    this.scheduler = scheduler;
+    const { suite, enabled } = this._createBehaviorSuite(scheduler);
+    this.behaviorSuite = suite;
+    this.enabledBehaviors = enabled;
+    for (const name of this.enabledBehaviors) {
+      this.behaviorSuite[name]?.initialize?.(context);
+    }
+  }
+
+  _createBehaviorSuite(scheduler) {
+    const desiredOrder =
+      this.behaviorOrder && this.behaviorOrder.length > 0
+        ? [...new Set(this.behaviorOrder)]
+        : [...DEFAULT_BEHAVIOR_ORDER];
+    const config = isPlainObject(this.behaviorConfig) ? this.behaviorConfig : {};
+    const optionMap = {};
+    const enabled = [];
+    const names = new Set([...desiredOrder, ...Object.keys(config)]);
+    for (const name of names) {
+      const normalized = normalizeBehaviorEntry(config[name]);
+      if (!normalized.enabled) {
+        continue;
+      }
+      if (normalized.options) {
+        optionMap[name] = normalized.options;
+      }
+      enabled.push(name);
+    }
+    const suite = createAmbientBehaviorSuite(scheduler, optionMap);
+    const filtered = enabled.filter((name) => suite[name]);
+    return { suite, enabled: filtered };
+  }
+
+  _updateBehaviors(delta, context) {
+    if (!this.behaviorSuite) {
+      return;
+    }
+    for (const name of this.enabledBehaviors) {
+      this.behaviorSuite[name]?.update?.(delta, context);
+    }
+  }
+
+  _executeAmbientTask(context) {
+    const scheduler = this._resolveScheduler(context);
+    if (!scheduler) {
+      return;
+    }
+    const requestOptions = this.taskRequestOptions ? { ...this.taskRequestOptions } : {};
+    const handle = scheduler.requestTask(context, requestOptions);
+    if (!handle) {
+      return;
+    }
+    const result = handle.execute?.(context) ?? null;
+    if (!result || result.success === false) {
+      handle.fail(result?.reason ?? 'failed');
+      return;
+    }
+    handle.succeed(result);
+    const intent = this._mapInstructionToIntent(result, handle);
+    if (intent) {
+      this._recordIntent(context, intent, { task: handle.name, result: cloneValue(result) });
+    }
+  }
+
+  _mapInstructionToIntent(result, handle) {
+    if (!result) {
+      return null;
+    }
+    const task = handle?.name ?? result.task ?? null;
+    const target = result.target ? cloneValue(result.target) : null;
+    if (result.type === 'movement') {
+      if (result.style === 'explore') {
+        if (result.intent === 'resource') {
+          return { type: 'gather-resource', target, task };
+        }
+        if (result.intent === 'poi') {
+          return { type: 'inspect-poi', target, task };
+        }
+        return { type: 'explore-area', target, task };
+      }
+      if (result.style === 'wander') {
+        return { type: 'wander', target, task };
+      }
+      return { type: 'move-to', target, style: result.style ?? 'movement', task };
+    }
+    if (result.type === 'social') {
+      if (result.style === 'chat') {
+        return {
+          type: 'socialize',
+          partner: result.partner ? cloneValue(result.partner) : null,
+          message: result.message ?? null,
+          task,
+        };
+      }
+      return { type: 'social', payload: cloneValue(result), task };
+    }
+    if (typeof result.intent === 'string') {
+      return { type: result.intent, payload: cloneValue(result), task };
+    }
+    return { type: 'ambient-task', payload: cloneValue(result), task };
+  }
+
+  _recordIntent(context, intent, meta = {}) {
+    if (!context || !intent) {
+      return;
+    }
+    const record = { ...intent };
+    context.intents ??= {};
+    const existing = Array.isArray(context.intents.ambient) ? context.intents.ambient : [];
+    const next = trimIntentHistory([...existing, record]);
+    context.intents.ambient = next;
+    context.ambient ??= {};
+    context.ambient.lastIntent = record;
+    context.ambient.intents = next;
+
+    const eventPayload = { ...meta, intent: record };
+    if (typeof context.emit === 'function') {
+      context.emit('ambient:intent', record, { ...eventPayload, context });
+    } else if (context.ai?.events?.emit) {
+      context.ai.events.emit('ambient:intent', record, { ...eventPayload, context });
+    }
+  }
+}
+
+export default AmbientBehaviorLayer;

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -3,6 +3,7 @@ import { BehaviorRegistry } from './behavior-nodes.js';
 import { PersonaRegistry } from './personas/persona-registry.js';
 import { defaultTraits } from './traits/index.js';
 import { AmbientTaskScheduler } from './environment/ambient-task-scheduler.js';
+import { AmbientBehaviorLayer } from './environment/ambient-behavior-layer.js';
 
 const deepClone = (value) => {
   if (typeof structuredClone === 'function') {
@@ -187,6 +188,16 @@ export class MobAICore {
     this.currentPersona = null;
     this.initialized = false;
     this.events = events ?? new EventEmitter();
+    this._boundEmit = this.emit.bind(this);
+    this.ambientBehaviorSettings = {
+      enabled: false,
+      priority: -5,
+      behaviors: {},
+      taskRequest: null,
+      order: null,
+      name: 'ambient-behaviors',
+    };
+    this._ambientLayer = null;
 
     traitDefinitions.forEach((trait) => {
       const definition = normalizeTraitDefinition(trait.name ?? trait, trait);
@@ -222,7 +233,8 @@ export class MobAICore {
     const persona = this.personaRegistry.create(reference, overrides);
     const previousPersona = this.currentPersona;
     this.currentPersona = persona;
-    this._applyPersona(persona, { resetResources: true });
+    const ambientOverrides = overrides?.ambient ?? overrides?.ambientBehaviors ?? null;
+    this._applyPersona(persona, { resetResources: true, ambientOverrides });
     this.emit('persona:applied', persona, { previous: previousPersona });
     return persona;
   }
@@ -270,7 +282,7 @@ export class MobAICore {
     this.activeTraitHandles.set(name, handle);
   }
 
-  _applyPersona(persona, { resetResources = false } = {}) {
+  _applyPersona(persona, { resetResources = false, ambientOverrides = null } = {}) {
     if (!persona) {
       return;
     }
@@ -279,6 +291,9 @@ export class MobAICore {
     this._updateTraitContext();
     this._syncPersonaContext(persona, { resetResources });
     this._installPersonaBehaviors(persona);
+    const baseAmbient = persona.metadata?.ambient ?? null;
+    const mergedAmbient = this._mergeAmbientConfig(baseAmbient, ambientOverrides);
+    this._configureAmbientLayer(mergedAmbient);
   }
 
   _syncPersonaContext(persona, { resetResources = false } = {}) {
@@ -390,10 +405,16 @@ export class MobAICore {
       this.context.ambientScheduler = this.ambientScheduler;
       this.context.ambient ??= {};
       this.context.ambient.scheduler = this.ambientScheduler;
+      this.context.events = this.events;
+      this.context.emit = this._boundEmit;
+      this.context.ai ??= {};
+      this.context.ai.core = this;
+      this.context.ai.events = this.events;
       this._updateTraitContext();
       if (this.currentPersona) {
         this._syncPersonaContext(this.currentPersona);
       }
+      this._ensureAmbientLayer(this.context);
       this.ambientScheduler.tick(0, this.context);
       return this.context;
     }
@@ -411,9 +432,15 @@ export class MobAICore {
     this.context.ambientScheduler = this.ambientScheduler;
     this.context.ambient ??= {};
     this.context.ambient.scheduler = this.ambientScheduler;
+    this.context.events = this.events;
+    this.context.emit = this._boundEmit;
+    this.context.ai ??= {};
+    this.context.ai.core = this;
+    this.context.ai.events = this.events;
     if (this.currentPersona) {
       this._syncPersonaContext(this.currentPersona, { resetResources: true });
     }
+    this._ensureAmbientLayer(this.context);
     this.scheduler.initialize(this.context);
     this.ambientScheduler.tick(0, this.context);
     this.initialized = true;
@@ -451,6 +478,109 @@ export class MobAICore {
     this.ambientScheduler.tick(delta, this.context);
     this.scheduler.tick(delta, this.context);
     this.emit('afterUpdate', this.context);
+  }
+
+  _mergeAmbientConfig(base, overrides) {
+    if (!overrides) {
+      return base ? { ...base } : base;
+    }
+    const merged = base ? { ...base } : {};
+    if (overrides && typeof overrides === 'object') {
+      if (Object.prototype.hasOwnProperty.call(overrides, 'enabled')) {
+        merged.enabled = overrides.enabled;
+      }
+      if (Object.prototype.hasOwnProperty.call(overrides, 'priority')) {
+        merged.priority = overrides.priority;
+      }
+      if (Object.prototype.hasOwnProperty.call(overrides, 'name')) {
+        merged.name = overrides.name;
+      }
+      if (Object.prototype.hasOwnProperty.call(overrides, 'order')) {
+        merged.order = Array.isArray(overrides.order) ? [...overrides.order] : overrides.order;
+      }
+      if (Object.prototype.hasOwnProperty.call(overrides, 'taskRequest')) {
+        merged.taskRequest = overrides.taskRequest;
+      }
+      if (Object.prototype.hasOwnProperty.call(overrides, 'behaviors')) {
+        const baseBehaviors = merged.behaviors && typeof merged.behaviors === 'object' ? merged.behaviors : {};
+        merged.behaviors = { ...baseBehaviors, ...(overrides.behaviors ?? {}) };
+      }
+    }
+    return merged;
+  }
+
+  _configureAmbientLayer(config) {
+    const normalized = {
+      enabled: false,
+      priority: -5,
+      behaviors: {},
+      taskRequest: null,
+      order: null,
+      name: 'ambient-behaviors',
+    };
+    if (config && typeof config === 'object') {
+      if (Object.prototype.hasOwnProperty.call(config, 'enabled')) {
+        normalized.enabled = Boolean(config.enabled);
+      }
+      if (Object.prototype.hasOwnProperty.call(config, 'priority')) {
+        const priority = Number(config.priority);
+        if (Number.isFinite(priority)) {
+          normalized.priority = priority;
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(config, 'behaviors')) {
+        normalized.behaviors =
+          config.behaviors && typeof config.behaviors === 'object' ? { ...config.behaviors } : {};
+      }
+      if (Object.prototype.hasOwnProperty.call(config, 'taskRequest')) {
+        normalized.taskRequest =
+          config.taskRequest && typeof config.taskRequest === 'object' ? { ...config.taskRequest } : null;
+      }
+      if (Object.prototype.hasOwnProperty.call(config, 'order')) {
+        normalized.order = Array.isArray(config.order) ? [...config.order] : null;
+      }
+      if (Object.prototype.hasOwnProperty.call(config, 'name')) {
+        normalized.name = typeof config.name === 'string' ? config.name : normalized.name;
+      }
+    }
+
+    this.ambientBehaviorSettings = normalized;
+
+    if (this._ambientLayer) {
+      this.scheduler.removeLayer(this._ambientLayer.name);
+      this._ambientLayer.dispose?.();
+      this._ambientLayer = null;
+    }
+
+    if (this.initialized && this.context) {
+      this._ensureAmbientLayer(this.context);
+    }
+  }
+
+  _ensureAmbientLayer(context) {
+    if (!this.ambientBehaviorSettings?.enabled) {
+      return;
+    }
+    if (this._ambientLayer) {
+      return;
+    }
+
+    const layer = new AmbientBehaviorLayer({
+      name: this.ambientBehaviorSettings.name,
+      scheduler: this.ambientScheduler,
+      behaviors: this.ambientBehaviorSettings.behaviors,
+      taskRequest: this.ambientBehaviorSettings.taskRequest,
+      order: this.ambientBehaviorSettings.order,
+    });
+    this._ambientLayer = layer;
+    this.addBehaviorLayer({
+      name: layer.name,
+      node: layer,
+      priority: this.ambientBehaviorSettings.priority ?? -5,
+    });
+    if (this.initialized && context?.entity) {
+      layer.attachToEntity?.(context.entity, context);
+    }
   }
 
   /**

--- a/three-demo/src/entities/ai/personas/persona-registry.js
+++ b/three-demo/src/entities/ai/personas/persona-registry.js
@@ -207,6 +207,25 @@ const mergeBehaviors = (base = [], overrides = []) => {
   return Array.from(merged.values());
 };
 
+const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const mergeMetadata = (base = {}, overrides = {}) => {
+  const result = isPlainObject(base) ? { ...base } : {};
+  if (!isPlainObject(overrides)) {
+    return result;
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (isPlainObject(value) && isPlainObject(result[key])) {
+      result[key] = mergeMetadata(result[key], value);
+    } else if (Array.isArray(value)) {
+      result[key] = value.slice();
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
 const normalizePersona = (persona) => {
   if (!persona || typeof persona !== 'object') {
     throw new Error('Persona definition must be an object.');
@@ -271,11 +290,16 @@ const mergePersona = (base, overrides = {}) => {
   const resources = mergeResources(base.resources, normalizedOverrides.resources ?? {});
   const behaviors = mergeBehaviors(base.behaviors, normalizedOverrides.behaviors ?? []);
 
+  const metadata =
+    normalizedOverrides.metadata !== undefined
+      ? mergeMetadata(base.metadata ?? {}, normalizedOverrides.metadata ?? {})
+      : { ...base.metadata };
+
   return {
     name: normalizedOverrides.name ?? base.name,
     label: normalizedOverrides.label ?? base.label,
     description: normalizedOverrides.description ?? base.description,
-    metadata: normalizedOverrides.metadata ?? { ...base.metadata },
+    metadata,
     traits,
     sensors,
     resources,

--- a/three-demo/src/entities/ai/personas/spectral-runner.js
+++ b/three-demo/src/entities/ai/personas/spectral-runner.js
@@ -83,6 +83,16 @@ export const spectralRunnerPersona = {
         'mob-idle:chase': { animation: { variant: 'runner', fadeDuration: 0.15 } },
       },
     },
+    ambient: {
+      enabled: true,
+      priority: -5,
+      taskRequest: { include: ['explore', 'wander', 'socialize'] },
+      behaviors: {
+        seekSunlight: { lightThreshold: 0.5 },
+        gatherResources: { radius: 48 },
+        idleChatter: { radius: 18 },
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add an AmbientBehaviorLayer that wraps ambient behaviors, requests scheduler jobs, and emits intents through the AI context
- wire MobAICore and persona metadata to configure the ambient layer, including deep metadata merging and spectral-runner defaults
- extend MobAICore tests to cover ambient intents, scheduler cooldowns, and persona overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e02f503108832a99ceb87b03e02b9a