### PR TITLE
Fix block coordinate key helper usage

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -598,7 +598,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
 
     updateBoundsFromVisual(visualPosition, visualScaleVector);
 
-    const coordinateKey = blockKey(x, y, z);
+    const coordinateKey = makeBlockKey(x, y, z);
     const key = options.key ?? coordinateKey;
 
     const paletteColor = engine.getBlockColor(biome, type);


### PR DESCRIPTION
## Summary
- use the existing makeBlockKey helper when creating instanced chunk entries to avoid undefined references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6712967ac832a8406af80049b35a9