### PR TITLE
Handle transparent solids when culling fluid and block faces

### DIFF
--- a/three-demo/src/world/generation.js
+++ b/three-demo/src/world/generation.js
@@ -1462,6 +1462,17 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
     { dx: 0, dy: 0, dz: -1 },
   ];
 
+  const isOccludingSolid = (entry) => {
+    if (!entry || entry.collisionMode !== 'solid') {
+      return false;
+    }
+    const material = blockMaterials?.[entry.type];
+    if (material && material.transparent) {
+      return false;
+    }
+    return true;
+  };
+
   const isFluidColumnExposed = (column) => {
     if (!column) {
       return false;
@@ -1542,7 +1553,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
           }
           return true;
         }
-        if (neighborEntry.collisionMode !== 'solid') {
+        if (!isOccludingSolid(neighborEntry)) {
           return true;
         }
       }
@@ -1590,7 +1601,7 @@ export function generateChunk(blockMaterials, chunkX, chunkZ) {
         if (neighborEntry === entry) {
           continue;
         }
-        if (neighborEntry.collisionMode !== 'solid') {
+        if (!isOccludingSolid(neighborEntry)) {
           exposed = true;
           break;
         }


### PR DESCRIPTION
## Summary
- ensure `isFluidColumnExposed` treats transparent solid neighbors as exposing faces based on block material metadata in `world/generation`
- reuse the same transparency-aware occlusion helper for block occupancy culling so nearby faces remain visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68ac7e770832aad4f4f829de21bbb