### PR TITLE
Implement visibility-aware chunk meshing with debug toggle

### DIFF
--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -1,6 +1,11 @@
 import * as THREE from 'three';
 
-import { generateChunk, getWorldOptions } from './generation.js';
+import {
+  generateChunk,
+  getWorldOptions,
+  buildInstancedBlockMesh,
+  makeBlockKey,
+} from './generation.js';
 import {
   createFluidSurface,
   disposeFluidSurface,
@@ -133,6 +138,32 @@ const fluidNeighborOffsets = [
   { key: 'pz', dx: 0, dz: 1, opposite: 'nz' },
   { key: 'nz', dx: 0, dz: -1, opposite: 'pz' },
 ];
+
+const blockNeighborOffsets = [
+  { dx: 1, dy: 0, dz: 0 },
+  { dx: -1, dy: 0, dz: 0 },
+  { dx: 0, dy: 1, dz: 0 },
+  { dx: 0, dy: -1, dz: 0 },
+  { dx: 0, dy: 0, dz: 1 },
+  { dx: 0, dy: 0, dz: -1 },
+];
+
+function parseBlockCoordinateKey(key) {
+  if (typeof key !== 'string') {
+    return null;
+  }
+  const parts = key.split('|');
+  if (parts.length !== 3) {
+    return null;
+  }
+  const x = Number.parseInt(parts[0], 10);
+  const y = Number.parseInt(parts[1], 10);
+  const z = Number.parseInt(parts[2], 10);
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+    return null;
+  }
+  return { x, y, z };
+}
 
 
 export function createChunkManager({
@@ -402,6 +433,197 @@ export function createChunkManager({
     });
   }
 
+  function ensureTypeRecord(chunk, type) {
+    if (!chunk || !type) {
+      return null;
+    }
+    if (!(chunk.typeData instanceof Map)) {
+      chunk.typeData = new Map();
+    }
+    let record = chunk.typeData.get(type);
+    if (record) {
+      return record;
+    }
+    const capacitySource = chunk.typeCapacities instanceof Map
+      ? chunk.typeCapacities.get(type)
+      : null;
+    const capacity = Math.max(1, Number.isInteger(capacitySource) ? capacitySource : 1);
+    const { mesh, tintAttribute } = buildInstancedBlockMesh({
+      THREE,
+      blockMaterials,
+      type,
+      entries: [],
+      capacity,
+    });
+    mesh.count = 0;
+    mesh.instanceMatrix.needsUpdate = true;
+    if (tintAttribute) {
+      tintAttribute.needsUpdate = true;
+    }
+    mesh.userData = mesh.userData || {};
+    mesh.userData.chunkKey = chunkKey(chunk.chunkX, chunk.chunkZ);
+    chunk.group?.add(mesh);
+    record = {
+      entries: [],
+      mesh,
+      tintAttribute,
+      capacity,
+    };
+    chunk.typeData.set(type, record);
+    return record;
+  }
+
+  function addEntryToChunkMesh(chunk, entry) {
+    if (!chunk || !entry || entry.isDecoration) {
+      return;
+    }
+    const record = ensureTypeRecord(chunk, entry.type);
+    if (!record) {
+      return;
+    }
+    const { entries, mesh, tintAttribute } = record;
+    if (Number.isInteger(entry.index) && entry.index >= 0) {
+      return;
+    }
+    const capacity = mesh.instanceMatrix.count;
+    if (entries.length >= capacity) {
+      return;
+    }
+    const index = entries.length;
+    entries.push(entry);
+    entry.index = index;
+    mesh.setMatrixAt(index, entry.matrix);
+    mesh.count = entries.length;
+    mesh.instanceMatrix.needsUpdate = true;
+    const tint = entry.tintColor ?? mesh.userData?.defaultTint;
+    if (tintAttribute && tint) {
+      const offset = index * 3;
+      tintAttribute.array[offset] = tint.r;
+      tintAttribute.array[offset + 1] = tint.g;
+      tintAttribute.array[offset + 2] = tint.b;
+      tintAttribute.needsUpdate = true;
+    }
+    entry.mesh = mesh;
+    entry.tintAttribute = tintAttribute;
+  }
+
+  function removeEntryFromChunkMesh(chunk, entry) {
+    if (!chunk || !entry || !chunk.typeData) {
+      entry.index = -1;
+      entry.mesh = null;
+      entry.tintAttribute = null;
+      return;
+    }
+    const record = chunk.typeData.get(entry.type);
+    if (!record) {
+      entry.index = -1;
+      entry.mesh = null;
+      entry.tintAttribute = null;
+      return;
+    }
+    const { entries, mesh, tintAttribute } = record;
+    const index = entry.index;
+    if (!Number.isInteger(index) || index < 0 || index >= entries.length) {
+      entry.index = -1;
+      entry.mesh = null;
+      entry.tintAttribute = null;
+      return;
+    }
+    const lastIndex = entries.length - 1;
+    if (index !== lastIndex) {
+      const swapped = entries[lastIndex];
+      entries[index] = swapped;
+      mesh.setMatrixAt(index, swapped.matrix);
+      const tint = swapped.tintColor ?? mesh.userData?.defaultTint;
+      if (tintAttribute && tint) {
+        const offset = index * 3;
+        tintAttribute.array[offset] = tint.r;
+        tintAttribute.array[offset + 1] = tint.g;
+        tintAttribute.array[offset + 2] = tint.b;
+      }
+      swapped.index = index;
+    }
+    entries.pop();
+    mesh.count = entries.length;
+    mesh.instanceMatrix.needsUpdate = true;
+    if (tintAttribute) {
+      tintAttribute.needsUpdate = true;
+    }
+    entry.index = -1;
+    entry.mesh = null;
+    entry.tintAttribute = null;
+  }
+
+  function computeBlockVisibility(chunk, entry) {
+    if (!chunk || !entry || !entry.position) {
+      return false;
+    }
+    const baseX = Math.round(entry.position.x);
+    const baseY = Math.round(entry.position.y);
+    const baseZ = Math.round(entry.position.z);
+    for (let i = 0; i < blockNeighborOffsets.length; i += 1) {
+      const offset = blockNeighborOffsets[i];
+      const neighborKey = makeBlockKey(
+        baseX + offset.dx,
+        baseY + offset.dy,
+        baseZ + offset.dz,
+      );
+      const neighborEntry = chunk.blockLookup?.get(neighborKey);
+      if (neighborEntry && neighborEntry !== entry) {
+        if (neighborEntry.collisionMode === 'solid') {
+          continue;
+        }
+      }
+      if (chunk.fluidBlockKeys?.has(neighborKey)) {
+        return true;
+      }
+      if (!neighborEntry || neighborEntry.collisionMode !== 'solid') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function refreshBlockVisibility(chunk, positions) {
+    if (!chunk || !(chunk.blockLookup instanceof Map)) {
+      return;
+    }
+    const targets = new Map();
+    const appendPosition = (pos) => {
+      if (!pos) {
+        return;
+      }
+      const key = makeBlockKey(pos.x, pos.y, pos.z);
+      targets.set(key, pos);
+    };
+    (Array.isArray(positions) ? positions : []).forEach((pos) => {
+      if (!pos) {
+        return;
+      }
+      appendPosition(pos);
+      blockNeighborOffsets.forEach((offset) => {
+        appendPosition({
+          x: pos.x + offset.dx,
+          y: pos.y + offset.dy,
+          z: pos.z + offset.dz,
+        });
+      });
+    });
+    targets.forEach((pos, key) => {
+      const entry = chunk.blockLookup.get(key);
+      if (!entry || entry.isDecoration) {
+        return;
+      }
+      const shouldBeVisible = computeBlockVisibility(chunk, entry);
+      const currentlyVisible = Number.isInteger(entry.index) && entry.index >= 0;
+      if (shouldBeVisible && !currentlyVisible) {
+        addEntryToChunkMesh(chunk, entry);
+      } else if (!shouldBeVisible && currentlyVisible) {
+        removeEntryFromChunkMesh(chunk, entry);
+      }
+    });
+  }
+
   function registerDecorationGroup(chunkKey, group, chunkOverride = null) {
     if (!group || !group.key) {
       return;
@@ -524,6 +746,16 @@ export function createChunkManager({
     });
     chunk.waterColumns = normalizedWaterColumns;
     chunk.waterColumnKeys = new Set(normalizedWaterColumns.keys());
+
+    if (chunk.fluidBlockKeys instanceof Set) {
+      chunk.fluidBlockKeys = new Set(chunk.fluidBlockKeys);
+    } else if (Array.isArray(chunk.fluidBlockKeys)) {
+      chunk.fluidBlockKeys = new Set(chunk.fluidBlockKeys);
+    } else if (chunk.fluidBlockKeys && typeof chunk.fluidBlockKeys === 'object') {
+      chunk.fluidBlockKeys = new Set(Object.keys(chunk.fluidBlockKeys));
+    } else {
+      chunk.fluidBlockKeys = new Set();
+    }
 
     if (chunk.fluidColumnsByType instanceof Map) {
       chunk.fluidColumnsByType = new Map(
@@ -1028,158 +1260,112 @@ export function createChunkManager({
   }
 
   function removeBlockInstancesBulk({ chunk, type, entries: removalEntries }) {
-    if (!chunk || !chunk.typeData) {
+    if (!chunk) {
       return [];
     }
-    const typeData = chunk.typeData.get(type);
-    if (!typeData) {
-      return [];
-    }
-    const { entries, mesh, tintAttribute } = typeData;
-    if (!mesh?.isInstancedMesh || !Array.isArray(entries) || entries.length === 0) {
+    const candidates = Array.isArray(removalEntries) ? removalEntries : [];
+    if (candidates.length === 0) {
       return [];
     }
 
-    const candidates = Array.isArray(removalEntries) ? removalEntries : [];
-    const indices = [];
-    const seen = new Set();
-    const settleColumnKeys = new Set();
+    const uniqueEntries = [];
+    const seenKeys = new Set();
 
     candidates.forEach((candidate) => {
-      if (!candidate) {
+      const rawEntry = candidate?.entry ?? candidate;
+      if (!rawEntry) {
         return;
       }
-      const entry = candidate.entry ?? candidate;
+      const key = rawEntry.coordinateKey ?? rawEntry.key;
+      if (!key || seenKeys.has(key)) {
+        return;
+      }
+      seenKeys.add(key);
+      let entry = rawEntry;
+      if (chunk.blockLookup?.has(key)) {
+        const lookup = chunk.blockLookup.get(key);
+        if (lookup) {
+          entry = lookup;
+        }
+      }
       if (!entry) {
         return;
       }
-      let index = Number.isInteger(candidate.instanceId)
-        ? candidate.instanceId
-        : Number.isInteger(entry.index)
-        ? entry.index
-        : null;
-      if (entry.key && chunk.blockLookup?.has(entry.key)) {
-        const lookup = chunk.blockLookup.get(entry.key);
-        if (Number.isInteger(lookup?.index)) {
-          index = lookup.index;
-        }
-      }
-      if (!Number.isInteger(index)) {
-        return;
-      }
-      if (index < 0 || index >= entries.length) {
-        return;
-      }
-      if (seen.has(index)) {
-        return;
-      }
-      const current = entries[index];
-      if (!current || (entry.key && current.key !== entry.key)) {
-        return;
-      }
-      seen.add(index);
-      indices.push(index);
+      uniqueEntries.push(entry);
     });
 
-    if (indices.length === 0) {
+    if (uniqueEntries.length === 0) {
       return [];
     }
 
-    indices.sort((a, b) => a - b);
-    const removalSet = new Set(indices);
     const removedEntries = [];
     const prototypeRefs = [];
+    const settleColumnKeys = new Set();
+    const visibilityPositions = [];
 
-    const writeTint = (index, tintColor) => {
-      if (!tintAttribute) {
-        return;
-      }
-      const tint = tintColor ?? mesh.userData?.defaultTint;
-      if (!tint) {
-        return;
-      }
-      const offset = index * 3;
-      tintAttribute.array[offset] = tint.r;
-      tintAttribute.array[offset + 1] = tint.g;
-      tintAttribute.array[offset + 2] = tint.b;
-    };
-
-    let writeIndex = 0;
-    const totalEntries = entries.length;
-    for (let readIndex = 0; readIndex < totalEntries; readIndex += 1) {
-      const entry = entries[readIndex];
+    uniqueEntries.forEach((entry) => {
       if (!entry) {
-        continue;
+        return;
       }
-      if (removalSet.has(readIndex)) {
-        removedEntries.push(entry);
-        if (entry.prototypeKey) {
-          prototypeRefs.push({ prototypeKey: entry.prototypeKey, entryKey: entry.key });
-        }
-        if (chunk.blockLookup) {
-          chunk.blockLookup.delete(entry.key);
-          if (entry.coordinateKey && entry.coordinateKey !== entry.key) {
-            chunk.blockLookup.delete(entry.coordinateKey);
-          }
-        }
-        if (entry.isSolid) {
-          const coordinateKey = entry.coordinateKey ?? entry.key;
-          chunk.solidBlockKeys.delete(coordinateKey);
-          solidBlocks.delete(coordinateKey);
-          if (entry.position) {
-            const settleKey = `${Math.round(entry.position.x)}|${Math.round(entry.position.z)}`;
-            settleColumnKeys.add(settleKey);
-          }
-        }
-        if (entry.collisionMode === 'soft') {
-          const coordinateKey = entry.coordinateKey ?? entry.key;
-          chunk.softBlockKeys.delete(coordinateKey);
-          softBlocks.delete(coordinateKey);
-        }
-        if (entry.isWater) {
-          const columnKey = `${entry.position.x}|${entry.position.z}`;
-          chunk.waterColumns?.delete?.(columnKey);
-          if (chunk.waterColumnKeys instanceof Set) {
-            chunk.waterColumnKeys.delete(columnKey);
-          }
-          waterColumns.delete(columnKey);
-        }
-        entry.index = -1;
-        continue;
+      removedEntries.push(entry);
+      if (entry.prototypeKey) {
+        prototypeRefs.push({ prototypeKey: entry.prototypeKey, entryKey: entry.key });
       }
-
-      if (writeIndex !== readIndex) {
-        entries[writeIndex] = entry;
-        mesh.setMatrixAt(writeIndex, entry.matrix);
-        writeTint(writeIndex, entry.tintColor);
+      if (Number.isInteger(entry.index) && entry.index >= 0) {
+        removeEntryFromChunkMesh(chunk, entry);
       }
-      entry.index = writeIndex;
       if (chunk.blockLookup) {
         if (entry.key) {
-          const lookup = chunk.blockLookup.get(entry.key);
-          if (lookup) {
-            lookup.index = writeIndex;
-          }
+          chunk.blockLookup.delete(entry.key);
         }
         if (entry.coordinateKey && entry.coordinateKey !== entry.key) {
-          const coordinateEntry = chunk.blockLookup.get(entry.coordinateKey);
-          if (coordinateEntry) {
-            coordinateEntry.index = writeIndex;
-          }
+          chunk.blockLookup.delete(entry.coordinateKey);
         }
       }
-      writeIndex += 1;
-    }
-
-    while (entries.length > writeIndex) {
-      entries.pop();
-    }
-
-    mesh.count = entries.length;
-    mesh.instanceMatrix.needsUpdate = true;
-    if (tintAttribute) {
-      tintAttribute.needsUpdate = true;
-    }
+      const coordinateKey = entry.coordinateKey ?? entry.key;
+      if (entry.isSolid && coordinateKey) {
+        chunk.solidBlockKeys?.delete(coordinateKey);
+        solidBlocks.delete(coordinateKey);
+        if (entry.position) {
+          const settleKey = `${Math.round(entry.position.x)}|${Math.round(entry.position.z)}`;
+          settleColumnKeys.add(settleKey);
+        }
+      }
+      if (entry.collisionMode === 'soft' && coordinateKey) {
+        chunk.softBlockKeys?.delete(coordinateKey);
+        softBlocks.delete(coordinateKey);
+      }
+      if (entry.isWater && entry.position) {
+        const columnKey = `${entry.position.x}|${entry.position.z}`;
+        chunk.waterColumns?.delete?.(columnKey);
+        if (chunk.waterColumnKeys instanceof Set) {
+          chunk.waterColumnKeys.delete(columnKey);
+        }
+        waterColumns.delete(columnKey);
+      }
+      if (coordinateKey && chunk.fluidBlockKeys instanceof Set) {
+        chunk.fluidBlockKeys.delete(coordinateKey);
+      }
+      if (chunk.typeCapacities instanceof Map && entry.type) {
+        const previous = chunk.typeCapacities.get(entry.type) ?? 0;
+        chunk.typeCapacities.set(entry.type, Math.max(0, previous - 1));
+      }
+      if (entry.position) {
+        visibilityPositions.push({
+          x: Math.round(entry.position.x),
+          y: Math.round(entry.position.y),
+          z: Math.round(entry.position.z),
+        });
+      } else if (coordinateKey) {
+        const coords = parseBlockCoordinateKey(coordinateKey);
+        if (coords) {
+          visibilityPositions.push(coords);
+        }
+      }
+      entry.index = -1;
+      entry.mesh = null;
+      entry.tintAttribute = null;
+    });
 
     prototypeRefs.forEach(({ prototypeKey, entryKey }) => {
       removePrototypePlacement(chunk, prototypeKey, entryKey);
@@ -1190,6 +1376,8 @@ export function createChunkManager({
         settleFluidColumn(chunk, columnKey);
       }
     });
+
+    refreshBlockVisibility(chunk, visibilityPositions);
 
     return removedEntries;
   }
@@ -1240,99 +1428,19 @@ export function createChunkManager({
 
 
   function removeBlockInstance({ chunk, type, instanceId }) {
-    if (!chunk || typeof instanceId !== 'number' || !chunk.typeData) {
+    if (!chunk || typeof instanceId !== 'number' || !(chunk.typeData instanceof Map)) {
       return null;
     }
     const typeData = chunk.typeData.get(type);
-    if (!typeData) {
+    if (!typeData || !Array.isArray(typeData.entries)) {
       return null;
     }
-    const { entries, mesh, tintAttribute } = typeData;
-    if (!mesh || !mesh.isInstancedMesh) {
+    if (instanceId < 0 || instanceId >= typeData.entries.length) {
       return null;
     }
-    if (instanceId < 0 || instanceId >= entries.length) {
-      return null;
-    }
-
-    const lastIndex = entries.length - 1;
-    const removed = entries[instanceId];
-
-    if (!removed) {
-      return null;
-    }
-
-    const writeTint = (index, tintColor) => {
-      if (!tintAttribute) {
-        return;
-      }
-      const tint = tintColor ?? mesh.userData?.defaultTint;
-      if (!tint) {
-        return;
-      }
-      const offset = index * 3;
-      tintAttribute.array[offset] = tint.r;
-      tintAttribute.array[offset + 1] = tint.g;
-      tintAttribute.array[offset + 2] = tint.b;
-    };
-
-    if (instanceId !== lastIndex) {
-      const swapped = entries[lastIndex];
-      entries[instanceId] = swapped;
-      mesh.setMatrixAt(instanceId, swapped.matrix);
-      writeTint(instanceId, swapped.tintColor);
-      mesh.instanceMatrix.needsUpdate = true;
-      if (chunk.blockLookup) {
-        const swappedInfo = chunk.blockLookup.get(swapped.key);
-        if (swappedInfo) {
-          swappedInfo.index = instanceId;
-        }
-      }
-      swapped.index = instanceId;
-    }
-
-    entries.pop();
-    mesh.count = entries.length;
-    mesh.instanceMatrix.needsUpdate = true;
-    if (tintAttribute) {
-      tintAttribute.needsUpdate = true;
-    }
-
-    if (chunk.blockLookup) {
-      chunk.blockLookup.delete(removed.key);
-      if (removed.coordinateKey && removed.coordinateKey !== removed.key) {
-        chunk.blockLookup.delete(removed.coordinateKey);
-      }
-    }
-    if (removed.isSolid) {
-      const coordinateKey = removed.coordinateKey ?? removed.key;
-      chunk.solidBlockKeys.delete(coordinateKey);
-      solidBlocks.delete(coordinateKey);
-    }
-    if (removed.collisionMode === 'soft') {
-      const coordinateKey = removed.coordinateKey ?? removed.key;
-      chunk.softBlockKeys.delete(coordinateKey);
-      softBlocks.delete(coordinateKey);
-    }
-    if (removed.isWater) {
-      const columnKey = `${removed.position.x}|${removed.position.z}`;
-      chunk.waterColumns?.delete?.(columnKey);
-      if (chunk.waterColumnKeys instanceof Set) {
-        chunk.waterColumnKeys.delete(columnKey);
-      }
-      waterColumns.delete(columnKey);
-    }
-
-    if (removed.prototypeKey) {
-      removePrototypePlacement(chunk, removed.prototypeKey, removed.key);
-    }
-
-    if (removed.isSolid && removed.position) {
-      const columnKey = `${Math.round(removed.position.x)}|${Math.round(removed.position.z)}`;
-      settleFluidColumn(chunk, columnKey);
-    }
-
-    return removed;
+    const target = typeData.entries[instanceId];
+    const removed = removeBlockInstancesBulk({ chunk, type, entries: [target] });
+    return removed.length > 0 ? removed[0] : null;
   }
 
   function removeDecorationGroupsBulk({ chunk, type, groups }) {

--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -23,6 +23,171 @@ import { worldOptions, applyWorldOptions } from './world-settings.js';
 import { configureSectorObjectPlanner } from './sector-object-planner.js';
 export { worldOptions, getWorldOptions } from './world-settings.js';
 
+const MESHING_MODE_STORAGE_KEY = 'voxelMeshingMode';
+
+const normalizeMeshingMode = (value) => {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (['legacy', 'old', 'classic', 'cubes'].includes(normalized)) {
+    return 'legacy';
+  }
+  if (['compare', 'both', 'debug'].includes(normalized)) {
+    return 'compare';
+  }
+  if (['greedy', 'new', 'modern', 'default'].includes(normalized)) {
+    return 'greedy';
+  }
+  return null;
+};
+
+let meshingDebugMode = 'greedy';
+
+const persistMeshingMode = (mode) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage?.setItem(MESHING_MODE_STORAGE_KEY, mode);
+  } catch (error) {
+    console.warn('[browser] [meshing debug] failed to persist meshing mode', error);
+  }
+};
+
+const resolveMeshingModeFromQuery = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('meshing')) {
+      return null;
+    }
+    return normalizeMeshingMode(params.get('meshing'));
+  } catch (error) {
+    console.warn('[browser] [meshing debug] failed to resolve query mode', error);
+    return null;
+  }
+};
+
+const resolveMeshingModeFromStorage = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = window.localStorage?.getItem(MESHING_MODE_STORAGE_KEY);
+    return normalizeMeshingMode(stored);
+  } catch (error) {
+    console.warn('[browser] [meshing debug] failed to resolve stored mode', error);
+    return null;
+  }
+};
+
+export const getMeshingDebugMode = () => meshingDebugMode;
+
+export const isLegacyMeshingEnabled = () => meshingDebugMode === 'legacy';
+
+export const setMeshingDebugMode = (mode, { persist = true } = {}) => {
+  const normalized = normalizeMeshingMode(mode) ?? 'greedy';
+  meshingDebugMode = normalized;
+  if (persist) {
+    persistMeshingMode(normalized);
+  }
+  return meshingDebugMode;
+};
+
+export const initializeMeshingDebug = ({
+  defaultMode = 'greedy',
+  persistDefault = false,
+  forceDefault = false,
+} = {}) => {
+  const fromQuery = resolveMeshingModeFromQuery();
+  if (fromQuery) {
+    return setMeshingDebugMode(fromQuery, { persist: false });
+  }
+
+  if (!forceDefault) {
+    const fromStorage = resolveMeshingModeFromStorage();
+    if (fromStorage) {
+      return setMeshingDebugMode(fromStorage, { persist: false });
+    }
+  }
+
+  return setMeshingDebugMode(defaultMode, { persist: persistDefault });
+};
+
+export const makeBlockKey = (x, y, z) =>
+  `${Math.round(x)}|${Math.round(y)}|${Math.round(z)}`;
+
+let sharedBlockGeometry = null;
+
+export const ensureBlockGeometry = (THREE) => {
+  if (!sharedBlockGeometry) {
+    sharedBlockGeometry = new THREE.BoxGeometry(1, 1, 1);
+  }
+  return sharedBlockGeometry;
+};
+
+export const buildInstancedBlockMesh = ({
+  THREE,
+  blockMaterials,
+  type,
+  entries = [],
+  capacity,
+}) => {
+  const instanceCapacity = Math.max(
+    1,
+    Number.isInteger(capacity) && capacity > 0
+      ? capacity
+      : Array.isArray(entries)
+      ? entries.length
+      : 0,
+  );
+  const geometry = ensureBlockGeometry(THREE).clone();
+  const mesh = new THREE.InstancedMesh(
+    geometry,
+    blockMaterials[type],
+    instanceCapacity,
+  );
+  mesh.userData.defaultTint = new THREE.Color(1, 1, 1);
+
+  const entryCount = Array.isArray(entries) ? entries.length : 0;
+  const tintArray = new Float32Array(instanceCapacity * 3);
+  const tintAttribute = new THREE.InstancedBufferAttribute(tintArray, 3);
+  tintAttribute.setUsage(THREE.DynamicDrawUsage);
+  mesh.geometry.setAttribute('biomeTint', tintAttribute);
+
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = entries[index];
+    if (!entry) {
+      continue;
+    }
+    mesh.setMatrixAt(index, entry.matrix);
+    entry.index = index;
+    const tint = entry.tintColor ?? mesh.userData.defaultTint;
+    const offset = index * 3;
+    tintAttribute.array[offset] = tint.r;
+    tintAttribute.array[offset + 1] = tint.g;
+    tintAttribute.array[offset + 2] = tint.b;
+    entry.mesh = mesh;
+    entry.tintAttribute = tintAttribute;
+  }
+
+  mesh.count = entryCount;
+  mesh.instanceMatrix.needsUpdate = entryCount > 0;
+  tintAttribute.needsUpdate = entryCount > 0;
+  mesh.castShadow = ['cloud', 'water'].includes(type) ? false : true;
+  mesh.receiveShadow = type !== 'cloud';
+  mesh.frustumCulled = false;
+  mesh.userData.type = type;
+  mesh.userData.biomePalette = true;
+  mesh.userData.biomeTintAttribute = tintAttribute;
+  mesh.userData.capacity = instanceCapacity;
+
+  return { mesh, tintAttribute };
+};
+
 initializeFluidDebug({ defaultEnabled: false, persistDefault: true, forceDefault: true });
 
 function clamp(value, min, max) {
@@ -30,7 +195,6 @@ function clamp(value, min, max) {
 }
 
 let THREERef = null;
-let blockGeometry = null;
 let terrainEngine = null;
 let worldSeedHash = worldOptions.seedHash >>> 0;
 
@@ -73,7 +237,7 @@ export function initializeWorldGeneration({ THREE, worldOptions: overrides } = {
     disposeTerrainEngineInstance(terrainEngine);
   }
 
-  blockGeometry = new THREE.BoxGeometry(1, 1, 1);
+  initializeMeshingDebug({ defaultMode: 'greedy', persistDefault: true, forceDefault: false });
   terrainEngine = createTerrainEngine({
     THREE,
     seed: worldSeedHash,
@@ -199,10 +363,6 @@ export function sampleBiomeCoverage({
 
 const solidTypes = new Set(['grass', 'dirt', 'stone', 'sand', 'leaf', 'log', 'snow']);
 
-function blockKey(x, y, z) {
-  return `${x}|${y}|${z}`;
-}
-
 function addCloud(addBlock, x, y, z) {
   const blocks = [
     [0, 0, 0],
@@ -228,9 +388,6 @@ function chunkWorldBounds(chunkX, chunkZ) {
 export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const THREE = ensureThree();
   const engine = ensureTerrainEngine();
-  if (!blockGeometry) {
-    blockGeometry = new THREE.BoxGeometry(1, 1, 1);
-  }
   const instancedData = new Map();
   const decorationInstancedData = new Map();
   const decorationData = new Map();
@@ -242,6 +399,9 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const waterColumnMetadata = new Map();
   const fluidColumnsByType = new Map();
   const fluidSurfaces = [];
+  const pendingEntries = new Map();
+  const typeCapacities = new Map();
+  const fluidBlockKeys = new Set();
   let minBoundX = Number.POSITIVE_INFINITY;
   let minBoundY = Number.POSITIVE_INFINITY;
   let minBoundZ = Number.POSITIVE_INFINITY;
@@ -524,13 +684,9 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   const addBlock = (type, x, y, z, biome, options = {}) => {
     const entry = createInstancedEntry(type, x, y, z, biome, options);
 
-    if (!instancedData.has(type)) {
-      instancedData.set(type, []);
-    }
-
     const coordinateKey = entry.coordinateKey;
     const key = entry.key;
-    const existingEntry = coordinateKey ? blockLookup.get(coordinateKey) : null;
+    const existingEntry = coordinateKey ? pendingEntries.get(coordinateKey) : null;
     const replaceExisting = options.replaceExisting === true;
 
     const isWater = type === 'water';
@@ -556,6 +712,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         : !isFluid && type !== 'cloud';
 
     if (isFluid) {
+      fluidBlockKeys.add(coordinateKey);
       if (!fluidColumnsByType.has(type)) {
         fluidColumnsByType.set(type, new Map());
       }
@@ -606,8 +763,10 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
           });
         }
       }
-      return;
+      return entry;
     }
+
+    fluidBlockKeys.delete(coordinateKey);
 
     entry.isSolid = isSolid;
     entry.isWater = isWater;
@@ -625,28 +784,26 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       shouldReplaceExisting &&
       (replaceExisting || existingIsSolid || isSolid)
     ) {
-      const existingEntries = instancedData.get(existingEntry.type);
-      if (existingEntries) {
-        const existingIndex = existingEntries.indexOf(existingEntry);
-        if (existingIndex !== -1) {
-          existingEntries.splice(existingIndex, 1);
-        }
-      }
-
       if (existingEntry.key) {
         blockLookup.delete(existingEntry.key);
       }
       if (existingEntry.coordinateKey) {
         blockLookup.delete(existingEntry.coordinateKey);
-      }
-
-      if (existingEntry.coordinateKey) {
         solidBlockKeys.delete(existingEntry.coordinateKey);
         softBlockKeys.delete(existingEntry.coordinateKey);
       }
+      pendingEntries.delete(existingEntry.coordinateKey);
+      if (existingEntry.type) {
+        const previous = typeCapacities.get(existingEntry.type) ?? 1;
+        typeCapacities.set(existingEntry.type, Math.max(0, previous - 1));
+      }
+    } else if (existingEntry) {
+      return existingEntry;
     }
 
-    instancedData.get(type).push(entry);
+    pendingEntries.set(coordinateKey, entry);
+    typeCapacities.set(type, (typeCapacities.get(type) ?? 0) + 1);
+
     blockLookup.set(key, entry);
     if (key !== coordinateKey) {
       blockLookup.set(coordinateKey, entry);
@@ -657,6 +814,9 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     if (isSoft) {
       softBlockKeys.add(coordinateKey);
     }
+    entry.index = -1;
+    entry.mesh = null;
+    entry.tintAttribute = null;
     return entry;
   };
 
@@ -973,53 +1133,51 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     return instanceKey;
   };
 
-  const buildInstancedMesh = (entries, type) => {
-    const geometry = blockGeometry.clone();
-    const mesh = new THREE.InstancedMesh(
-      geometry,
-      blockMaterials[type],
-      entries.length,
+  const buildInstancedMesh = (entries, type, { capacity } = {}) => {
+    const effectiveCapacity = Math.max(
+      Array.isArray(entries) ? entries.length : 0,
+      Number.isInteger(capacity) && capacity > 0 ? capacity : 0,
     );
-    mesh.userData.defaultTint = new THREE.Color(1, 1, 1);
-
-    const tintArray = new Float32Array(entries.length * 3);
-    const tintAttribute = new THREE.InstancedBufferAttribute(tintArray, 3);
-    tintAttribute.setUsage(THREE.DynamicDrawUsage);
-    mesh.geometry.setAttribute('biomeTint', tintAttribute);
-
-    entries.forEach((entry, index) => {
-      mesh.setMatrixAt(index, entry.matrix);
-      entry.index = index;
-      const tint = entry.tintColor ?? mesh.userData.defaultTint;
-      const offset = index * 3;
-      tintAttribute.array[offset] = tint.r;
-      tintAttribute.array[offset + 1] = tint.g;
-      tintAttribute.array[offset + 2] = tint.b;
+    const { mesh, tintAttribute } = buildInstancedBlockMesh({
+      THREE,
+      blockMaterials,
+      type,
+      entries,
+      capacity: effectiveCapacity,
     });
-
-    mesh.count = entries.length;
-    mesh.instanceMatrix.needsUpdate = true;
-    tintAttribute.needsUpdate = true;
-    mesh.castShadow = ['cloud', 'water'].includes(type) ? false : true;
-    mesh.receiveShadow = type !== 'cloud';
-    mesh.frustumCulled = false;
-    mesh.userData.type = type;
-    mesh.userData.biomePalette = true;
-    mesh.userData.biomeTintAttribute = tintAttribute;
-
     return { mesh, tintAttribute };
   };
 
-  const addMeshesFromMap = (targetGroup, map) => {
-    map.forEach((entries, type) => {
+  instancedData.forEach((entries, type) => {
+    if (!typeCapacities.has(type)) {
+      typeCapacities.set(type, entries.length);
+    }
+  });
+
+  const addMeshesFromMap = (targetGroup) => {
+    typeCapacities.forEach((capacity, type) => {
       if (isFluidType(type)) {
         return;
       }
-      if (!entries || entries.length === 0) {
+      const entries = instancedData.get(type) ?? [];
+      const effectiveCapacity = Math.max(capacity ?? 0, entries.length);
+      if (effectiveCapacity <= 0 && entries.length === 0) {
         return;
       }
-      const { mesh, tintAttribute } = buildInstancedMesh(entries, type);
-      typeData.set(type, { entries, mesh, tintAttribute });
+      const { mesh, tintAttribute } = buildInstancedMesh(entries, type, {
+        capacity: Math.max(1, effectiveCapacity),
+      });
+      mesh.count = entries.length;
+      mesh.instanceMatrix.needsUpdate = entries.length > 0;
+      if (tintAttribute) {
+        tintAttribute.needsUpdate = entries.length > 0;
+      }
+      typeData.set(type, {
+        entries,
+        mesh,
+        tintAttribute,
+        capacity: Math.max(1, effectiveCapacity),
+      });
       targetGroup.add(mesh);
     });
   };
@@ -1178,6 +1336,190 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
       });
     }
   }
+
+  const parseBlockKey = (key) => {
+    if (!key || typeof key !== 'string') {
+      return null;
+    }
+    const parts = key.split('|');
+    if (parts.length !== 3) {
+      return null;
+    }
+    const x = Number.parseInt(parts[0], 10);
+    const y = Number.parseInt(parts[1], 10);
+    const z = Number.parseInt(parts[2], 10);
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+      return null;
+    }
+    return { x, y, z };
+  };
+
+  const pendingValues = Array.from(pendingEntries.values());
+  let occupancyMinY = Number.POSITIVE_INFINITY;
+  let occupancyMaxY = Number.NEGATIVE_INFINITY;
+
+  const registerHeightBounds = (value) => {
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    occupancyMinY = Math.min(occupancyMinY, value);
+    occupancyMaxY = Math.max(occupancyMaxY, value);
+  };
+
+  pendingValues.forEach((entry) => {
+    if (!entry?.position) {
+      return;
+    }
+    registerHeightBounds(Math.round(entry.position.y));
+  });
+
+  fluidBlockKeys.forEach((key) => {
+    const coords = parseBlockKey(key);
+    if (!coords) {
+      return;
+    }
+    registerHeightBounds(coords.y);
+  });
+
+  if (occupancyMinY === Number.POSITIVE_INFINITY) {
+    occupancyMinY = Math.floor(waterLevel ?? 0);
+    occupancyMaxY = occupancyMinY;
+  }
+
+  const occupancyWidth = chunkSize;
+  const occupancyDepth = chunkSize;
+  const occupancyHeight = Math.max(1, occupancyMaxY - occupancyMinY + 1);
+  const occupancyArea = occupancyWidth * occupancyDepth;
+  const occupancyData = new Array(occupancyArea * occupancyHeight).fill(null);
+  const fluidOccupancy = new Uint8Array(occupancyArea * occupancyHeight);
+
+  const toIndex = (lx, ly, lz) => ly * occupancyArea + lz * occupancyWidth + lx;
+
+  const assignLocalGridPosition = (entry) => {
+    if (!entry?.position) {
+      entry.gridPosition = null;
+      return null;
+    }
+    const lx = Math.round(entry.position.x - minX);
+    const lz = Math.round(entry.position.z - minZ);
+    const ly = Math.round(entry.position.y) - occupancyMinY;
+    if (
+      lx < 0 ||
+      lx >= occupancyWidth ||
+      lz < 0 ||
+      lz >= occupancyDepth ||
+      ly < 0 ||
+      ly >= occupancyHeight
+    ) {
+      entry.gridPosition = null;
+      return null;
+    }
+    const local = { x: lx, y: ly, z: lz };
+    entry.gridPosition = local;
+    return local;
+  };
+
+  pendingValues.forEach((entry) => {
+    const local = assignLocalGridPosition(entry);
+    if (!local) {
+      return;
+    }
+    const index = toIndex(local.x, local.y, local.z);
+    occupancyData[index] = entry;
+  });
+
+  fluidBlockKeys.forEach((key) => {
+    const coords = parseBlockKey(key);
+    if (!coords) {
+      return;
+    }
+    const lx = Math.round(coords.x - minX);
+    const lz = Math.round(coords.z - minZ);
+    const ly = Math.round(coords.y) - occupancyMinY;
+    if (
+      lx < 0 ||
+      lx >= occupancyWidth ||
+      lz < 0 ||
+      lz >= occupancyDepth ||
+      ly < 0 ||
+      ly >= occupancyHeight
+    ) {
+      return;
+    }
+    const index = toIndex(lx, ly, lz);
+    fluidOccupancy[index] = 1;
+  });
+
+  const meshingMode = getMeshingDebugMode();
+  const legacyMeshing = meshingMode === 'legacy';
+
+  const neighborOffsets3D = [
+    { dx: 1, dy: 0, dz: 0 },
+    { dx: -1, dy: 0, dz: 0 },
+    { dx: 0, dy: 1, dz: 0 },
+    { dx: 0, dy: -1, dz: 0 },
+    { dx: 0, dy: 0, dz: 1 },
+    { dx: 0, dy: 0, dz: -1 },
+  ];
+
+  pendingEntries.forEach((entry) => {
+    if (!entry) {
+      return;
+    }
+    const local = entry.gridPosition;
+    let exposed = legacyMeshing;
+    if (!local) {
+      exposed = true;
+    }
+    if (!exposed && local) {
+      for (let i = 0; i < neighborOffsets3D.length; i += 1) {
+        const offset = neighborOffsets3D[i];
+        const nx = local.x + offset.dx;
+        const ny = local.y + offset.dy;
+        const nz = local.z + offset.dz;
+        if (
+          nx < 0 ||
+          nx >= occupancyWidth ||
+          nz < 0 ||
+          nz >= occupancyDepth ||
+          ny < 0 ||
+          ny >= occupancyHeight
+        ) {
+          exposed = true;
+          break;
+        }
+        const neighborIndex = toIndex(nx, ny, nz);
+        const neighborEntry = occupancyData[neighborIndex];
+        if (!neighborEntry) {
+          if (fluidOccupancy[neighborIndex] === 1) {
+            exposed = true;
+            break;
+          }
+          exposed = true;
+          break;
+        }
+        if (neighborEntry === entry) {
+          continue;
+        }
+        if (neighborEntry.collisionMode !== 'solid') {
+          exposed = true;
+          break;
+        }
+      }
+    }
+
+    if (exposed) {
+      if (!instancedData.has(entry.type)) {
+        instancedData.set(entry.type, []);
+      }
+      instancedData.get(entry.type).push(entry);
+    } else {
+      entry.index = -1;
+      entry.mesh = null;
+      entry.tintAttribute = null;
+    }
+    entry.isVisible = exposed;
+  });
 
   const neighborOffsets = [
     { key: 'px', dx: 1, dz: 0 },
@@ -1462,7 +1804,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
   }
 
   const group = new THREE.Group();
-  addMeshesFromMap(group, instancedData);
+  addMeshesFromMap(group);
   decorationInstancedData.forEach((entries, type) => {
     addDecorationMesh(group, type, entries);
   });
@@ -1496,10 +1838,12 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     group,
     solidBlockKeys,
     softBlockKeys,
+    typeCapacities,
     waterColumns: waterColumnMetadata,
     fluidColumnsByType,
     fluidSurfaces,
     blockLookup,
+    fluidBlockKeys,
     typeData,
     decorationData,
     decorationGroups,


### PR DESCRIPTION
## Summary
- build a dense chunk occupancy grid to skip occluded voxels, attach capacity metadata, and provide a meshing debug toggle
- reuse the new instancing helpers to allocate meshes on demand and to support both legacy and greedy visibility modes
- refresh chunk visibility after block mutations so newly exposed faces are emitted when terrain is modified

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6657b6c34832a81105662610a534c