### PR TITLE
Preserve typed array payloads in worker snapshots

### DIFF
--- a/three-demo/src/world/__tests__/chunk-build-core.test.js
+++ b/three-demo/src/world/__tests__/chunk-build-core.test.js
@@ -433,19 +433,44 @@ test('buildChunkPayload normalizes occupancy, fluid, and decoration payloads', (
     },
   ]);
 
-  assert.deepStrictEqual(payload.decorations.batches, [
-    {
-      type: 'flora',
-      capacity: 10,
-      entryKeys: ['fern-a'],
-      entries: [
-        {
-          transform: [1, 0, 0, 0],
-          tags: ['flora'],
-        },
-      ],
-    },
-  ]);
+  const [floraBatch] = payload.decorations.batches;
+  assert.ok(floraBatch, 'expected flora decoration batch');
+  assert.strictEqual(floraBatch.type, 'flora');
+  assert.strictEqual(floraBatch.capacity, 10);
+  assert.deepStrictEqual(floraBatch.entryKeys, ['fern-a']);
+  const [floraEntry] = floraBatch.entries;
+  assert.ok(floraEntry, 'expected flora decoration entry');
+  assert.deepStrictEqual(floraEntry.tags, ['flora']);
+  assert.ok(ArrayBuffer.isView(floraEntry.transform));
+  assertFloatArrayClose(floraEntry.transform, [1, 0, 0, 0]);
+  assert.strictEqual(floraEntry.key, 'fern-a');
+  assert.strictEqual(floraEntry.coordinateKey, null);
+  assert.strictEqual(floraEntry.type, null);
+  assert.strictEqual(floraEntry.biomeId, null);
+  assert.ok(ArrayBuffer.isView(floraEntry.matrix));
+  assertFloatArrayClose(floraEntry.matrix, new Array(16).fill(0));
+  assert.ok(ArrayBuffer.isView(floraEntry.position));
+  assertFloatArrayClose(floraEntry.position, [0, 0, 0]);
+  assert.ok(ArrayBuffer.isView(floraEntry.scale));
+  assertFloatArrayClose(floraEntry.scale, [0, 0, 0]);
+  assert.ok(ArrayBuffer.isView(floraEntry.visualScale));
+  assertFloatArrayClose(floraEntry.visualScale, [0, 0, 0]);
+  assert.ok(ArrayBuffer.isView(floraEntry.visualOffset));
+  assertFloatArrayClose(floraEntry.visualOffset, [0, 0, 0]);
+  assert.strictEqual(floraEntry.paletteColor, null);
+  assert.strictEqual(floraEntry.tintColor, null);
+  assert.strictEqual(floraEntry.tintOverride, null);
+  assert.strictEqual(floraEntry.destructible, null);
+  assert.strictEqual(floraEntry.collisionMode, null);
+  assert.strictEqual(floraEntry.isSolid, null);
+  assert.strictEqual(floraEntry.isSoft, null);
+  assert.strictEqual(floraEntry.isDecoration, false);
+  assert.strictEqual(floraEntry.isVisible, null);
+  assert.strictEqual(floraEntry.sourceObjectId, null);
+  assert.strictEqual(floraEntry.voxelIndex, null);
+  assert.strictEqual(floraEntry.prototypeKey, null);
+  assert.strictEqual(floraEntry.prototypeLocalKey, null);
+  assert.strictEqual(floraEntry.metadata, null);
 
   assert.deepStrictEqual(payload.decorations.groups, [
     {

--- a/three-demo/src/world/__tests__/chunk-worker-typed-array-regression.test.js
+++ b/three-demo/src/world/__tests__/chunk-worker-typed-array-regression.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import * as THREE from 'three';
+
+const biomeDefinition = JSON.parse(
+  await readFile(new URL('../biomes/temperate.json', import.meta.url), 'utf8'),
+);
+
+globalThis.__BIOME_MODULE_MAP__ = {
+  './temperate.json': biomeDefinition,
+};
+
+const voxelObjectDefinition = JSON.parse(
+  await readFile(
+    new URL('../voxel-objects/small-plants/temperate_shrub.json', import.meta.url),
+    'utf8',
+  ),
+);
+
+globalThis.__VOXEL_OBJECT_MODULE_MAP__ = {
+  './small-plants/temperate_shrub.json': voxelObjectDefinition,
+};
+
+const generationModule = await import('../generation.js');
+generationModule.initializeWorldGeneration({ THREE });
+const fluidRegistryModule = await import('../fluids/fluid-registry.js');
+fluidRegistryModule.initializeFluidRegistry({ THREE });
+
+const { createChunkManager } = await import('../chunk-manager.js');
+const worldOptions = generationModule.getWorldOptions();
+
+function createBlockMaterials() {
+  const createdMaterials = new Set();
+  const registry = new Proxy(
+    {},
+    {
+      get(target, property) {
+        if (property in target) {
+          return target[property];
+        }
+        if (typeof property !== 'string') {
+          return target[property];
+        }
+        const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
+        target[property] = material;
+        createdMaterials.add(material);
+        return material;
+      },
+    },
+  );
+  return {
+    registry,
+    dispose: () => createdMaterials.forEach((material) => material.dispose?.()),
+  };
+}
+
+function findPayloadWithTransform(records) {
+  if (!Array.isArray(records)) {
+    return null;
+  }
+  for (const record of records) {
+    const entryPayloads = Array.isArray(record?.entryPayloads)
+      ? record.entryPayloads
+      : [];
+    for (const entry of entryPayloads) {
+      if (entry?.matrix && entry?.position) {
+        return entry;
+      }
+    }
+  }
+  return null;
+}
+
+test('retention worker payload keeps typed arrays while lean cache snapshot is plain arrays', async () => {
+  const { registry: blockMaterials, dispose } = createBlockMaterials();
+
+  try {
+    const candidateChunks = [];
+    const searchRange = 3;
+    for (let x = -searchRange; x <= searchRange; x += 1) {
+      for (let z = -searchRange; z <= searchRange; z += 1) {
+        candidateChunks.push({ chunkX: x, chunkZ: z });
+      }
+    }
+
+    let retentionTask = null;
+    let retentionPayload = null;
+    let typedEntry = null;
+    let targetChunk = null;
+
+    for (const coords of candidateChunks) {
+      const task = generationModule.createChunkBuildTask({
+        chunkX: coords.chunkX,
+        chunkZ: coords.chunkZ,
+        blockMaterials,
+        detailLevel: 'core',
+        requireWorkerPayload: true,
+      });
+
+      let done = false;
+      while (!done) {
+        done = Boolean(task.step(32)?.done);
+      }
+
+      const payload = task.exportPayloadSnapshot();
+      const entry = findPayloadWithTransform(payload?.typeMetadata);
+      if (entry) {
+        payload.detailLevel = 'retention';
+        retentionTask = task;
+        retentionPayload = payload;
+        typedEntry = entry;
+        targetChunk = coords;
+        break;
+      }
+
+      task.releaseCachedPayload?.();
+    }
+
+    assert.ok(typedEntry, 'expected to find retention payload with instanced metadata');
+    assert.ok(targetChunk, 'target chunk coordinates should be resolved');
+    assert.ok(ArrayBuffer.isView(typedEntry.matrix), 'matrix should remain a typed array');
+    assert.ok(typedEntry.matrix instanceof Float32Array, 'matrix should be Float32Array');
+    assert.ok(!Array.isArray(typedEntry.matrix));
+    assert.ok(ArrayBuffer.isView(typedEntry.position), 'position should remain a typed array');
+    assert.ok(typedEntry.position instanceof Float32Array, 'position should be Float32Array');
+    assert.ok(!Array.isArray(typedEntry.position));
+
+    const scene = new THREE.Scene();
+    const manager = createChunkManager({
+      scene,
+      blockMaterials,
+      viewDistance: 0,
+      retainDistance: 0,
+      maxPreloadPerUpdate: 4,
+      maxActivationsPerUpdate: 4,
+      maxDisposalsPerUpdate: 0,
+      payloadCacheSize: 4,
+    });
+
+    try {
+      const leanPayload = manager.__createLeanCachePayloadForTest?.(retentionPayload);
+      assert.ok(leanPayload, 'expected lean cache payload to be produced');
+      const leanEntry = findPayloadWithTransform(leanPayload.typeMetadata);
+      assert.ok(leanEntry, 'expected lean payload to retain instanced metadata');
+      assert.ok(Array.isArray(leanEntry.matrix));
+      assert.ok(!ArrayBuffer.isView(leanEntry.matrix));
+      assert.deepStrictEqual(leanEntry.matrix, Array.from(typedEntry.matrix));
+      assert.ok(Array.isArray(leanEntry.position));
+      assert.ok(!ArrayBuffer.isView(leanEntry.position));
+      assert.deepStrictEqual(leanEntry.position, Array.from(typedEntry.position));
+    } finally {
+      await manager.dispose();
+    }
+
+    retentionTask?.releaseCachedPayload?.();
+  } finally {
+    dispose();
+  }
+});

--- a/three-demo/src/world/chunk-build-core.js
+++ b/three-demo/src/world/chunk-build-core.js
@@ -1,5 +1,25 @@
 import { serializeInstancedEntry } from './chunk-payload-serializers.js';
 
+const mergeInstancedPayload = (entry, fallback = null) => {
+  const serialized = serializeInstancedEntry(entry);
+  const baseSource =
+    entry?.payload && typeof entry.payload === 'object'
+      ? entry.payload
+      : fallback && typeof fallback === 'object'
+      ? fallback
+      : null;
+  if (!serialized) {
+    return baseSource ? { ...baseSource } : serialized ?? fallback ?? null;
+  }
+  const merged = baseSource ? { ...baseSource } : {};
+  Object.entries(serialized).forEach(([key, value]) => {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  });
+  return merged;
+};
+
 const DEFAULT_CHUNK_SIZE = 16;
 export const MAX_OCCUPANCY_COORDINATE_SNAPSHOT = 4096;
 export const MAX_COORDINATE_INDEX_ENTRIES = 8192;
@@ -220,12 +240,13 @@ const serializeFluidColumnsByType = (source) => {
           ? column.shoreline
           : 0;
         exposed[index] = column.isExposed ? 1 : 0;
-        metadata[index] = normalizeSerializable({
-          biome: column.biome ?? null,
-          lifecycleCues:
-            column.lifecycleCues instanceof Set
-              ? Array.from(column.lifecycleCues)
-              : column.lifecycleCues ?? null,
+        metadata[index] = normalizeSerializable(
+          {
+            biome: column.biome ?? null,
+            lifecycleCues:
+              column.lifecycleCues instanceof Set
+                ? Array.from(column.lifecycleCues)
+                : column.lifecycleCues ?? null,
           auroraIntensitySum: column.auroraIntensitySum ?? null,
           auroraIntensitySamples: column.auroraIntensitySamples ?? null,
           glowBiasSum: column.glowBiasSum ?? null,
@@ -248,9 +269,11 @@ const serializeFluidColumnsByType = (source) => {
           ribbonOrientation: column.ribbonOrientation ?? null,
           ribbonVector: column.ribbonVector ?? null,
           ribbonSegments: column.ribbonSegments ?? null,
-          ribbonSpan: column.ribbonSpan ?? null,
-          ribbonHeight: column.ribbonHeight ?? null,
-        });
+            ribbonSpan: column.ribbonSpan ?? null,
+            ribbonHeight: column.ribbonHeight ?? null,
+          },
+          { preserveTyped: true },
+        );
       });
       return {
         type,
@@ -331,7 +354,9 @@ const serializeDecorationBatches = (instancedSource, decorationData) => {
       ? Array.from(value.values())
       : [];
     const serializedEntries = entryArray.map((entry) =>
-      normalizeSerializable(entry?.payload ?? serializeInstancedEntry(entry)),
+      normalizeSerializable(mergeInstancedPayload(entry), {
+        preserveTyped: true,
+      }),
     );
     const capacityCandidate = dataMap?.get(type)?.capacity ?? entryArray.length;
     const entryKeys = entryArray
@@ -437,7 +462,8 @@ const serializeDecorationTypeIndex = (source) => {
   return result;
 };
 
-const normalizeSerializable = (value) => {
+const normalizeSerializable = (value, options = {}) => {
+  const { preserveTyped = false } = options;
   if (value === null || value === undefined) {
     return null;
   }
@@ -449,15 +475,15 @@ const normalizeSerializable = (value) => {
     return value;
   }
   if (isTypedArray(value)) {
-    return Array.from(value);
+    return preserveTyped ? value : Array.from(value);
   }
   if (Array.isArray(value)) {
-    return value.map((entry) => normalizeSerializable(entry));
+    return value.map((entry) => normalizeSerializable(entry, options));
   }
   if (typeof value === 'object') {
     const result = {};
     Object.entries(value).forEach(([key, entry]) => {
-      const normalized = normalizeSerializable(entry);
+      const normalized = normalizeSerializable(entry, options);
       if (normalized !== undefined) {
         result[key] = normalized;
       }
@@ -466,6 +492,9 @@ const normalizeSerializable = (value) => {
   }
   return undefined;
 };
+
+export const normalizeSerializableToPlain = (value) =>
+  normalizeSerializable(value, { preserveTyped: false });
 
 const extractBiomePayload = (engine) => {
   if (!engine) {
@@ -571,7 +600,9 @@ const extractTypeMetadata = (engine) => {
       .map((entry) => (entry?.key ? String(entry.key) : null))
       .filter(Boolean);
     const entryPayloads = entries.map((entry) =>
-      normalizeSerializable(entry?.payload ?? serializeInstancedEntry(entry)),
+      normalizeSerializable(mergeInstancedPayload(entry), {
+        preserveTyped: true,
+      }),
     );
     const capacityCandidate = Number.isFinite(record?.capacity)
       ? record.capacity
@@ -622,12 +653,11 @@ const extractPrototypeInstances = (engine) => {
             return null;
           }
           const entry = entryRecord.entry ?? null;
-          const payload = entryRecord.entryPayload ??
-            (entry ? serializeInstancedEntry(entry) : null);
+          const payload = mergeInstancedPayload(entry, entryRecord.entryPayload);
           return {
             type: entryRecord.type ?? entry?.type ?? null,
             entryKey: entry?.key ?? entryRecord.entryKey ?? null,
-            entryPayload: normalizeSerializable(payload),
+            entryPayload: normalizeSerializable(payload, { preserveTyped: true }),
           };
         })
         .filter(Boolean),

--- a/three-demo/src/world/chunk-manager.js
+++ b/three-demo/src/world/chunk-manager.js
@@ -25,6 +25,7 @@ import {
   pruneTerrainSampleCacheOutsideRadius,
   clearTerrainSampleCache,
 } from './terrain-sample-cache.js';
+import { normalizeSerializableToPlain } from './chunk-build-core.js';
 import { createChunkBuildWorker } from './workers/chunk-build.worker.js';
 import {
   createChunkStoreQueue,
@@ -3717,6 +3718,93 @@ export function createChunkManager({
       } else {
         delete leanPayload.occupancy;
       }
+    }
+
+    if (Array.isArray(basePayload.typeMetadata)) {
+      leanPayload.typeMetadata = basePayload.typeMetadata.map((record) => {
+        if (!record || typeof record !== 'object') {
+          return record;
+        }
+        const entryPayloads = Array.isArray(record.entryPayloads)
+          ? record.entryPayloads.map((entry) => normalizeSerializableToPlain(entry))
+          : record.entryPayloads;
+        return {
+          ...record,
+          entryPayloads,
+        };
+      });
+    }
+
+    if (basePayload.decorations && typeof basePayload.decorations === 'object') {
+      const decorations = {
+        ...basePayload.decorations,
+      };
+      if (Array.isArray(basePayload.decorations.batches)) {
+        decorations.batches = basePayload.decorations.batches.map((batch) => {
+          if (!batch || typeof batch !== 'object') {
+            return batch;
+          }
+          const entries = Array.isArray(batch.entries)
+            ? batch.entries.map((entry) => normalizeSerializableToPlain(entry))
+            : batch.entries;
+          return {
+            ...batch,
+            entries,
+          };
+        });
+      }
+      leanPayload.decorations = decorations;
+    }
+
+    if (Array.isArray(basePayload.prototypeInstances)) {
+      leanPayload.prototypeInstances = basePayload.prototypeInstances.map((record) => {
+        if (!record || typeof record !== 'object') {
+          return record;
+        }
+        const blockEntries = Array.isArray(record.blockEntries)
+          ? record.blockEntries.map((blockEntry) => {
+              if (!blockEntry || typeof blockEntry !== 'object') {
+                return blockEntry;
+              }
+              if (!Object.prototype.hasOwnProperty.call(blockEntry, 'entryPayload')) {
+                return { ...blockEntry };
+              }
+              const normalizedPayload =
+                blockEntry.entryPayload === undefined
+                  ? undefined
+                  : normalizeSerializableToPlain(blockEntry.entryPayload);
+              return {
+                ...blockEntry,
+                entryPayload: normalizedPayload,
+              };
+            })
+          : record.blockEntries;
+        return {
+          ...record,
+          blockEntries,
+        };
+      });
+    }
+
+    if (basePayload.fluids && typeof basePayload.fluids === 'object') {
+      const fluids = {
+        ...basePayload.fluids,
+      };
+      if (Array.isArray(basePayload.fluids.columnsByType)) {
+        fluids.columnsByType = basePayload.fluids.columnsByType.map((record) => {
+          if (!record || typeof record !== 'object') {
+            return record;
+          }
+          const metadata = Array.isArray(record.metadata)
+            ? record.metadata.map((entry) => normalizeSerializableToPlain(entry))
+            : record.metadata;
+          return {
+            ...record,
+            metadata,
+          };
+        });
+      }
+      leanPayload.fluids = fluids;
     }
 
     return leanPayload;
@@ -9858,6 +9946,11 @@ export function createChunkManager({
         detailLevel: entry?.detailLevel ?? null,
         payload: entry?.payload ?? null,
       })),
+    enumerable: false,
+  });
+
+  Object.defineProperty(managerApi, '__createLeanCachePayloadForTest', {
+    value: (payload) => createLeanCachePayload(payload),
     enumerable: false,
   });
 


### PR DESCRIPTION
## Summary
- ensure instanced entry serialization keeps typed arrays for worker payloads while merging any custom payload fields
- sanitize cached chunk payloads with a plain JSON-friendly helper and expose a test-only lean payload factory
- add regression coverage for retention payload typing and update decoration batch expectations for typed data

## Testing
- npm test -- src/world/__tests__/chunk-worker-typed-array-regression.test.js
- npm test -- src/world/__tests__/chunk-build-core.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f959c65640832ab85bd13fc4fd7bc6