### PR TITLE
Handle persona behavior layer removal

### DIFF
--- a/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
+++ b/three-demo/src/entities/ai/__tests__/mob-ai-core.test.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { MobAICore } from '../mob-ai-core.js';
-import { ActionNode } from '../behavior-nodes.js';
+import { ActionNode, BehaviorRegistry } from '../behavior-nodes.js';
 
 const createAmbientContext = () => ({
   time: 0,
@@ -238,5 +238,68 @@ describe('MobAICore', () => {
     const enabled = ambientLayerEntry.node.enabledBehaviors;
     assert.ok(enabled.includes('seekSunlight'));
     assert.ok(!enabled.includes('gatherResources'), 'gatherResources should be disabled via override');
+  });
+
+  it('removes persona-managed layers that disappear when switching personas', () => {
+    const disposeLog = [];
+    const createDisposable = (label) => ({
+      name: label,
+      initialize: () => {},
+      attachToEntity: () => {},
+      update: () => {},
+      dispose: () => disposeLog.push(label),
+    });
+
+    const behaviorRegistry = new BehaviorRegistry();
+    behaviorRegistry.registerLoop('alpha-loop', (options = {}) =>
+      createDisposable(options.trackName ?? 'alpha-loop'),
+    );
+    behaviorRegistry.registerLoop('beta-loop', (options = {}) =>
+      createDisposable(options.trackName ?? 'beta-loop'),
+    );
+
+    core = new MobAICore({
+      random: () => 0,
+      behaviorRegistry,
+    });
+
+    core.addBehaviorLayer({ name: 'manual-layer', node: createDisposable('manual-layer'), priority: 5 });
+
+    core.registerPersona({
+      name: 'persona-alpha',
+      traits: [],
+      sensors: {},
+      resources: {},
+      behaviors: [
+        { name: 'alpha-layer', loop: 'alpha-loop', priority: 3, options: { trackName: 'alpha-layer' } },
+        { name: 'shared-layer', loop: 'beta-loop', priority: 1, options: { trackName: 'shared-layer' } },
+      ],
+    });
+
+    core.registerPersona({
+      name: 'persona-beta',
+      traits: [],
+      sensors: {},
+      resources: {},
+      behaviors: [
+        { name: 'shared-layer', loop: 'beta-loop', priority: 2, options: { trackName: 'shared-layer' } },
+      ],
+    });
+
+    core.usePersona('persona-alpha');
+    assert.deepStrictEqual(core.scheduler.layers.map((layer) => layer.name), [
+      'manual-layer',
+      'alpha-layer',
+      'shared-layer',
+    ]);
+
+    core.usePersona('persona-beta');
+    assert.deepStrictEqual(core.scheduler.layers.map((layer) => layer.name), [
+      'manual-layer',
+      'shared-layer',
+    ]);
+
+    assert.ok(disposeLog.includes('alpha-layer'), 'expected removed persona layer to dispose');
+    assert.ok(!disposeLog.includes('manual-layer'), 'manual layers should remain untouched');
   });
 });

--- a/three-demo/src/entities/ai/mob-ai-core.js
+++ b/three-demo/src/entities/ai/mob-ai-core.js
@@ -198,6 +198,7 @@ export class MobAICore {
       name: 'ambient-behaviors',
     };
     this._ambientLayer = null;
+    this._personaBehaviorLayers = new Set();
 
     traitDefinitions.forEach((trait) => {
       const definition = normalizeTraitDefinition(trait.name ?? trait, trait);
@@ -326,10 +327,30 @@ export class MobAICore {
   }
 
   _installPersonaBehaviors(persona) {
-    if (!persona.behaviors || persona.behaviors.length === 0) {
+    const descriptors = Array.isArray(persona.behaviors) ? persona.behaviors : [];
+    const nextLayerNames = new Set();
+
+    for (const descriptor of descriptors) {
+      const layerName = descriptor?.name ?? descriptor?.loop;
+      if (!layerName) {
+        continue;
+      }
+      nextLayerNames.add(layerName);
+    }
+
+    for (const layerName of [...this._personaBehaviorLayers]) {
+      if (!nextLayerNames.has(layerName)) {
+        const removed = this.scheduler.removeLayer(layerName);
+        removed?.node?.dispose?.();
+      }
+    }
+
+    if (descriptors.length === 0) {
+      this._personaBehaviorLayers = nextLayerNames;
       return;
     }
-    for (const descriptor of persona.behaviors) {
+
+    for (const descriptor of descriptors) {
       const layerName = descriptor.name ?? descriptor.loop;
       if (!layerName) {
         continue;
@@ -352,6 +373,8 @@ export class MobAICore {
       const loop = this.behaviorRegistry.createLoop(descriptor.loop, options, this.dependencies);
       this.addBehaviorLayer({ name: layerName, node: loop, priority: descriptor.priority ?? 0 });
     }
+
+    this._personaBehaviorLayers = nextLayerNames;
   }
 
   _updateTraitContext() {


### PR DESCRIPTION
## Summary
- track persona-managed behavior layers in `mob-ai-core` so outdated entries are removed and disposed before installing new persona behaviors
- add a regression test that swaps personas and asserts stale behavior layers are cleared while manual layers remain intact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e5514e2a20832a9f590e8793e6e5b6